### PR TITLE
Feat/getcorrespondences default search

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -153,7 +153,7 @@ namespace Altinn.Correspondence.API.Controllers
             [FromQuery] DateTimeOffset? from,
             [FromQuery] DateTimeOffset? to,
             [FromServices] GetCorrespondencesHandler handler,
-            [FromQuery] CorrespondenceStatusExt status = CorrespondenceStatusExt.Published,
+            [FromQuery] CorrespondenceStatusExt? status,
             CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Get correspondences for receiver");
@@ -164,7 +164,7 @@ namespace Altinn.Correspondence.API.Controllers
                 From = from,
                 Limit = limit,
                 Offset = offset,
-                Status = (CorrespondenceStatus)status,
+                Status = status is null? null : (CorrespondenceStatus)status,
                 To = to
 
             }, cancellationToken);

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesRequest.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesRequest.cs
@@ -12,6 +12,6 @@ public class GetCorrespondencesRequest
 
     public DateTimeOffset? To { get; set; }
 
-    public CorrespondenceStatus Status { get; set; } = CorrespondenceStatus.Published;
+    public CorrespondenceStatus? Status { get; set; }
 
 }

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -16,8 +16,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
             };
             if (status == null) // No status specified, return all except blacklisted
             {
-                return query
-                .Where(correspondence => blacklistedStatues.Contains(correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status));
+                return query.Where(correspondence => !blacklistedStatues.Contains(correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status));
             }
             else
             {

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -1,0 +1,29 @@
+using Altinn.Correspondence.Core.Models;
+using Altinn.Correspondence.Core.Models.Enums;
+
+namespace Altinn.Correspondence.Persistence.Helpers
+{
+    public static class QueryExtensions
+    {
+
+        public static IQueryable<CorrespondenceEntity> WithValidStatuses(this IQueryable<CorrespondenceEntity> query, CorrespondenceStatus? status)
+        {
+            var blacklistedStatues = new List<CorrespondenceStatus?>
+            {
+                CorrespondenceStatus.Archived,
+                CorrespondenceStatus.PurgedByAltinn,
+                CorrespondenceStatus.PurgedByRecipient
+            };
+            if (status == null) // No status specified, return all except blacklisted
+            {
+                return query
+                .Where(correspondence => blacklistedStatues.Contains(correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status));
+            }
+            else
+            {
+                return query
+                .Where(correspondence => correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status == status);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implement default search for GetCorrespondences, with filter for Archived and Purged.

## Description
Previously a call to the GetCorrespondences would return an empty list if the `status` was not specified. This feature allows a call to ommit specifying a status. However, a blacklist is used to statuses we do not wish to return. Right now it consist of `Archived`, `PurgedByAltinn` and `PurgedByRecipient`.

## Related Issue(s)
- #202

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
