### PR TITLE
ReadyForPublish should be set after virus scan

### DIFF
--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Altinn.Correspondence.Application.GetAttachmentOverview;
 using Altinn.Correspondence.Application.GetCorrespondenceDetails;
 using Altinn.Correspondence.Application.GetCorrespondenceOverview;
 using Altinn.Correspondence.Application.GetCorrespondences;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Application.InitializeAttachment;
 using Altinn.Correspondence.Application.InitializeCorrespondence;
 using Altinn.Correspondence.Application.InitializeMultipleCorrespondences;
@@ -35,5 +36,8 @@ public static class DependencyInjection
         services.AddScoped<MalwareScanResultHandler>();
         services.AddScoped<PurgeCorrespondenceHandler>();
         services.AddScoped<UpdateMarkAsUnreadHandler>();
+
+        services.AddScoped<InitializeCorrespondenceHelper>();
+        services.AddScoped<UploadHelper>();
     }
 }

--- a/src/Altinn.Correspondence.Application/Helpers/UploadHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/UploadHelper.cs
@@ -97,7 +97,7 @@ namespace Altinn.Correspondence.Application.Helpers
             await _attachmentStatusRepository.AddAttachmentStatus(currentStatus, cancellationToken);
             return currentStatus;
         }
-        public async Task CheckCorrespondenceStatusesAfterUploadAndPublish(Guid attachmentId, CancellationToken cancellationToken)
+        public async Task CheckCorrespondenceStatusesAfterUploadAndPublish(Guid attachmentId, bool uploadSuccessful, CancellationToken cancellationToken)
         {
             var attachment = await _attachmentRepository.GetAttachmentById(attachmentId, true, cancellationToken);
             if (attachment == null)
@@ -114,15 +114,29 @@ namespace Altinn.Correspondence.Application.Helpers
             var list = new List<CorrespondenceStatusEntity>();
             foreach (var correspondenceId in correspondences)
             {
-                list.Add(
-                    new CorrespondenceStatusEntity
-                    {
-                        CorrespondenceId = correspondenceId,
-                        Status = CorrespondenceStatus.ReadyForPublish,
-                        StatusChanged = DateTime.UtcNow,
-                        StatusText = CorrespondenceStatus.ReadyForPublish.ToString()
-                    }
-                );
+                if (uploadSuccessful) 
+                { 
+                    list.Add(
+                        new CorrespondenceStatusEntity
+                        {
+                            CorrespondenceId = correspondenceId,
+                            Status = CorrespondenceStatus.ReadyForPublish,
+                            StatusChanged = DateTime.UtcNow,
+                            StatusText = CorrespondenceStatus.ReadyForPublish.ToString()
+                        }
+                    );
+                } else
+                {
+                    list.Add(
+                        new CorrespondenceStatusEntity
+                        {
+                            CorrespondenceId = correspondenceId,
+                            Status = CorrespondenceStatus.Failed,
+                            StatusChanged = DateTime.UtcNow,
+                            StatusText = "Malware scan failed"
+                        }
+                    );
+                }
             }
             await _correspondenceStatusRepository.AddCorrespondenceStatuses(list, cancellationToken);
             return;

--- a/src/Altinn.Correspondence.Application/Helpers/UploadHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/UploadHelper.cs
@@ -34,6 +34,7 @@ namespace Altinn.Correspondence.Application.Helpers
             var attachment = await _attachmentRepository.GetAttachmentById(attachmentId, true, cancellationToken);
             if (attachment == null)
             {
+                return Errors.AttachmentNotFound;
             }
 
             var currentStatus = await SetAttachmentStatus(attachmentId, AttachmentStatus.UploadProcessing, cancellationToken);

--- a/src/Altinn.Correspondence.Application/InitializeMultipleCorrespondences/InitializeMultipleCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeMultipleCorrespondences/InitializeMultipleCorrespondencesHandler.cs
@@ -16,25 +16,17 @@ public class InitializeMultipleCorrespondencesHandler : IHandler<InitializeMulti
 {
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly ICorrespondenceRepository _correspondenceRepository;
-    private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
-    private readonly IAttachmentRepository _attachmentRepository;
-    private readonly IAttachmentStatusRepository _attachmentStatusRepository;
     private readonly IEventBus _eventBus;
-    private readonly IStorageRepository _storageRepository;
-    private readonly IHostEnvironment _hostEnvironment;
-    IBackgroundJobClient _backgroundJobClient;
+    private readonly InitializeCorrespondenceHelper _initializeCorrespondenceHelper;
+    private readonly IBackgroundJobClient _backgroundJobClient;
 
-    public InitializeMultipleCorrespondencesHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, IAttachmentRepository attachmentRepository, IAttachmentStatusRepository attachmentStatusRepository, IStorageRepository storageRepository, IHostEnvironment hostEnvironment, IEventBus eventBus, IBackgroundJobClient backgroundJobClient)
+    public InitializeMultipleCorrespondencesHandler(InitializeCorrespondenceHelper initializeCorrespondenceHelper, IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, IEventBus eventBus, IBackgroundJobClient backgroundJobClient)
     {
+        _initializeCorrespondenceHelper = initializeCorrespondenceHelper;
         _altinnAuthorizationService = altinnAuthorizationService;
         _correspondenceRepository = correspondenceRepository;
-        _correspondenceStatusRepository = correspondenceStatusRepository;
-        _attachmentRepository = attachmentRepository;
-        _attachmentStatusRepository = attachmentStatusRepository;
         _eventBus = eventBus;
         _backgroundJobClient = backgroundJobClient;
-        _storageRepository = storageRepository;
-        _hostEnvironment = hostEnvironment;
     }
 
     public async Task<OneOf<InitializeMultipleCorrespondencesResponse, Error>> Process(InitializeMultipleCorrespondencesRequest request, CancellationToken cancellationToken)
@@ -52,33 +44,32 @@ public class InitializeMultipleCorrespondencesHandler : IHandler<InitializeMulti
         {
             return Errors.DuplicateRecipients;
         }
-        InitializeCorrespondenceHelper initializeCorrespondenceHelper = new InitializeCorrespondenceHelper(_correspondenceRepository, _correspondenceStatusRepository, _attachmentStatusRepository, _attachmentRepository, _storageRepository, _hostEnvironment);
-        var contentError = initializeCorrespondenceHelper.ValidateCorrespondenceContent(request.Correspondence.Content);
+        var contentError = _initializeCorrespondenceHelper.ValidateCorrespondenceContent(request.Correspondence.Content);
         if (contentError != null)
         {
             return contentError;
         }
 
-        var attachmentError = initializeCorrespondenceHelper.ValidateAttachmentFiles(request.Attachments, request.Correspondence.Content!.Attachments, true);
+        var attachmentError = _initializeCorrespondenceHelper.ValidateAttachmentFiles(request.Attachments, request.Correspondence.Content!.Attachments, true);
         if (attachmentError != null) return attachmentError;
         var attachments = new List<AttachmentEntity>();
         if (request.Correspondence.Content!.Attachments.Count() > 0)
         {
             foreach (var attachment in request.Correspondence.Content!.Attachments)
             {
-                var a = await initializeCorrespondenceHelper.ProcessAttachment(attachment, true, cancellationToken);
+                var a = await _initializeCorrespondenceHelper.ProcessAttachment(attachment, cancellationToken);
                 attachments.Add(a);
             }
         }
         if (request.Attachments.Count > 0)
         {
-            var uploadError = await initializeCorrespondenceHelper.UploadAttachments(attachments, request.Attachments, cancellationToken);
+            var uploadError = await _initializeCorrespondenceHelper.UploadAttachments(attachments, request.Attachments, cancellationToken);
             if (uploadError != null)
             {
                 return uploadError;
             }
         }
-        var status = initializeCorrespondenceHelper.GetInitializeCorrespondenceStatus(request.Correspondence);
+        var status = _initializeCorrespondenceHelper.GetInitializeCorrespondenceStatus(request.Correspondence);
         var correspondences = new List<CorrespondenceEntity>();
         foreach (var recipient in request.Recipients)
         {
@@ -108,7 +99,7 @@ public class InitializeMultipleCorrespondencesHandler : IHandler<InitializeMulti
                 PropertyList = request.Correspondence.PropertyList.ToDictionary(x => x.Key, x => x.Value),
                 ReplyOptions = request.Correspondence.ReplyOptions,
                 IsReservable = request.Correspondence.IsReservable,
-                Notifications = initializeCorrespondenceHelper.ProcessNotifications(request.Correspondence.Notifications, cancellationToken),
+                Notifications = _initializeCorrespondenceHelper.ProcessNotifications(request.Correspondence.Notifications, cancellationToken),
                 Statuses = new List<CorrespondenceStatusEntity>(){
                     new CorrespondenceStatusEntity
                     {

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -18,7 +18,7 @@ public class MalwareScanResultHandler(
 {
     private readonly IAttachmentRepository _attachmentRepository = attachmentRepository;
     private readonly IAttachmentStatusRepository _attachmentStatusRepository = attachmentStatusRepository;
-    private readonly UploadHelper _uploadHelper;
+    private readonly UploadHelper _uploadHelper = uploadHelper;
     private readonly ILogger<MalwareScanResultHandler> _logger = logger;
     private readonly IEventBus _eventBus = eventBus;
 
@@ -65,7 +65,7 @@ public class MalwareScanResultHandler(
             }, cancellationToken);
             await _eventBus.Publish(AltinnEventType.AttachmentUploadFailed, attachment.ResourceId, attachmentIdFromBlobUri, "Malware scan", attachment.SendersReference, cancellationToken);
             _logger.LogWarning("Malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
-            await _uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachment.Id, false, cancellationToken);
+            await _uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachmentId, false, cancellationToken);
             return Task.CompletedTask;
         }
     }

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -4,9 +4,6 @@ using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
-using Altinn.Correspondence.Persistence.Repositories;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging;
 using OneOf;
 
@@ -15,19 +12,13 @@ namespace Altinn.Correspondence.Application;
 public class MalwareScanResultHandler(
     IAttachmentRepository attachmentRepository,
     IAttachmentStatusRepository attachmentStatusRepository,
-    ICorrespondenceRepository correspondenceRepository,
-    ICorrespondenceStatusRepository correspondenceStatusRepository,
-    IHostEnvironment hostEnvironment,
-    IStorageRepository storageRepository,
     IEventBus eventBus,
+    UploadHelper uploadHelper,
     ILogger<MalwareScanResultHandler> logger) : IHandler<ScanResultData, Task>
 {
     private readonly IAttachmentRepository _attachmentRepository = attachmentRepository;
     private readonly IAttachmentStatusRepository _attachmentStatusRepository = attachmentStatusRepository;
-    private readonly ICorrespondenceRepository _correspondenceRepository = correspondenceRepository;
-    private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository = correspondenceStatusRepository;
-    private readonly IHostEnvironment _hostEnvironment = hostEnvironment;
-    private readonly IStorageRepository _storageRepository = storageRepository;
+    private readonly UploadHelper _uploadHelper;
     private readonly ILogger<MalwareScanResultHandler> _logger = logger;
     private readonly IEventBus _eventBus = eventBus;
 
@@ -59,8 +50,7 @@ public class MalwareScanResultHandler(
             }, cancellationToken);
             await _eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.SendersReference, cancellationToken);
             _logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
-            UploadHelper uploadHelper = new UploadHelper(_correspondenceRepository, _correspondenceStatusRepository, _attachmentStatusRepository, _attachmentRepository, _storageRepository, _hostEnvironment);
-            await uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachment.Id, cancellationToken);
+            await _uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachment.Id, true, cancellationToken);
             return Task.CompletedTask;
         }
         else
