### PR TITLE
Determine version in CI/CD workflow, not the release version call

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -6,6 +6,9 @@ inputs:
   dockerImageBaseName:
     description: "Base image name for docker images"
     required: true
+  imageTag:
+    description: "Version image tag"
+    required: true
   GITHUB_TOKEN:
     description: "GitHub token"
     required: true
@@ -15,10 +18,6 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-
-    - name: Get version
-      id: get-version
-      uses: ./.github/actions/get-current-version
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -31,6 +30,6 @@ runs:
       shell: bash
       run: |
         # Construct the image tag using the Git hash
-        IMAGE="${{ inputs.dockerImageBaseName }}:${{ steps.get-version.outputs.imageTag }}"
+        IMAGE="${{ inputs.dockerImageBaseName }}:${{ inputs.imageTag }}"
         docker build . --tag $IMAGE
         docker push $IMAGE

--- a/.github/actions/release-version/action.yml
+++ b/.github/actions/release-version/action.yml
@@ -6,6 +6,8 @@ inputs:
   region:
     description: "Azure region to deploy to"
     required: true
+  imageTag:
+    description: "Version image tag to release"
   environment:
     description: "Github environment to deploy from"
     required: true
@@ -41,15 +43,11 @@ runs:
         tenant-id: ${{ inputs.AZURE_TENANT_ID }}
         subscription-id: ${{ inputs.AZURE_SUBSCRIPTION_ID }}
 
-    - name: Get version
-      id: get-version
-      uses: ./.github/actions/get-current-version
-
     - name: Deploy app
       uses: azure/arm-deploy@v2
       id: deploy
       env:
-        IMAGE_TAG: ${{ steps.get-version.outputs.imageTag }}
+        IMAGE_TAG: ${{ inputs.imageTag }}
         ENVIRONMENT: ${{ inputs.environment }}
         KEY_VAULT_NAME: ${{ inputs.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
         KEY_VAULT_URL: https://${{ inputs.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}.vault.azure.net

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -7,13 +7,14 @@ on:
     - "Test/**" # ignore changes to tests
 
 jobs:
-  check-for-changes:
-    name: Check for changes
+  prepare-deployment:
+    name: Prepare deployment
     runs-on: ubuntu-latest
     outputs:
       hasAzureChanges: ${{ steps.check-for-changes.outputs.hasAzureChanges }}
       hasBackendChanges: ${{ steps.check-for-changes.outputs.hasBackendChanges }}
       hasMigrationChanges: ${{ steps.check-for-changes.outputs.hasMigrationChanges }}
+      imageTag: ${{ steps.get-version.outputs.imageTag}}
     steps:        
       - uses: actions/checkout@v4
 
@@ -32,18 +33,22 @@ jobs:
       - name: "Inform about database migration skip"
         if: ${{ steps.check-for-changes.outputs.hasMigrationChanges != 'true' }}
         run: echo "::warning file=.github/workflows/ci-cd.yaml,line=1,col=1::Migrations did not change. No migration will run."
+        
+      - name: Get version
+        id: get-version
+        uses: ./.github/actions/get-current-version
  
   test:	
     name: QA	
     uses: ./.github/workflows/test-application.yml	
-    needs: [check-for-changes]
-    if: ${{ needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+    needs: [prepare-deployment]
+    if: ${{ needs.prepare-deployment.outputs.hasBackendChanges == 'true' || needs.prepare-deployment.outputs.hasMigrationChanges == 'true' }}
 
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    needs: [check-for-changes]
-    if: ${{ needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
+    needs: [prepare-deployment]
+    if: ${{ needs.prepare-deployment.outputs.hasBackendChanges == 'true' }}
     permissions: 
       packages: write
       contents: read
@@ -61,7 +66,7 @@ jobs:
     if: always() && !failure() && !cancelled() 
     needs: [ 
       publish,
-      check-for-changes
+      prepare-deployment
     ]
     permissions: 
       id-token: write
@@ -69,9 +74,10 @@ jobs:
     secrets: inherit
     with:
       environment: test
-      hasAzureChanges: ${{ needs.check-for-changes.outputs.hasAzureChanges }}
-      hasBackendChanges: ${{ needs.check-for-changes.outputs.hasBackendChanges }}
-      hasMigrationChanges: ${{ needs.check-for-changes.outputs.hasMigrationChanges }}
+      hasAzureChanges: ${{ needs.prepare-deployment.outputs.hasAzureChanges }}
+      hasBackendChanges: ${{ needs.prepare-deployment.outputs.hasBackendChanges }}
+      hasMigrationChanges: ${{ needs.prepare-deployment.outputs.hasMigrationChanges }}
+      imageTag: ${{ needs.prepare-deployment.outputs.imageTag }}
 
 #    deploy-staging:
 #      name: Internal staging

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -11,6 +11,8 @@ on:
         type: string
       hasMigrationChanges:
         type: string
+      imageTag:
+        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -28,6 +30,9 @@ on:
       hasMigrationChanges:
         description: Migrate database
         type: boolean
+      imageTag:
+        description: Version image tag
+        type: string
 
 jobs:
   deploy:
@@ -82,6 +87,7 @@ jobs:
       with:
         region: norwayeast
         environment: ${{ inputs.environment }}
+        imageTag: ${{ inputs.imageTag }}
         AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
         AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
         AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Description
Move the logic for determining version to the CI/CD workflow because deploy to environment workflow should be possible to use with arbitrary version for workflow dispatch.

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
