### PR TITLE
Fix/remove data location url in responses

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -135,7 +135,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             var response = await uploadCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
             var attachmentId = response?.AttachmentIds.FirstOrDefault();
             var attachmentOverview = await _client.GetFromJsonAsync<AttachmentOverviewExt>($"correspondence/api/v1/attachment/{attachmentId}", _responseSerializerOptions);
-            Assert.NotNull(attachmentOverview.DataLocationUrl);
             payload.Correspondence.Content.Attachments.Add(new InitializeCorrespondenceAttachmentExt()
             {
                 DataLocationUrl = attachmentOverview.DataLocationUrl,

--- a/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
@@ -15,7 +15,6 @@ internal static class AttachmentDetailsMapper
             ResourceId = "1",
             AttachmentId = AttachmentDetails.AttachmentId,
             Status = (AttachmentStatusExt)AttachmentDetails.Status,
-            DataLocationUrl = AttachmentDetails.DataLocationUrl,
             FileName = AttachmentDetails.FileName,
             Name = AttachmentDetails.Name,
             Sender = AttachmentDetails.Sender,

--- a/src/Altinn.Correspondence.API/Mappers/AttachmentOverviewMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentOverviewMapper.cs
@@ -19,7 +19,6 @@ internal static class AttachmentOverviewMapper
             Status = (AttachmentStatusExt)attachmentOverview.Status,
             StatusText = attachmentOverview.StatusText,
             Checksum = attachmentOverview.Checksum,
-            DataLocationUrl = attachmentOverview.DataLocationUrl,
             StatusChanged = attachmentOverview.StatusChanged,
             DataType = attachmentOverview.DataType,
             SendersReference = attachmentOverview.SendersReference,

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
@@ -18,7 +18,6 @@ internal static class CorrespondenceAttachmentMapper
             SendersReference = attachment.Attachment.SendersReference,
             Checksum = attachment.Attachment.Checksum,
             DataLocationType = (AttachmentDataLocationTypeExt)attachment.Attachment.DataLocationType,
-            DataLocationUrl = attachment.Attachment.DataLocationUrl,
             RestrictionName = attachment.Attachment.RestrictionName,
             Status = (AttachmentStatusExt)attachment.Attachment.Statuses.OrderByDescending(s => s.StatusChanged).FirstOrDefault()!.Status,
             StatusText = attachment.Attachment.Statuses.OrderByDescending(s => s.StatusChanged).FirstOrDefault()!.StatusText,

--- a/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsHandler.cs
@@ -36,7 +36,6 @@ public class GetAttachmentDetailsHandler : IHandler<Guid, GetAttachmentDetailsRe
         {
             ResourceId = attachment.ResourceId,
             AttachmentId = attachment.Id,
-            DataLocationUrl = attachment.DataLocationUrl,
             Name = attachment.FileName,
             Status = attachmentStatus.Status,
             Statuses = attachment.Statuses,

--- a/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsResponse.cs
@@ -10,8 +10,6 @@ public class GetAttachmentDetailsResponse
 
     public AttachmentDataLocationType DataLocationType { get; set; }
 
-    public string? DataLocationUrl { get; set; }
-
     public AttachmentStatus Status { get; set; }
 
     public string StatusText { get; set; } = string.Empty;

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
@@ -38,7 +38,6 @@ public class GetAttachmentOverviewHandler : IHandler<Guid, GetAttachmentOverview
         {
             AttachmentId = attachment.Id,
             ResourceId = attachment.ResourceId,
-            DataLocationUrl = attachment.DataLocationUrl,
             Name = attachment.FileName,
             Checksum = attachment.Checksum,
             Status = attachmentStatus.Status,

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewResponse.cs
@@ -9,8 +9,6 @@ public class GetAttachmentOverviewResponse
 
     public AttachmentDataLocationType DataLocationType { get; set; }
 
-    public string? DataLocationUrl { get; set; }
-
     public AttachmentStatus Status { get; set; }
 
     public required string StatusText { get; set; }


### PR DESCRIPTION
Fjern datalocationUrl fra respons slik at det ikke eksponeres for brukeren

## Description
Fjernet fra de som var direkte i Response objekter og fleste som var i External mappers.

## Related Issue(s)
- #222 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
