### PR TITLE
Bugfix: skipping default logic should only happen when authenticate fails

### DIFF
--- a/src/Altinn.Correspondence.API/Helpers/JwtBearerEventsHelper.cs
+++ b/src/Altinn.Correspondence.API/Helpers/JwtBearerEventsHelper.cs
@@ -9,8 +9,8 @@ namespace Altinn.Correspondence.API.Helpers
         {
             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
             context.Response.ContentType = "application/json";
-            context.Response.Headers.Append("WWW-Authenticate", context.Options.Challenge + " error=\"invalid_token\", error_description=\"" + context.Exception.Message + "\"");
-            string err = "";
+            context.Response.Headers.Append("WWW-Authenticate", context.Options.Challenge + " error=\"invalid_token\"");
+            string err = context.Exception.Message;
             if (context.Exception is SecurityTokenInvalidIssuerException)
             {
                 context.Response.StatusCode = StatusCodes.Status403Forbidden;

--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -88,7 +88,10 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
                 OnAuthenticationFailed = context => JWTBearerEventsHelper.OnAuthenticationFailed(context),
                 OnChallenge = c =>
                 {
-                    c.HandleResponse();
+                    if (c.AuthenticateFailure != null)
+                    {
+                        c.HandleResponse();
+                    }
                     return Task.CompletedTask;
                 }
             };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Only skip default login on authenticateFailure


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
