### PR TITLE
Remove sender from correspondence attachment

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -122,8 +122,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
                 RestrictionName = "testFile3",
                 SendersReference = "1234",
                 FileName = file.FileName,
-                IsEncrypted = false,
-                Sender = correspondence.Sender
+                IsEncrypted = false
             };
             correspondence.Content.Attachments = new List<InitializeCorrespondenceAttachmentExt>() { attachmentData };
             var formData = CorrespondenceToFormData(correspondence);
@@ -143,7 +142,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
                 FileName = attachmentOverview.FileName,
                 Name = "Logical file name",
                 RestrictionName = attachmentOverview.RestrictionName,
-                Sender = attachmentOverview.Sender,
                 SendersReference = attachmentOverview.SendersReference,
                 IsEncrypted = attachmentOverview.IsEncrypted,
                 Checksum = attachmentOverview.Checksum
@@ -171,7 +169,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
                 DataType = "text",
                 Name = "markdown example",
                 RestrictionName = "testFile3",
-                Sender = correspondence.Sender,
                 SendersReference = "1234",
                 FileName = file.FileName,
                 IsEncrypted = false,
@@ -180,7 +177,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
                 DataType = "text",
                 Name = "test file",
                 RestrictionName = "testFile3",
-                Sender = correspondence.Sender,
                 SendersReference = "1234",
                 FileName = file2.FileName,
                 IsEncrypted = false,
@@ -227,7 +223,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
                 DataType = "text",
                 Name = "MARKDOWN EXAMPLE",
                 RestrictionName = "testFile3",
-                Sender = correspondence.Sender,
                 SendersReference = "1234",
                 FileName = file.FileName,
                 IsEncrypted = false,
@@ -236,7 +231,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
                 DataType = "text",
                 Name = "test file",
                 RestrictionName = "testFile3",
-                Sender = correspondence.Sender,
                 SendersReference = "1234",
                 FileName = file2.FileName,
                 IsEncrypted = false,
@@ -479,7 +473,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             new { Key = $"{prefix}content.Attachments[{index}].Name", Value = attachment.Name },
             new { Key = $"{prefix}content.Attachments[{index}].FileName", Value = attachment.FileName ?? "" },
             new { Key = $"{prefix}content.Attachments[{index}].RestrictionName", Value = attachment.RestrictionName },
-            new { Key = $"{prefix}content.Attachments[{index}].Sender", Value = attachment.Sender },
             new { Key = $"{prefix}content.Attachments[{index}].SendersReference", Value = attachment.SendersReference },
             new { Key = $"{prefix}content.Attachments[{index}].IsEncrypted", Value = attachment.IsEncrypted.ToString() }
         }).SelectMany(x => x).ToList()

--- a/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
@@ -22,7 +22,6 @@ internal static class InitializeCorrespondenceFactory
                     DataType = "html",
                     Name = "2",
                     RestrictionName = "testFile2",
-                    Sender = "0192:986252932",
                     SendersReference = "1234",
                     FileName = "test-fil2e",
                     IsEncrypted = false,
@@ -93,7 +92,6 @@ internal static class InitializeCorrespondenceFactory
                         SendersReference = "1234",
                         FileName = "test-fil2e",
                         IsEncrypted = false,
-                        Sender = "0192:986252932",
                         DataLocationUrl = url
                     }
                 },
@@ -158,8 +156,7 @@ internal static class InitializeCorrespondenceFactory
                 RestrictionName = "testFile3",
                 SendersReference = "1234",
                 FileName = "test-fil3e",
-                IsEncrypted = false,
-                Sender = correspondence.Sender
+                IsEncrypted = false
             });
         return correspondence;
     }
@@ -178,7 +175,6 @@ internal static class InitializeCorrespondenceFactory
                 DataType = "pdf",
                 Name = "3",
                 RestrictionName = "testFile3",
-                Sender = "0192:986252932",
                 SendersReference = "1234",
                 FileName = "test-fil3e",
                 IsEncrypted = false,

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
@@ -15,7 +15,6 @@ internal static class CorrespondenceAttachmentMapper
             Id = attachment.Id,
             IsEncrypted = attachment.Attachment.IsEncrypted,
             Name = attachment.Attachment.Name,
