### PR TITLE
Use correspondence attachment id for download attachment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY src/Altinn.Correspondence.API/*.csproj ./src/Altinn.Correspondence.API/
 COPY src/Altinn.Correspondence.Core/*.csproj ./src/Altinn.Correspondence.Core/
 COPY src/Altinn.Correspondence.Persistence/*.csproj ./src/Altinn.Correspondence.Persistence/
+COPY src/Altinn.Correspondence.Integrations/*.csproj ./src/Altinn.Correspondence.Integrations/
 RUN dotnet restore ./src/Altinn.Correspondence.API/Altinn.Correspondence.API.csproj
 
 # Copy everything else and build

--- a/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
@@ -121,7 +121,7 @@ public class AttachmentControllerTests : IClassFixture<CustomWebApplicationFacto
         var originalAttachmentData = new byte[] { 1, 2, 3, 4 };
         var content = new ByteArrayContent(originalAttachmentData);
         var uploadedAttachment = await (await UploadAttachment(attachmentId, content)).Content.ReadFromJsonAsync<AttachmentOverviewExt>(_responseSerializerOptions);
-
+        Assert.NotNull(uploadedAttachment);
         var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", InitializeCorrespondenceFactory.BasicCorrespondenceWithFileAttachment(uploadedAttachment.DataLocationUrl), _responseSerializerOptions);
         var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondenceResponseExt>();
 

--- a/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
@@ -145,4 +145,21 @@ internal static class InitializeCorrespondenceFactory
             });
         return correspondence;
     }
+    internal static InitializeCorrespondenceExt BasicCorrespondenceWithFileAttachment(string url)
+    {
+        var correspondence = BasicCorrespondence();
+        correspondence.Content!.Attachments.Add(
+            new InitializeCorrespondenceAttachmentExt()
+            {
+                DataType = "pdf",
+                Name = "3",
+                RestrictionName = "testFile3",
+                SendersReference = "1234",
+                IntendedPresentation = IntendedPresentationTypeExt.MachineReadable,
+                FileName = "test-fil3e",
+                IsEncrypted = false,
+                DataLocationUrl = url
+            });
+        return correspondence;
+    }
 }

--- a/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
@@ -148,7 +148,7 @@ internal static class InitializeCorrespondenceFactory
     internal static InitializeCorrespondenceExt BasicCorrespondenceWithFileAttachment(string url)
     {
         var correspondence = BasicCorrespondence();
-        correspondence.Content!.Attachments.Add(
+        correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>(){
             new InitializeCorrespondenceAttachmentExt()
             {
                 DataType = "pdf",
@@ -159,7 +159,7 @@ internal static class InitializeCorrespondenceFactory
                 FileName = "test-fil3e",
                 IsEncrypted = false,
                 DataLocationUrl = url
-            });
+            }};
         return correspondence;
     }
 }

--- a/altinn-correspondence-v1.json
+++ b/altinn-correspondence-v1.json
@@ -33,7 +33,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -64,7 +64,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -86,7 +86,6 @@
                         "name": "attachmentId",
                         "in": "path",
                         "required": true,
-                        "style": "simple",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -95,7 +94,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -115,7 +114,6 @@
                         "name": "attachmentId",
                         "in": "path",
                         "required": true,
-                        "style": "simple",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -124,7 +122,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -146,7 +144,6 @@
                         "name": "attachmentId",
                         "in": "path",
                         "required": true,
-                        "style": "simple",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -155,7 +152,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -163,30 +160,6 @@
                                 }
                             }
                         }
-                    }
-                }
-            }
-        },
-        "/correspondence/api/v1/attachment/{attachmentId}/download": {
-            "get": {
-                "tags": [
-                    "Attachment"
-                ],
-                "parameters": [
-                    {
-                        "name": "attachmentId",
-                        "in": "path",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success"
                     }
                 }
             }
@@ -212,7 +185,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -231,7 +204,6 @@
                     {
                         "name": "offset",
                         "in": "query",
-                        "style": "form",
                         "schema": {
                             "type": "integer",
                             "format": "int32"
@@ -240,7 +212,6 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "style": "form",
                         "schema": {
                             "type": "integer",
                             "format": "int32"
@@ -249,7 +220,6 @@
                     {
                         "name": "from",
                         "in": "query",
-                        "style": "form",
                         "schema": {
                             "type": "string",
                             "format": "date-time"
@@ -258,7 +228,6 @@
                     {
                         "name": "to",
                         "in": "query",
-                        "style": "form",
                         "schema": {
                             "type": "string",
                             "format": "date-time"
@@ -267,7 +236,6 @@
                     {
                         "name": "status",
                         "in": "query",
-                        "style": "form",
                         "schema": {
                             "$ref": "#/components/schemas/CorrespondenceStatusExt"
                         }
@@ -275,7 +243,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -308,7 +276,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -330,7 +298,6 @@
                         "name": "correspondenceId",
                         "in": "path",
                         "required": true,
-                        "style": "simple",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -339,7 +306,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -361,7 +328,6 @@
                         "name": "correspondenceId",
                         "in": "path",
                         "required": true,
-                        "style": "simple",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -370,7 +336,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -392,7 +358,6 @@
                         "name": "correspondenceId",
                         "in": "path",
                         "required": true,
-                        "style": "simple",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -401,7 +366,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success"
+                        "description": "OK"
                     }
                 }
             }
@@ -416,7 +381,6 @@
                         "name": "correspondenceId",
                         "in": "path",
                         "required": true,
-                        "style": "simple",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -425,7 +389,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success"
+                        "description": "OK"
                     }
                 }
             }
@@ -440,7 +404,6 @@
                         "name": "correspondenceId",
                         "in": "path",
                         "required": true,
-                        "style": "simple",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -449,10 +412,12 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success"
+                        "description": "OK"
                     }
                 }
-            },
+            }
+        },
+        "/correspondence/api/v1/correspondence/{correspondenceId}/delete": {
             "delete": {
                 "tags": [
                     "Correspondence"
@@ -462,7 +427,6 @@
                         "name": "correspondenceId",
                         "in": "path",
                         "required": true,
-                        "style": "simple",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -471,7 +435,30 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success"
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/correspondence/api/v1/correspondence/attachment/{attachmentId}/download": {
+            "get": {
+                "tags": [
+                    "Correspondence"
+                ],
+                "parameters": [
+                    {
+                        "name": "attachmentId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -483,7 +470,26 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success"
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/correspondence/api/v1/webhooks/malwarescanresults": {
+            "post": {
+                "tags": [
+                    "MalwareScanResults"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {}
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -517,13 +523,18 @@
             },
             "AttachmentDetailsExt": {
                 "required": [
+                    "attachmentId",
+                    "correspondenceIds",
                     "dataLocationUrl",
                     "dataType",
                     "expirationTime",
+                    "IntendedPresentation",
                     "name",
                     "restrictionName",
                     "sendersReference",
-                    "intendedPresentation"
+                    "status",
+                    "statusChanged",
+                    "statusText"
                 ],
                 "type": "object",
                 "properties": {
@@ -554,7 +565,7 @@
                         "minLength": 1,
                         "type": "string"
                     },
-                    "intendedPresentation": {
+                    "IntendedPresentation": {
                         "$ref": "#/components/schemas/IntendedPresentationTypeExt"
                     },
                     "restrictionName": {
@@ -570,7 +581,8 @@
                         "format": "uuid"
                     },
                     "dataLocationUrl": {
-                        "$ref": "#/components/schemas/AttachmentDataLocationTypeExt"
+                        "minLength": 1,
+                        "type": "string"
                     },
                     "status": {
                         "$ref": "#/components/schemas/AttachmentStatusExt"
@@ -582,6 +594,14 @@
                     "statusChanged": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "correspondenceIds": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "nullable": true
                     },
                     "statusHistory": {
                         "type": "array",
@@ -595,13 +615,18 @@
             },
             "AttachmentOverviewExt": {
                 "required": [
+                    "attachmentId",
+                    "correspondenceIds",
                     "dataLocationUrl",
                     "dataType",
                     "expirationTime",
+                    "IntendedPresentation",
                     "name",
                     "restrictionName",
                     "sendersReference",
-                    "intendedPresentation"
+                    "status",
+                    "statusChanged",
+                    "statusText"
                 ],
                 "type": "object",
                 "properties": {
@@ -632,7 +657,7 @@
                         "minLength": 1,
                         "type": "string"
                     },
-                    "intendedPresentation": {
+                    "IntendedPresentation": {
                         "$ref": "#/components/schemas/IntendedPresentationTypeExt"
                     },
                     "restrictionName": {
@@ -648,7 +673,8 @@
                         "format": "uuid"
                     },
                     "dataLocationUrl": {
-                        "$ref": "#/components/schemas/AttachmentDataLocationTypeExt"
+                        "minLength": 1,
+                        "type": "string"
                     },
                     "status": {
                         "$ref": "#/components/schemas/AttachmentStatusExt"
@@ -660,6 +686,14 @@
                     "statusChanged": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "correspondenceIds": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "nullable": true
                     }
                 },
                 "additionalProperties": false
@@ -674,7 +708,7 @@
                 ],
                 "type": "string"
             },
-            "CorrespondenceAttachmentOverviewExt": {
+            "CorrespondenceAttachmentExt": {
                 "required": [
                     "dataLocationType",
                     "dataType",
@@ -685,6 +719,10 @@
                 ],
                 "type": "object",
                 "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
                     "fileName": {
                         "maxLength": 255,
                         "minLength": 0,
@@ -750,6 +788,12 @@
                 "additionalProperties": false
             },
             "CorrespondenceContentExt": {
+                "required": [
+                    "attachments",
+                    "language",
+                    "messageSummary",
+                    "messageTitle"
+                ],
                 "type": "object",
                 "properties": {
                     "language": {
@@ -767,7 +811,7 @@
                     "attachments": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/CorrespondenceAttachmentOverviewExt"
+                            "$ref": "#/components/schemas/CorrespondenceAttachmentExt"
                         },
                         "nullable": true
                     },
@@ -784,10 +828,13 @@
             },
             "CorrespondenceDetailsExt": {
                 "required": [
+                    "correspondenceId",
+                    "created",
                     "recipient",
                     "resourceId",
                     "sender",
-                    "sendersReference"
+                    "sendersReference",
+                    "visibleFrom"
                 ],
                 "type": "object",
                 "properties": {
@@ -855,7 +902,7 @@
                     "notifications": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/CorrespondenceNotificationOverviewExt"
+                            "$ref": "#/components/schemas/CorrespondenceNotificationDetailsExt"
                         },
                         "nullable": true
                     },
@@ -899,7 +946,11 @@
                 },
                 "additionalProperties": false
             },
-            "CorrespondenceNotificationOverviewExt": {
+            "CorrespondenceNotificationDetailsExt": {
+                "required": [
+                    "notificationTemplate",
+                    "status"
+                ],
                 "type": "object",
                 "properties": {
                     "notificationTemplate": {
@@ -927,6 +978,25 @@
                     "notificationChannel": {
                         "$ref": "#/components/schemas/NotificationChannelExt"
                     },
+                    "status": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "statusText": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "statusChanged": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "statusHistory": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/NotificationStatusEventExt"
+                        },
+                        "nullable": true
+                    },
                     "created": {
                         "type": "string",
                         "format": "date-time"
@@ -936,10 +1006,13 @@
             },
             "CorrespondenceOverviewExt": {
                 "required": [
+                    "correspondenceId",
+                    "created",
                     "recipient",
                     "resourceId",
                     "sender",
-                    "sendersReference"
+                    "sendersReference",
+                    "visibleFrom"
                 ],
                 "type": "object",
                 "properties": {
@@ -1039,6 +1112,9 @@
                 "additionalProperties": false
             },
             "CorrespondenceReplyOptionExt": {
+                "required": [
+                    "linkURL"
+                ],
                 "type": "object",
                 "properties": {
                     "linkURL": {
@@ -1072,12 +1148,13 @@
             "CorrespondenceStatusExt": {
                 "enum": [
                     "Initialized",
+                    "ReadyForPublish",
                     "Published",
                     "Fetched",
                     "Read",
                     "Replied",
                     "Confirmed",
-                    "PurgedByRecipient",
+                    "PurgedBByRecipient",
                     "PurgedByAltinn",
                     "Archived",
                     "Reserved",
@@ -1103,6 +1180,10 @@
                 "additionalProperties": false
             },
             "ExternalReferenceExt": {
+                "required": [
+                    "referenceType",
+                    "referenceValue"
+                ],
                 "type": "object",
                 "properties": {
                     "referenceValue": {
@@ -1127,10 +1208,10 @@
                 "required": [
                     "dataType",
                     "expirationTime",
+                    "IntendedPresentation",
                     "name",
                     "restrictionName",
-                    "sendersReference",
-                    "intendedPresentation"
+                    "sendersReference"
                 ],
                 "type": "object",
                 "properties": {
@@ -1161,7 +1242,7 @@
                         "minLength": 1,
                         "type": "string"
                     },
-                    "intendedPresentation": {
+                    "IntendedPresentation": {
                         "$ref": "#/components/schemas/IntendedPresentationTypeExt"
                     },
                     "restrictionName": {
@@ -1186,6 +1267,10 @@
                 ],
                 "type": "object",
                 "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
                     "fileName": {
                         "maxLength": 255,
                         "minLength": 0,
@@ -1231,6 +1316,11 @@
                 "additionalProperties": false
             },
             "InitializeCorrespondenceContentExt": {
+                "required": [
+                    "language",
+                    "messageSummary",
+                    "messageTitle"
+                ],
                 "type": "object",
                 "properties": {
                     "language": {
@@ -1268,7 +1358,8 @@
                     "recipient",
                     "resourceId",
                     "sender",
-                    "sendersReference"
+                    "sendersReference",
+                    "visibleFrom"
                 ],
                 "type": "object",
                 "properties": {
@@ -1316,15 +1407,10 @@
                     },
                     "propertyList": {
                         "type": "object",
-                        "additionalProperties": false,
-                        "maxProperties": 10,
-                        "nullable": true,
-                        "patternProperties": {
-                            "^.{1,50}$": {
-                                "maxLength": 300,
-                                "type": "string"
-                            }
-                        }
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "nullable": true
                     },
                     "replyOptions": {
                         "type": "array",
@@ -1349,6 +1435,9 @@
                 "additionalProperties": false
             },
             "InitializeCorrespondenceNotificationExt": {
+                "required": [
+                    "notificationTemplate"
+                ],
                 "type": "object",
                 "properties": {
                     "notificationTemplate": {
@@ -1387,6 +1476,11 @@
                 "type": "string"
             },
             "NotificationStatusEventExt": {
+                "required": [
+                    "status",
+                    "statusChanged",
+                    "statusText"
+                ],
                 "type": "object",
                 "properties": {
                     "status": {

--- a/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
@@ -2,7 +2,6 @@
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.PurgeAttachment;
-using Altinn.Correspondence.Application.DownloadAttachment;
 using Altinn.Correspondence.Application.GetAttachmentDetails;
 using Altinn.Correspondence.Application.GetAttachmentOverview;
 using Altinn.Correspondence.Application.InitializeAttachment;
@@ -112,27 +111,6 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
 
         return commandResult.Match(
             attachment => Ok(AttachmentDetailsMapper.MapToExternal(attachment)),
-            Problem
-        );
-    }
-
-    /// <summary>
-    /// Downloads the attachment data
-    /// </summary>
-    /// <returns></returns>
-    [HttpGet]
-    [Route("{attachmentId}/download")]
-    public async Task<ActionResult> DownloadAttachmentData(
-        Guid attachmentId,
-        [FromServices] DownloadAttachmentHandler handler,
-        CancellationToken cancellationToken)
-    {
-        var commandResult = await handler.Process(new DownloadAttachmentRequest()
-        {
-            AttachmentId = attachmentId
-        }, cancellationToken);
-        return commandResult.Match(
-            result => File(result, "application/octet-stream"),
             Problem
         );
     }

--- a/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
@@ -82,7 +82,6 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
         [FromServices] GetAttachmentOverviewHandler handler,
         CancellationToken cancellationToken)
     {
-
         _logger.LogInformation("Get attachment overview {attachmentId}", attachmentId.ToString());
 
         var commandResult = await handler.Process(attachmentId, cancellationToken);

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -1,6 +1,7 @@
 ﻿using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application;
+using Altinn.Correspondence.Application.DownloadAttachment;
 using Altinn.Correspondence.Application.GetCorrespondenceDetails;
 using Altinn.Correspondence.Application.GetCorrespondenceOverview;
 using Altinn.Correspondence.Application.GetCorrespondences;
@@ -268,6 +269,29 @@ namespace Altinn.Correspondence.API.Controllers
 
             return Ok();
         }
-        private ObjectResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
+
+
+        /// <summary>
+        /// Downloads the attachment data
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("attachment/{attachmentId}/download")]
+        public async Task<ActionResult> DownloadAttachmentData(
+            Guid attachmentId,
+            [FromServices] DownloadAttachmentHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var commandResult = await handler.Process(new DownloadAttachmentRequest()
+            {
+                AttachmentId = attachmentId
+            }, cancellationToken);
+            return commandResult.Match(
+                result => File(result, "application/octet-stream"),
+                Problem
+            );
+        }
+
+        private ActionResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
     }
 }

--- a/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
@@ -15,6 +15,7 @@ internal static class AttachmentDetailsMapper
             AttachmentId = AttachmentDetails.AttachmentId,
             Name = AttachmentDetails.Name ?? string.Empty,
             Status = (AttachmentStatusExt)AttachmentDetails.Status,
+            DataLocationUrl = AttachmentDetails.DataLocationUrl,
             StatusText = AttachmentDetails.StatusText,
             StatusChanged = AttachmentDetails.StatusChanged,
             DataType = AttachmentDetails.DataType,

--- a/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
@@ -21,7 +21,8 @@ internal static class AttachmentDetailsMapper
             DataType = AttachmentDetails.DataType,
             IntendedPresentation = (IntendedPresentationTypeExt)AttachmentDetails.IntendedPresentation,
             SendersReference = AttachmentDetails.SendersReference,
-            StatusHistory = AttachmentStatusMapper.MapToExternal(AttachmentDetails.Statuses)
+            StatusHistory = AttachmentStatusMapper.MapToExternal(AttachmentDetails.Statuses),
+            CorrespondenceIds = AttachmentDetails.CorrespondenceIds
         };
         return attachment;
     }

--- a/src/Altinn.Correspondence.API/Mappers/AttachmentOverviewMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentOverviewMapper.cs
@@ -1,8 +1,6 @@
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application.GetAttachmentOverview;
-using Altinn.Correspondence.Core.Models;
-using Altinn.Correspondence.Core.Models.Enums;
 
 namespace Altinn.Correspondence.Mappers;
 
@@ -16,6 +14,7 @@ internal static class AttachmentOverviewMapper
             Name = attachmentOverview.Name ?? string.Empty,
             Status = (AttachmentStatusExt)attachmentOverview.Status,
             StatusText = attachmentOverview.StatusText,
+            DataLocationUrl = attachmentOverview.DataLocationUrl,
             StatusChanged = attachmentOverview.StatusChanged,
             DataType = attachmentOverview.DataType,
             IntendedPresentation = (IntendedPresentationTypeExt)attachmentOverview.IntendedPresentation,

--- a/src/Altinn.Correspondence.API/Mappers/AttachmentOverviewMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentOverviewMapper.cs
@@ -18,7 +18,8 @@ internal static class AttachmentOverviewMapper
             StatusChanged = attachmentOverview.StatusChanged,
             DataType = attachmentOverview.DataType,
             IntendedPresentation = (IntendedPresentationTypeExt)attachmentOverview.IntendedPresentation,
-            SendersReference = attachmentOverview.SendersReference
+            SendersReference = attachmentOverview.SendersReference,
+            CorrespondenceIds = attachmentOverview.CorrespondenceIds
         };
         return attachment;
     }

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
@@ -1,0 +1,33 @@
+using Altinn.Correspondence.API.Models;
+using Altinn.Correspondence.API.Models.Enums;
+using Altinn.Correspondence.Core.Models;
+
+namespace Altinn.Correspondence.Mappers;
+
+internal static class CorrespondenceAttachmentMapper
+{
+    internal static CorrespondenceAttachmentExt MapToExternal(CorrespondenceAttachmentEntity attachment)
+    {
+        var content = new CorrespondenceAttachmentExt
+        {
+            DataType = attachment.DataType,
+            FileName = attachment.Attachment.FileName,
+            AttachmentId = attachment.Id,
+            IsEncrypted = attachment.IsEncrypted,
+            IntendedPresentation = (IntendedPresentationTypeExt)attachment.IntendedPresentation,
+            Name = attachment.Name,
+            SendersReference = attachment.SendersReference,
+            Checksum = attachment.Checksum,
+            DataLocationType = (AttachmentDataLocationTypeExt)attachment.DataLocationType,
+            DataLocationUrl = attachment.DataLocationUrl,
+            RestrictionName = attachment.RestrictionName,
+            Status = (AttachmentStatusExt)attachment.Attachment.Statuses.OrderByDescending(s => s.StatusChanged).FirstOrDefault().Status,
+
+        };
+        return content;
+    }
+    internal static List<CorrespondenceAttachmentExt> MapListToExternal(List<CorrespondenceAttachmentEntity> attachments)
+    {
+        return attachments.Select(MapToExternal).ToList();
+    }
+}

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceContentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceContentMapper.cs
@@ -1,0 +1,20 @@
+using Altinn.Correspondence.API.Models;
+using Altinn.Correspondence.API.Models.Enums;
+using Altinn.Correspondence.Core.Models;
+
+namespace Altinn.Correspondence.Mappers;
+
+internal static class CorrespondenceContentMapper
+{
+    internal static CorrespondenceContentExt MapToExternal(CorrespondenceContentEntity correspondenceContent)
+    {
+        var content = new CorrespondenceContentExt
+        {
+            Language = correspondenceContent.Language,
+            MessageSummary = correspondenceContent.MessageSummary,
+            MessageTitle = correspondenceContent.MessageTitle,
+            Attachments = CorrespondenceAttachmentMapper.MapListToExternal(correspondenceContent.Attachments),
+        };
+        return content;
+    }
+}

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceDetailsMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceDetailsMapper.cs
@@ -15,6 +15,7 @@ internal static class CorrespondenceDetailsMapper
             StatusText = correspondenceDetails.StatusText,
             StatusChanged = (DateTimeOffset)correspondenceDetails.StatusChanged,
             SendersReference = correspondenceDetails.SendersReference,
+            Content = CorrespondenceContentMapper.MapToExternal(correspondenceDetails.Content),
             Sender = correspondenceDetails.Sender,
             Created = correspondenceDetails.Created,
             Recipient = correspondenceDetails.Recipient,

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceOverviewMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceOverviewMapper.cs
@@ -18,6 +18,7 @@ internal static class CorrespondenceOverviewMapper
             Sender = correspondenceOverview.Sender,
             Created = correspondenceOverview.Created,
             Recipient = correspondenceOverview.Recipient,
+            Content = CorrespondenceContentMapper.MapToExternal(correspondenceOverview.Content),
             ReplyOptions = CorrespondenceReplyOptionsMapper.MapListToExternal(correspondenceOverview.ReplyOptions),
             Notifications = InitializeCorrespondenceNotificationMapper.MapListToExternal(correspondenceOverview.Notifications),
             ResourceId = correspondenceOverview.ResourceId.ToString(),

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceAttachmentMapper.cs
@@ -24,7 +24,9 @@ internal static class InitializeCorrespondenceAttachmentMapper
             DataType = initializeAttachmentExt.DataType,
             IntendedPresentation = (IntendedPresentationType)initializeAttachmentExt.IntendedPresentation,
             Checksum = initializeAttachmentExt.Checksum,
-            IsEncrypted = initializeAttachmentExt.IsEncrypted
+            IsEncrypted = initializeAttachmentExt.IsEncrypted,
+            DataLocationUrl = initializeAttachmentExt.DataLocationUrl,
+            DataLocationType = (AttachmentDataLocationType)initializeAttachmentExt.DataLocationType,
         };
     }
 }

--- a/src/Altinn.Correspondence.API/Models/AttachmentOverviewExt.cs
+++ b/src/Altinn.Correspondence.API/Models/AttachmentOverviewExt.cs
@@ -39,5 +39,11 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("statusChanged")]
         public required DateTimeOffset StatusChanged { get; set; }
+
+        /// <summary>
+        /// List of correspondences that are using this attachment
+        /// </summary>
+        [JsonPropertyName("correspondenceIds")]
+        public required List<Guid> CorrespondenceIds { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.API/Models/AttachmentOverviewExt.cs
+++ b/src/Altinn.Correspondence.API/Models/AttachmentOverviewExt.cs
@@ -20,7 +20,7 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("dataLocationUrl")]
         [Required]
-        public AttachmentDataLocationTypeExt DataLocationUrl { get; set; }
+        public string DataLocationUrl { get; set; }
 
         /// <summary>
         /// Current attachment status

--- a/src/Altinn.Correspondence.API/Models/CorrespondenceAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceAttachmentExt.cs
@@ -6,7 +6,7 @@ namespace Altinn.Correspondence.API.Models
     /// <summary>
     /// Represents a binary attachment to a Correspondence
     /// </summary>
-    public class CorrespondenceAttachmentOverviewExt : InitializeCorrespondenceAttachmentExt
+    public class CorrespondenceAttachmentExt : InitializeCorrespondenceAttachmentExt
     {
         /// <summary>
         /// A unique id for the attachment.

--- a/src/Altinn.Correspondence.API/Models/CorrespondenceContentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceContentExt.cs
@@ -15,6 +15,6 @@ namespace Altinn.Correspondence.API.Models
         /// TODO: Number restriction?
         /// </remarks>
         [JsonPropertyName("attachments")]
-        public required new List<CorrespondenceAttachmentOverviewExt> Attachments { get; set; }
+        public required new List<CorrespondenceAttachmentExt> Attachments { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceAttachmentExt.cs
@@ -9,7 +9,9 @@ namespace Altinn.Correspondence.API.Models
     /// </summary>
     public class InitializeCorrespondenceAttachmentExt
     {
-
+        /// <summary>
+        /// A unique id for the correspondence attachment.
+        /// 
         [JsonPropertyName("id")]
         public Guid Id { get; set; }
 

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceAttachmentExt.cs
@@ -9,6 +9,10 @@ namespace Altinn.Correspondence.API.Models
     /// </summary>
     public class InitializeCorrespondenceAttachmentExt
     {
+
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
         /// <summary>
         /// The name of the attachment file.
         /// </summary>

--- a/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
@@ -5,24 +5,24 @@ namespace Altinn.Correspondence.Application.DownloadAttachment;
 
 public class DownloadAttachmentHandler : IHandler<DownloadAttachmentRequest, Stream>
 {
-    private readonly IAttachmentRepository _attachmentRepository;
     private readonly IStorageRepository _storageRepository;
+    private readonly ICorrespondenceAttachmentRepository _correspondenceAttachmentRepository;
 
-    public DownloadAttachmentHandler(IAttachmentRepository attachmentRepository, IStorageRepository storageRepository)
+    public DownloadAttachmentHandler(IStorageRepository storageRepository, ICorrespondenceAttachmentRepository correspondenceAttachmentRepository)
     {
-        _attachmentRepository = attachmentRepository;
         _storageRepository = storageRepository;
+        _correspondenceAttachmentRepository = correspondenceAttachmentRepository;
     }
 
     public async Task<OneOf<Stream, Error>> Process(DownloadAttachmentRequest request, CancellationToken cancellationToken)
     {
-        var attachment = await _attachmentRepository.GetAttachmentById(request.AttachmentId, false, cancellationToken);
-        if (attachment is null)
+        var attachmentId = await _correspondenceAttachmentRepository.GetAttachmentIdByCorrespondenceAttachmentId(request.AttachmentId, cancellationToken);
+        if (attachmentId is null)
         {
             return Errors.AttachmentNotFound;
         }
 
-        var attachmentStream = await _storageRepository.DownloadAttachment(request.AttachmentId, cancellationToken);
+        var attachmentStream = await _storageRepository.DownloadAttachment((Guid)attachmentId, cancellationToken);
         return attachmentStream;
     }
 }

--- a/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsResponse.cs
@@ -26,4 +26,5 @@ public class GetAttachmentDetailsResponse
     public IntendedPresentationType IntendedPresentation { get; set; }
 
     public List<AttachmentStatusEntity> Statuses { get; set; } = new List<AttachmentStatusEntity>();
+    public List<Guid> CorrespondenceIds { get; set; } = new List<Guid>();
 }

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
@@ -14,7 +14,6 @@ public class GetAttachmentOverviewHandler : IHandler<Guid, GetAttachmentOverview
         _attachmentStatusRepository = attachmentStatusRepository;
         _attachmentRepository = attachmentRepository;
         _correspondenceRepository = correspondenceRepository;
-
     }
 
     public async Task<OneOf<GetAttachmentOverviewResponse, Error>> Process(Guid attachmentId, CancellationToken cancellationToken)

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
@@ -7,11 +7,14 @@ public class GetAttachmentOverviewHandler : IHandler<Guid, GetAttachmentOverview
 {
     private readonly IAttachmentStatusRepository _attachmentStatusRepository;
     private readonly IAttachmentRepository _attachmentRepository;
+    private readonly ICorrespondenceRepository _correspondenceRepository;
 
-    public GetAttachmentOverviewHandler(IAttachmentStatusRepository attachmentStatusRepository, IAttachmentRepository attachmentRepository)
+    public GetAttachmentOverviewHandler(IAttachmentStatusRepository attachmentStatusRepository, IAttachmentRepository attachmentRepository, ICorrespondenceRepository correspondenceRepository)
     {
         _attachmentStatusRepository = attachmentStatusRepository;
         _attachmentRepository = attachmentRepository;
+        _correspondenceRepository = correspondenceRepository;
+
     }
 
     public async Task<OneOf<GetAttachmentOverviewResponse, Error>> Process(Guid attachmentId, CancellationToken cancellationToken)
@@ -22,6 +25,7 @@ public class GetAttachmentOverviewHandler : IHandler<Guid, GetAttachmentOverview
             return Errors.AttachmentNotFound;
         }
         var attachmentStatus = await _attachmentStatusRepository.GetLatestStatusByAttachmentId(attachmentId, cancellationToken);
+        var correspondenceIds = await _correspondenceRepository.GetCorrespondenceIdsByAttachmentId(attachmentId, cancellationToken);
 
         var response = new GetAttachmentOverviewResponse
         {
@@ -34,7 +38,8 @@ public class GetAttachmentOverviewHandler : IHandler<Guid, GetAttachmentOverview
             DataLocationType = attachment.DataLocationType,
             DataType = attachment.DataType,
             IntendedPresentation = attachment.IntendedPresentation,
-            SendersReference = attachment.SendersReference
+            SendersReference = attachment.SendersReference,
+            CorrespondenceIds = correspondenceIds
         };
         return response;
     }

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewResponse.cs
@@ -23,4 +23,5 @@ public class GetAttachmentOverviewResponse
     public string DataType { get; set; } = string.Empty;
 
     public IntendedPresentationType IntendedPresentation { get; set; }
+    public List<Guid> CorrespondenceIds { get; set; } = new List<Guid>();
 }

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewResponse.cs
@@ -23,5 +23,6 @@ public class GetAttachmentOverviewResponse
     public string DataType { get; set; } = string.Empty;
 
     public IntendedPresentationType IntendedPresentation { get; set; }
+
     public List<Guid> CorrespondenceIds { get; set; } = new List<Guid>();
 }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -15,7 +15,7 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
 
     public async Task<OneOf<GetCorrespondenceDetailsResponse, Error>> Process(Guid CorrespondenceId, CancellationToken cancellationToken)
     {
-        var correspondence = await _CorrespondenceRepository.GetCorrespondenceById(CorrespondenceId, true, false, cancellationToken);
+        var correspondence = await _CorrespondenceRepository.GetCorrespondenceById(CorrespondenceId, true, true, cancellationToken);
         if (correspondence == null)
         {
             return Errors.CorrespondenceNotFound;
@@ -28,6 +28,7 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
             StatusText = latestStatus.StatusText,
             StatusChanged = latestStatus.StatusChanged,
             SendersReference = correspondence.SendersReference,
+            Content = correspondence.Content!,
             Created = correspondence.Created,
             Recipient = correspondence.Recipient,
             ReplyOptions = correspondence.ReplyOptions == null ? new List<CorrespondenceReplyOptionEntity>() : correspondence.ReplyOptions,

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
@@ -22,6 +22,7 @@ public class GetCorrespondenceDetailsResponse
     public DateTimeOffset Created { get; set; }
 
     public string Recipient { get; set; } = string.Empty;
+
     public required CorrespondenceContentEntity Content { get; set; }
 
     public List<CorrespondenceReplyOptionEntity> ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionEntity>();

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
@@ -22,6 +22,7 @@ public class GetCorrespondenceDetailsResponse
     public DateTimeOffset Created { get; set; }
 
     public string Recipient { get; set; } = string.Empty;
+    public required CorrespondenceContentEntity Content { get; set; }
 
     public List<CorrespondenceReplyOptionEntity> ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionEntity>();
 

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -15,7 +15,7 @@ public class GetCorrespondenceOverviewHandler : IHandler<Guid, GetCorrespondence
 
     public async Task<OneOf<GetCorrespondenceOverviewResponse, Error>> Process(Guid CorrespondenceId, CancellationToken cancellationToken)
     {
-        var correspondence = await _CorrespondenceRepository.GetCorrespondenceById(CorrespondenceId, true, false, cancellationToken);
+        var correspondence = await _CorrespondenceRepository.GetCorrespondenceById(CorrespondenceId, true, true, cancellationToken);
         if (correspondence == null)
         {
             return Errors.CorrespondenceNotFound;
@@ -28,6 +28,7 @@ public class GetCorrespondenceOverviewHandler : IHandler<Guid, GetCorrespondence
         var response = new GetCorrespondenceOverviewResponse
         {
             CorrespondenceId = correspondence.Id,
+            Content = correspondence.Content,
             Status = latestStatus.Status,
             StatusText = latestStatus.StatusText,
             StatusChanged = latestStatus.StatusChanged,

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
@@ -22,6 +22,7 @@ public class GetCorrespondenceOverviewResponse
     public DateTimeOffset Created { get; set; }
 
     public string Recipient { get; set; } = string.Empty;
+
     public required CorrespondenceContentEntity Content { get; set; }
 
     public List<CorrespondenceReplyOptionEntity> ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionEntity>();

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
@@ -22,6 +22,7 @@ public class GetCorrespondenceOverviewResponse
     public DateTimeOffset Created { get; set; }
 
     public string Recipient { get; set; } = string.Empty;
+    public required CorrespondenceContentEntity Content { get; set; }
 
     public List<CorrespondenceReplyOptionEntity> ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionEntity>();
 

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondence/InitializeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondence/InitializeCorrespondenceHandler.cs
@@ -70,14 +70,17 @@ public class InitializeCorrespondenceHandler : IHandler<InitializeCorrespondence
         AttachmentEntity? attachment = null;
         if (correspondenceAttachment.DataLocationUrl != null)
         {
+            Console.WriteLine("Getting attachment by url:" + correspondenceAttachment.DataLocationUrl);
             var existingAttachment = await _attachmentRepository.GetAttachmentByUrl(correspondenceAttachment.DataLocationUrl, cancellationToken);
             if (existingAttachment != null)
             {
+                Console.WriteLine("Attachment found by url:" + correspondenceAttachment.DataLocationUrl);
                 attachment = existingAttachment;
             }
         }
         if (attachment == null)
         {
+            Console.WriteLine("Creating new attachment");
             var status = new List<AttachmentStatusEntity>(){
                     new AttachmentStatusEntity
                     {

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondence/InitializeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondence/InitializeCorrespondenceHandler.cs
@@ -70,17 +70,15 @@ public class InitializeCorrespondenceHandler : IHandler<InitializeCorrespondence
         AttachmentEntity? attachment = null;
         if (correspondenceAttachment.DataLocationUrl != null)
         {
-            Console.WriteLine("Getting attachment by url:" + correspondenceAttachment.DataLocationUrl);
             var existingAttachment = await _attachmentRepository.GetAttachmentByUrl(correspondenceAttachment.DataLocationUrl, cancellationToken);
             if (existingAttachment != null)
             {
-                Console.WriteLine("Attachment found by url:" + correspondenceAttachment.DataLocationUrl);
                 attachment = existingAttachment;
             }
         }
         if (attachment == null)
         {
-            Console.WriteLine("Creating new attachment");
+
             var status = new List<AttachmentStatusEntity>(){
                     new AttachmentStatusEntity
                     {

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceAttachmentRepository.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceAttachmentRepository.cs
@@ -6,6 +6,5 @@ namespace Altinn.Correspondence.Core.Repositories
     public interface ICorrespondenceAttachmentRepository
     {
         Task<Guid?> GetAttachmentIdByCorrespondenceAttachmentId(Guid correspondenceAttachmentId, CancellationToken cancellationToken);
-        Task<Guid> PurgeCorrespondenceAttachmentsByAttachmentId(Guid attachmentId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceAttachmentRepository.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceAttachmentRepository.cs
@@ -5,6 +5,7 @@ namespace Altinn.Correspondence.Core.Repositories
 {
     public interface ICorrespondenceAttachmentRepository
     {
+        Task<Guid?> GetAttachmentIdByCorrespondenceAttachmentId(Guid correspondenceAttachmentId, CancellationToken cancellationToken);
         Task<Guid> PurgeCorrespondenceAttachmentsByAttachmentId(Guid attachmentId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -23,5 +23,6 @@ namespace Altinn.Correspondence.Core.Repositories
 
         Task<List<CorrespondenceEntity>> GetCorrespondencesByAttachmentId(Guid attachmentId, bool includeStatus, CancellationToken cancellationToken = default);
         Task<List<Guid>> GetNonPublishedCorrespondencesByAttachmentId(Guid attachmentId, CancellationToken cancellationToken = default);
+        Task<List<Guid>> GetCorrespondenceIdsByAttachmentId(Guid attachmentId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceAttachmentRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceAttachmentRepository.cs
@@ -14,16 +14,5 @@ namespace Altinn.Correspondence.Persistence.Repositories
             return await _context.CorrespondenceAttachments
                 .Where(ca => ca.Id == correspondenceAttachmentId).Select(ca => ca.AttachmentId).FirstOrDefaultAsync(cancellationToken);
         }
-        public async Task<Guid> PurgeCorrespondenceAttachmentsByAttachmentId(Guid attachmentId, CancellationToken cancellationToken = default)
-        {
-            var correspondenceAttachments = await _context.CorrespondenceAttachments
-                .Where(ca => ca.AttachmentId == attachmentId)
-                .ToListAsync(cancellationToken);
-
-            _context.RemoveRange(correspondenceAttachments);
-            await _context.SaveChangesAsync(cancellationToken);
-
-            return attachmentId;
-        }
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceAttachmentRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceAttachmentRepository.cs
@@ -9,6 +9,11 @@ namespace Altinn.Correspondence.Persistence.Repositories
     {
         private readonly ApplicationDbContext _context = context;
 
+        public async Task<Guid?> GetAttachmentIdByCorrespondenceAttachmentId(Guid correspondenceAttachmentId, CancellationToken cancellationToken = default)
+        {
+            return await _context.CorrespondenceAttachments
+                .Where(ca => ca.Id == correspondenceAttachmentId).Select(ca => ca.AttachmentId).FirstOrDefaultAsync(cancellationToken);
+        }
         public async Task<Guid> PurgeCorrespondenceAttachmentsByAttachmentId(Guid attachmentId, CancellationToken cancellationToken = default)
         {
             var correspondenceAttachments = await _context.CorrespondenceAttachments

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -76,5 +76,13 @@ namespace Altinn.Correspondence.Persistence.Repositories
 
             return correspondences;
         }
+
+        public async Task<List<Guid>> GetCorrespondenceIdsByAttachmentId(Guid attachmentId, CancellationToken cancellationToken = default)
+        {
+            var correspondenceIds = await _context.Correspondences
+            .Where(c => c.Content != null && c.Content.Attachments.Any(ca => ca.AttachmentId == attachmentId))
+            .Select(c => c.Id).ToListAsync(cancellationToken);
+            return correspondenceIds;
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Features:
- Use correspondence attachment id for download attachment
- Update swagger documentation
- Add Correspondence Ids to attachment details/overview

Fixes: 
- Fix problem with data location url not beeing present in overview/details
- DataLocationUrl had wrong type in AttachmentOverviewExt

## Related Issue(s)
- #104 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
