### PR TITLE
Health check should verify database connectivity

### DIFF
--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -19,11 +19,24 @@ param containerAppEnvId string
 
 var probes = [
   {
+    type: 'Liveness'
     httpGet: {
-      port: 2525
       path: '/health'
+      port: 2525
     }
-    type: 'Startup'
+    periodSeconds: 10
+    failureThreshold: 3
+    initialDelaySeconds: 15
+  }
+  {
+    type: 'Readiness'
+    httpGet: {
+      path: '/health'
+      port: 2525
+    }
+    periodSeconds: 10
+    failureThreshold: 3
+    initialDelaySeconds: 15
   }
 ]
 

--- a/src/Altinn.Correspondence.API/Controllers/HealthController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/HealthController.cs
@@ -5,9 +5,10 @@ namespace Altinn.Correspondence.Controllers
 {
     [ApiController]
     [Route("health")]
-    public class HealthController(DbContext dbContext) : ControllerBase
+    public class HealthController(DbContext dbContext, ILogger<HealthController> logger) : ControllerBase
     {
         private readonly DbContext _dbContext = dbContext;
+        private readonly ILogger<HealthController> _logger;
 
         [HttpGet]
         public async Task<ActionResult> HealthCheckAsync()
@@ -23,6 +24,7 @@ namespace Altinn.Correspondence.Controllers
             }
             catch (Exception ex)
             {
+                _logger.LogError("Health check failed!)", ex);
                 return StatusCode(500, new
                 {
                     Status = "Unhealthy",

--- a/src/Altinn.Correspondence.API/Controllers/HealthController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/HealthController.cs
@@ -1,20 +1,34 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace Altinn.Correspondence.Controllers
 {
     [ApiController]
     [Route("health")]
-    public class HealthController : ControllerBase
+    public class HealthController(DbContext dbContext) : ControllerBase
     {
-
-        public HealthController()
-        {
-        }
+        private readonly DbContext _dbContext = dbContext;
 
         [HttpGet]
-        public ActionResult HealthCheckAsync()
+        public async Task<ActionResult> HealthCheckAsync()
         {
-            return Ok("Environment properly configured");
+            try
+            {
+                await _dbContext.Database.CanConnectAsync();
+                return Ok(new
+                {
+                    Status = "Healthy",
+                    Message = "Environment properly configured and database is accessible"
+                });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new
+                {
+                    Status = "Unhealthy",
+                    Message = $"Health check failed: {ex.Message}"
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Our health check should at the very least verify database connectivity. As our infra is still very simple I do not think we need more than that for now.

Also changed to use liveness and readiness probes instead of startup probe. If no startup probe is defined the readiness probe will instead be called immediately on startup.
These probes are called on regular intervals through the container's lifetime.

## Related Issue(s)
- #176 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