-            Sender = attachment.Attachment.Sender,
             SendersReference = attachment.Attachment.SendersReference,
             Checksum = attachment.Attachment.Checksum,
             DataLocationType = (AttachmentDataLocationTypeExt)attachment.Attachment.DataLocationType,

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceAttachmentMapper.cs
@@ -6,16 +6,7 @@ namespace Altinn.Correspondence.Mappers;
 
 internal static class InitializeCorrespondenceAttachmentMapper
 {
-    internal static List<CorrespondenceAttachmentEntity> MapListToEntities(List<InitializeCorrespondenceAttachmentExt> initializeAttachmentExt, string resourceId)
-    {
-        var attachments = new List<CorrespondenceAttachmentEntity>();
-        foreach (var attachment in initializeAttachmentExt)
-        {
-            attachments.Add(MapToEntity(attachment, resourceId));
-        }
-        return attachments;
-    }
-    internal static CorrespondenceAttachmentEntity MapToEntity(InitializeCorrespondenceAttachmentExt initializeAttachmentExt, string resourceId)
+    internal static CorrespondenceAttachmentEntity MapToEntity(InitializeCorrespondenceAttachmentExt initializeAttachmentExt, string resourceId, string sender)
     {
         return new CorrespondenceAttachmentEntity
         {
@@ -28,7 +19,7 @@ internal static class InitializeCorrespondenceAttachmentMapper
                 Name = initializeAttachmentExt.Name,
                 RestrictionName = initializeAttachmentExt.RestrictionName,
                 ResourceId = resourceId,
-                Sender = initializeAttachmentExt.Sender,
+                Sender = sender,
                 SendersReference = initializeAttachmentExt.SendersReference,
                 DataType = initializeAttachmentExt.DataType,
                 Checksum = initializeAttachmentExt.Checksum,

--- a/src/Altinn.Correspondence.API/Mappers/InitializeMultipleCorrespondencesMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeMultipleCorrespondencesMapper.cs
@@ -30,7 +30,9 @@ internal static class InitializeMultipleCorrespondencesMapper
                 MessageTitle = initializeCorrespondenceExt.Content.MessageTitle,
                 MessageSummary = initializeCorrespondenceExt.Content.MessageSummary,
                 MessageBody = initializeCorrespondenceExt.Content.MessageBody,
-                Attachments = InitializeCorrespondenceAttachmentMapper.MapListToEntities(initializeCorrespondenceExt.Content.Attachments, initializeCorrespondenceExt.ResourceId)
+                Attachments = initializeCorrespondenceExt.Content.Attachments.Select(
+                    attachment => InitializeCorrespondenceAttachmentMapper.MapToEntity(attachment, initializeCorrespondenceExt.ResourceId, initializeCorrespondenceExt.Sender)
+                ).ToList()
             } : null,
         };
         return new InitializeMultipleCorrespondencesRequest()

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceAttachmentExt.cs
@@ -44,17 +44,6 @@ namespace Altinn.Correspondence.API.Models
         public string? Checksum { get; set; } = string.Empty;
 
         /// <summary>
-        /// The Sending organisation of the correspondence. 
-        /// </summary>
-        /// <remarks>
-        /// Organization number in countrycode:organizationnumber format.
-        /// </remarks>
-        [JsonPropertyName("sender")]
-        [RegularExpression(@"^\d{4}:\d{9}$", ErrorMessage = "Organization numbers should be on the form countrycode:organizationnumber, for instance 0192:910753614")]
-        [Required]
-        public required string Sender { get; set; }
-
-        /// <summary>
         /// A reference value given to the attachment by the creator.
         /// </summary>
         [JsonPropertyName("sendersReference")]

--- a/src/Altinn.Correspondence.Persistence/Data/DatabaseContext.cs
+++ b/src/Altinn.Correspondence.Persistence/Data/DatabaseContext.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.Core.Models;
+using Altinn.Correspondence.Persistence.Helpers;
 using Azure.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -53,5 +54,11 @@ public class ApplicationDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.HasDefaultSchema("correspondence");
+    }
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder
+            .Properties<DateTimeOffset>()
+            .HaveConversion<DateTimeOffsetConverter>();
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Helpers/DateTimeOffsetConverter.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/DateTimeOffsetConverter.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Altinn.Correspondence.Persistence.Helpers
+{
+    internal class DateTimeOffsetConverter : ValueConverter<DateTimeOffset, DateTimeOffset>
+    {
+        public DateTimeOffsetConverter()
+            : base(
+                d => d.ToUniversalTime(),
+                d => d.ToUniversalTime())
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description
Sender is associated with the correspondence itself, not the correspondence attachment. By removing excess properties we are able to simplify the API for our consumers.

## Related Issue(s)
- #207 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