@@ -74,7 +64,8 @@ public class MalwareScanResultHandler(
                 StatusText = $"Malware scan failed: {data.ScanResultType}: {data.ScanResultDetails}"
             }, cancellationToken);
             await _eventBus.Publish(AltinnEventType.AttachmentUploadFailed, attachment.ResourceId, attachmentIdFromBlobUri, "Malware scan", attachment.SendersReference, cancellationToken);
-            _logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
+            _logger.LogWarning("Malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
+            await _uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachment.Id, false, cancellationToken);
             return Task.CompletedTask;
         }
     }

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -1,8 +1,12 @@
-﻿using Altinn.Correspondence.Application.MalwareScanResult.Models;
+﻿using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Application.MalwareScanResult.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
+using Altinn.Correspondence.Persistence.Repositories;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging;
 using OneOf;
 
@@ -11,11 +15,19 @@ namespace Altinn.Correspondence.Application;
 public class MalwareScanResultHandler(
     IAttachmentRepository attachmentRepository,
     IAttachmentStatusRepository attachmentStatusRepository,
+    ICorrespondenceRepository correspondenceRepository,
+    ICorrespondenceStatusRepository correspondenceStatusRepository,
+    IHostEnvironment hostEnvironment,
+    IStorageRepository storageRepository,
     IEventBus eventBus,
     ILogger<MalwareScanResultHandler> logger) : IHandler<ScanResultData, Task>
 {
     private readonly IAttachmentRepository _attachmentRepository = attachmentRepository;
     private readonly IAttachmentStatusRepository _attachmentStatusRepository = attachmentStatusRepository;
+    private readonly ICorrespondenceRepository _correspondenceRepository = correspondenceRepository;
+    private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository = correspondenceStatusRepository;
+    private readonly IHostEnvironment _hostEnvironment = hostEnvironment;
+    private readonly IStorageRepository _storageRepository = storageRepository;
     private readonly ILogger<MalwareScanResultHandler> _logger = logger;
     private readonly IEventBus _eventBus = eventBus;
 
@@ -47,6 +59,8 @@ public class MalwareScanResultHandler(
             }, cancellationToken);
             await _eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.SendersReference, cancellationToken);
             _logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
