### PR TITLE
Fix/add resourceId

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -324,6 +324,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var getCorrespondenceDetailsResponse = await _client.GetAsync($"correspondence/api/v1/correspondence/{correspondence?.CorrespondenceIds.FirstOrDefault()}/details");
         Assert.True(getCorrespondenceDetailsResponse.IsSuccessStatusCode, await getCorrespondenceDetailsResponse.Content.ReadAsStringAsync());
         var response = await getCorrespondenceDetailsResponse.Content.ReadFromJsonAsync<CorrespondenceDetailsExt>(_responseSerializerOptions);
+        Assert.NotEqual(Guid.Empty, Guid.Parse(response.ResourceId));
         Assert.Equal(response.Status, CorrespondenceStatusExt.Initialized);
     }
     [Fact]

--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -324,7 +324,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var getCorrespondenceDetailsResponse = await _client.GetAsync($"correspondence/api/v1/correspondence/{correspondence?.CorrespondenceIds.FirstOrDefault()}/details");
         Assert.True(getCorrespondenceDetailsResponse.IsSuccessStatusCode, await getCorrespondenceDetailsResponse.Content.ReadAsStringAsync());
         var response = await getCorrespondenceDetailsResponse.Content.ReadFromJsonAsync<CorrespondenceDetailsExt>(_responseSerializerOptions);
-        Assert.NotEqual(Guid.Empty, Guid.Parse(response.ResourceId));
+        Assert.NotEqual(string.Empty, response.ResourceId);
         Assert.Equal(response.Status, CorrespondenceStatusExt.Initialized);
     }
     [Fact]

--- a/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
@@ -8,7 +8,7 @@ internal static class InitializeCorrespondenceFactory
     {
         Correspondence = new BaseCorrespondenceExt()
         {
-            ResourceId = "12345678-1234-1234-1234-1234567890ab",
+            ResourceId = "1",
             Sender = "0192:991825827",
             SendersReference = "1",
             Content = new InitializeCorrespondenceContentExt()

--- a/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
@@ -8,7 +8,7 @@ internal static class InitializeCorrespondenceFactory
     {
         Correspondence = new BaseCorrespondenceExt()
         {
-            ResourceId = "1",
+            ResourceId = "12345678-1234-1234-1234-1234567890ab",
             Sender = "0192:991825827",
             SendersReference = "1",
             Content = new InitializeCorrespondenceContentExt()

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -72,7 +72,7 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
             VisibleFrom = correspondence.VisibleFrom,
             IsReservable = correspondence.IsReservable == null || correspondence.IsReservable.Value,
             StatusHistory = correspondence.Statuses,
-            ResourceId = Guid.Parse(correspondence.ResourceId)
+            ResourceId = correspondence.ResourceId
         };
         return response;
     }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -64,14 +64,15 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
             StatusText = latestStatus.StatusText,
             StatusChanged = latestStatus.StatusChanged,
             SendersReference = correspondence.SendersReference,
-            Content = correspondence.Content!,
             Created = correspondence.Created,
             Recipient = correspondence.Recipient,
+            Content = correspondence.Content!,
             ReplyOptions = correspondence.ReplyOptions == null ? new List<CorrespondenceReplyOptionEntity>() : correspondence.ReplyOptions,
             Notifications = correspondence.Notifications == null ? new List<CorrespondenceNotificationEntity>() : correspondence.Notifications,
             VisibleFrom = correspondence.VisibleFrom,
             IsReservable = correspondence.IsReservable == null || correspondence.IsReservable.Value,
-            StatusHistory = correspondence.Statuses
+            StatusHistory = correspondence.Statuses,
+            ResourceId = Guid.Parse(correspondence.ResourceId)
         };
         return response;
     }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
@@ -35,7 +35,7 @@ public class GetCorrespondenceDetailsResponse
 
     public List<ExternalReferenceEntity> ExternalReferences { get; set; } = new List<ExternalReferenceEntity>();
 
-    public Guid ResourceId { get; set; }
+    public string ResourceId { get; set; }
 
     public DateTimeOffset VisibleFrom { get; set; }
 


### PR DESCRIPTION
Legge til ResourceId i GetCorrespondenceDetails respons

## Description
ResourceId lå ikke i responsen på GetCorrespondenceDetails tidligere. Den var også satt som en Guid, som gjorde at det ble automatisk satt som en tom string som er en grunn til at det gikk gjennom testene tidligere uansett. Dette er endret til string nå. 

## Related Issue(s)
- #218 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
