### PR TITLE
add security headers for sniffing and cachecontrol

### DIFF
--- a/src/Altinn.Correspondence.API/Helpers/SecurityHeadersMiddleware.cs
+++ b/src/Altinn.Correspondence.API/Helpers/SecurityHeadersMiddleware.cs
@@ -11,8 +11,8 @@ public class SecurityHeadersMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        context.Response.Headers.Add("X-Content-Type-Options", new StringValues("nosniff"));
-        context.Response.Headers.Add("Cache-Control", new StringValues("no-store"));
+        context.Response.Headers.Append("X-Content-Type-Options", new StringValues("nosniff"));
+        context.Response.Headers.Append("Cache-Control", new StringValues("no-store"));
 
         await _next(context);
     }

--- a/src/Altinn.Correspondence.API/Helpers/SecurityHeadersMiddleware.cs
+++ b/src/Altinn.Correspondence.API/Helpers/SecurityHeadersMiddleware.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Primitives;
+
+public class SecurityHeadersMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public SecurityHeadersMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        context.Response.Headers.Add("X-Content-Type-Options", new StringValues("nosniff"));
+        context.Response.Headers.Add("Cache-Control", new StringValues("no-store"));
+
+        await _next(context);
+    }
+}

--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -37,6 +37,7 @@ static void BuildAndRun(string[] args)
     app.UseAuthorization();
 
     app.MapControllers();
+    app.UseMiddleware<SecurityHeadersMiddleware>();
 
     if (app.Environment.IsDevelopment())
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add security headers which disable sniffing of Http requests and tells browsers to not cache our requests

## Related Issue(s)
- https://github.com/Altinn/altinn-broker/issues/485 and https://github.com/Altinn/altinn-broker/issues/483

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
