### PR TITLE
Feat/attachmentid for existing attachments

### DIFF
--- a/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
@@ -140,8 +140,6 @@ public class AttachmentControllerTests : IClassFixture<CustomWebApplicationFacto
         var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
         payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
         payload.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
-
-
         var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
         var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
 

--- a/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
@@ -137,7 +137,12 @@ public class AttachmentControllerTests : IClassFixture<CustomWebApplicationFacto
         var content = new ByteArrayContent(originalAttachmentData);
         var uploadedAttachment = await (await UploadAttachment(attachmentId, content)).Content.ReadFromJsonAsync<AttachmentOverviewExt>(_responseSerializerOptions);
         Assert.NotNull(uploadedAttachment);
-        var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", InitializeCorrespondenceFactory.BasicCorrespondenceWithFileAttachment(uploadedAttachment.DataLocationUrl), _responseSerializerOptions);
+        var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
+        payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
+        payload.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
+
+
+        var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
         var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
 
         var overviewResponse = await _client.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{response?.CorrespondenceIds.FirstOrDefault().ToString()}", _responseSerializerOptions);

--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -332,7 +332,9 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
     {
         var uploadedAttachment = await InitializeAttachment();
         Assert.NotNull(uploadedAttachment);
-        var payload = InitializeCorrespondenceFactory.BasicCorrespondenceWithFileAttachment(uploadedAttachment.DataLocationUrl);
+        var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
+        payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
+        payload.Correspondence.Content.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
         payload.Correspondence.VisibleFrom = DateTime.UtcNow.AddMinutes(-1);
         var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
         var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
@@ -358,7 +360,10 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
     public async Task Correspondence_with_dataLocationUrl_Reuses_Attachment()
     {
         var uploadedAttachment = await InitializeAttachment();
-        var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", InitializeCorrespondenceFactory.BasicCorrespondenceWithFileAttachment(uploadedAttachment.DataLocationUrl), _responseSerializerOptions);
+        var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
+        payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
+        payload.Correspondence.Content.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
+        var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
         var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
         initializeCorrespondenceResponse.EnsureSuccessStatusCode();
         Assert.Equal(uploadedAttachment.AttachmentId.ToString(), response?.AttachmentIds?.FirstOrDefault().ToString());
@@ -396,8 +401,10 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
     {
         var attachment = await InitializeAttachment();
         Assert.NotNull(attachment);
-        var correspondence1 = InitializeCorrespondenceFactory.BasicCorrespondenceWithFileAttachment(attachment.DataLocationUrl);
-        var correspondence2 = InitializeCorrespondenceFactory.BasicCorrespondenceWithFileAttachment(attachment.DataLocationUrl);
+        var correspondence1 = InitializeCorrespondenceFactory.BasicCorrespondences();
+        correspondence1.ExistingAttachments = new List<Guid> { attachment.AttachmentId };
+        var correspondence2 = InitializeCorrespondenceFactory.BasicCorrespondences();
+        correspondence2.ExistingAttachments = new List<Guid> { attachment.AttachmentId };
 
         var initializeCorrespondenceResponse1 = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence1, _responseSerializerOptions);
         var response1 = await initializeCorrespondenceResponse1.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();

--- a/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
@@ -74,10 +74,11 @@ internal static class InitializeCorrespondenceFactory
             IsReservable = true
         },
         Recipients = new List<string>(){
-        "0192:986252931",
-        "0192:986252932",
-        "0192:986252933"
-    }
+            "0192:986252931",
+            "0192:986252932",
+            "0192:986252933"
+        },
+        ExistingAttachments = new List<Guid>(),
     };
 
     internal static InitializeCorrespondencesExt BasicCorrespondenceWithFileAttachment()
@@ -99,22 +100,6 @@ internal static class InitializeCorrespondenceFactory
     {
         var data = BasicCorrespondences();
         data.Correspondence.Content!.Attachments = attachments;
-        return data;
-    }
-    internal static InitializeCorrespondencesExt BasicCorrespondenceWithFileAttachment(string url)
-    {
-        var data = BasicCorrespondences();
-        data.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>(){
-            new InitializeCorrespondenceAttachmentExt()
-            {
-                DataType = "pdf",
-                Name = "3",
-                RestrictionName = "testFile3",
-                SendersReference = "1234",
-                FileName = "test-fil3e",
-                IsEncrypted = false,
-                DataLocationUrl = url
-            }};
         return data;
     }
     internal static InitializeCorrespondencesExt BasicCorrespondenceWithNoMessageBody()

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -43,7 +43,7 @@ namespace Altinn.Correspondence.API.Controllers
             LogContextHelpers.EnrichLogsWithInsertCorrespondence(request.Correspondence);
             _logger.LogInformation("Initialize correspondences");
 
