### PR TITLE
Add incident label to enable measurement of time-to-restore

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -19,6 +19,9 @@ changelog:
     - title: Dependency Upgrades 📦
       labels:
         - kind/dependencies
+    - title: Incident
+      labels:
+        - kind/incident
     - title: Uncategorized changes
       labels:
         - "*"


### PR DESCRIPTION
## Description
Shared with other repos in Altinn:
https://github.com/Altinn/labels/labels?q=incident
Used centrally to measure time-to-restore

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
