### PR TITLE
Entity framework expects UTC. …

### DIFF
--- a/src/Altinn.Correspondence.Persistence/Data/DatabaseContext.cs
+++ b/src/Altinn.Correspondence.Persistence/Data/DatabaseContext.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.Core.Models;
+using Altinn.Correspondence.Persistence.Helpers;
 using Azure.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -53,5 +54,11 @@ public class ApplicationDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.HasDefaultSchema("correspondence");
+    }
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder
+            .Properties<DateTimeOffset>()
+            .HaveConversion<DateTimeOffsetConverter>();
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Helpers/DateTimeOffsetConverter.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/DateTimeOffsetConverter.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Altinn.Correspondence.Persistence.Helpers
+{
+    internal class DateTimeOffsetConverter : ValueConverter<DateTimeOffset, DateTimeOffset>
+    {
+        public DateTimeOffsetConverter()
+            : base(
+                d => d.ToUniversalTime(),
+                d => d.ToUniversalTime())
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description
Entity framework postgressql expects UTC for all datetimes. Instead of writing code manually to fix this for all DateTimeOffsets in our models we register a EF Core converter.
Ref:
https://learn.microsoft.com/en-us/ef/core/modeling/value-conversions?tabs=data-annotations#bulk-configuring-a-value-converter
https://github.com/npgsql/npgsql/issues/4176

## Related Issue(s)
- #205 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