+            UploadHelper uploadHelper = new UploadHelper(_correspondenceRepository, _correspondenceStatusRepository, _attachmentStatusRepository, _attachmentRepository, _storageRepository, _hostEnvironment);
+            await uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachment.Id, cancellationToken);
             return Task.CompletedTask;
         }
         else

--- a/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
@@ -42,7 +42,10 @@ public class UploadAttachmentHandler(IAltinnAuthorizationService altinnAuthoriza
         UploadHelper uploadHelper = new UploadHelper(_correspondenceRepository, _correspondenceStatusRepository, _attachmentStatusRepository, _attachmentRepository, _storageRepository, _hostEnvironment);
         var uploadResult = await uploadHelper.UploadAttachment(request.UploadStream, request.AttachmentId, cancellationToken);
 
-        await uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachment.Id, cancellationToken);
+        if (_hostEnvironment.IsDevelopment())
+        {
+            await uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachment.Id, cancellationToken);
+        }
 
         return uploadResult.Match<OneOf<UploadAttachmentResponse, Error>>(
             data => { return data; },

--- a/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
@@ -44,7 +44,7 @@ public class UploadAttachmentHandler(IAltinnAuthorizationService altinnAuthoriza
 
         if (_hostEnvironment.IsDevelopment())
         {
-            await uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachment.Id, cancellationToken);
+            await uploadHelper.CheckCorrespondenceStatusesAfterUploadAndPublish(attachment.Id, true, cancellationToken);
         }
 
         return uploadResult.Match<OneOf<UploadAttachmentResponse, Error>>(


### PR DESCRIPTION
## Description
ReadyForPublish should be set after virus scan when running in Azure. Only locally should it be set after upload. Correspondences associated with malware attachments should also fail.

I also did some re-factoring by injecting the helper classes that contain shared application logic. 

## Related Issue(s)
- #207 
- #177 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