-            var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, null, false);
+            var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, null, request.ExistingAttachments, false);
             var commandResult = await handler.Process(commandRequest, cancellationToken);
 
             return commandResult.Match(
@@ -74,7 +74,7 @@ namespace Altinn.Correspondence.API.Controllers
 
             Request.EnableBuffering();
 
-            var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, attachments, true);
+            var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, attachments, request.ExistingAttachments, true);
             var commandResult = await handler.Process(commandRequest, cancellationToken);
 
             return commandResult.Match(

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
@@ -6,7 +6,7 @@ namespace Altinn.Correspondence.Mappers;
 
 internal static class InitializeCorrespondencesMapper
 {
-    internal static InitializeCorrespondencesRequest MapToRequest(BaseCorrespondenceExt initializeCorrespondenceExt, List<string> Recipients, List<IFormFile>? attachments, bool isUploadRequest)
+    internal static InitializeCorrespondencesRequest MapToRequest(BaseCorrespondenceExt initializeCorrespondenceExt, List<string> Recipients, List<IFormFile>? attachments, List<Guid>? existingAttachments, bool isUploadRequest)
     {
         var correspondence = new CorrespondenceEntity
         {
@@ -39,7 +39,8 @@ internal static class InitializeCorrespondencesMapper
         {
             Correspondence = correspondence,
             Attachments = attachments ?? new List<IFormFile>(),
-            isUploadRequest = isUploadRequest,
+            IsUploadRequest = isUploadRequest,
+            ExistingAttachments = existingAttachments ?? new List<Guid>(),
             Recipients = Recipients
         };
     }

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondencesExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondencesExt.cs
@@ -20,6 +20,12 @@ public class InitializeCorrespondencesExt
     [RecipientList]
     public required List<string> Recipients { get; set; }
 
+    /// <summary>
+    /// Existing attachments that should be added to the correspondence
+    /// </summary>
+    [JsonPropertyName("existingAttachments")]
+    public List<Guid> ExistingAttachments { get; set; } = new List<Guid>();
+
 
     [AttributeUsage(AttributeTargets.Property)]
     internal class RecipientListAttribute : ValidationAttribute

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -30,4 +30,5 @@ public static class Errors
     public static Error UploadCorrespondenceNoAttachments = new Error(22, "When uploading correspondences, either upload or use existing attachments", HttpStatusCode.BadRequest);
     public static Error HashError = new Error(23, "Checksum mismatch", HttpStatusCode.BadRequest);
     public static Error DataLocationNotFound = new Error(24, "Could not get data location url", HttpStatusCode.BadRequest);
+    public static Error ExistingAttachmentNotFound = new Error(25, "Existing attachment not found", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -108,16 +108,20 @@ namespace Altinn.Correspondence.Application.Helpers
             return null;
         }
 
-        public async Task<AttachmentEntity> ProcessAttachment(CorrespondenceAttachmentEntity correspondenceAttachment, CancellationToken cancellationToken)
+        public async Task<List<AttachmentEntity>?> GetExistingAttachments(List<Guid> attachmentIds, CancellationToken cancellationToken)
         {
-            if (!string.IsNullOrEmpty(correspondenceAttachment.Attachment?.DataLocationUrl))
+            var attachments = new List<AttachmentEntity>();
+            foreach (var attachmentId in attachmentIds)
             {
-                var existingAttachment = await _attachmentRepository.GetAttachmentByUrl(correspondenceAttachment.Attachment.DataLocationUrl, cancellationToken);
-                if (existingAttachment != null)
-                {
-                    return existingAttachment;
-                }
+                var attachment = await _attachmentRepository.GetAttachmentById(attachmentId, false, cancellationToken);
+                if (attachment == null) return null;
+                attachments.Add(attachment);
             }
+            return attachments;
+        }
+
+        public async Task<AttachmentEntity> ProcessNewAttachment(CorrespondenceAttachmentEntity correspondenceAttachment, CancellationToken cancellationToken)
+        {
             var status = new List<AttachmentStatusEntity>(){
                 new AttachmentStatusEntity
                 {

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesRequest.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesRequest.cs
@@ -9,6 +9,9 @@ public class InitializeCorrespondencesRequest
 
     public List<IFormFile> Attachments { get; set; } = new List<IFormFile>();
 
-    public bool isUploadRequest { get; set; }
+    public bool IsUploadRequest { get; set; }
+
+    public List<Guid> ExistingAttachments { get; set; }
+
     public List<string> Recipients { get; set; }
 }

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -31,7 +31,7 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
     public async Task<OneOf<Guid, Error>> Process(Guid correspondenceId, CancellationToken cancellationToken)
     {
         var correspondence = await _correspondenceRepository.GetCorrespondenceById(correspondenceId, true, false, cancellationToken);
-        if (correspondence == null) return Errors.AttachmentNotFound;
+        if (correspondence == null) return Errors.CorrespondenceNotFound;
         var hasAccess = await _altinnAuthorizationService.CheckUserAccess(correspondence.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Open }, cancellationToken);
         if (!hasAccess)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- When creating correspondences, existing attachments is now found by attachment id 
- Changed error message when purging correspondence, when correspondence is not found 

## Related Issue(s)
- #211 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
