### PR TITLE
Feat/update policies attachment

### DIFF
--- a/src/Altinn.Correspondence.API/Configuration/AuthorizationConstants.cs
+++ b/src/Altinn.Correspondence.API/Configuration/AuthorizationConstants.cs
@@ -1,0 +1,11 @@
+namespace Altinn.Correspondence.API.Configuration;
+
+public static class AuthorizationConstants
+{
+    public const string Sender = "Sender";
+    public const string Recipient = "Recipient";
+    public const string SenderOrRecipient = "SenderOrRecipient";
+
+    public const string SenderScope = "altinn:correspondence.write";
+    public const string RecipientScope = "altinn:correspondence.read";
+}

--- a/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Correspondence.API.Models;
+﻿using Altinn.Correspondence.API.Configuration;
+using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.GetAttachmentDetails;
 using Altinn.Correspondence.Application.GetAttachmentOverview;
@@ -24,6 +25,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <remarks>Only required if the attachment is to be shared, otherwise this is done as part of the Initialize Correspondence operation</remarks>
     /// <returns></returns>
     [HttpPost]
+    [Authorize(Policy = AuthorizationConstants.Sender)]
     public async Task<ActionResult<Guid>> InitializeAttachment(InitializeAttachmentExt InitializeAttachmentExt, [FromServices] InitializeAttachmentHandler handler, CancellationToken cancellationToken)
     {
         var commandRequest = InitializeAttachmentMapper.MapToRequest(InitializeAttachmentExt);
@@ -43,6 +45,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     [HttpPost]
     [Route("{attachmentId}/upload")]
     [Consumes("application/octet-stream")]
+    [Authorize(Policy = AuthorizationConstants.Sender)]
     public async Task<ActionResult<AttachmentOverviewExt>> UploadAttachmentData(
         Guid attachmentId,
         [FromServices] UploadAttachmentHandler uploadAttachmentHandler,
@@ -76,6 +79,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <returns>AttachmentOverviewExt</returns>
     [HttpGet]
     [Route("{attachmentId}")]
+    [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
     public async Task<ActionResult<AttachmentOverviewExt>> GetAttachmentOverview(
         Guid attachmentId,
         [FromServices] GetAttachmentOverviewHandler handler,
@@ -97,6 +101,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <returns></returns>
     [HttpGet]
     [Route("{attachmentId}/details")]
+    [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
     public async Task<ActionResult<AttachmentDetailsExt>> GetAttachmentDetails(
         Guid attachmentId,
         [FromServices] GetAttachmentDetailsHandler handler,
@@ -122,6 +127,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <returns></returns>
     [HttpDelete]
     [Route("{attachmentId}")]
+    [Authorize(Policy = AuthorizationConstants.Recipient)]
     public async Task<ActionResult<AttachmentOverviewExt>> DeleteAttachment(
         Guid attachmentId,
         [FromServices] PurgeAttachmentHandler handler,

--- a/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
@@ -127,7 +127,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <returns></returns>
     [HttpDelete]
     [Route("{attachmentId}")]
-    [Authorize(Policy = AuthorizationConstants.Recipient)]
+    [Authorize(Policy = AuthorizationConstants.Sender)]
     public async Task<ActionResult<AttachmentOverviewExt>> DeleteAttachment(
         Guid attachmentId,
         [FromServices] PurgeAttachmentHandler handler,

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Correspondence.API.Models;
+﻿using Altinn.Correspondence.API.Configuration;
+using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.DownloadAttachment;
@@ -38,6 +39,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>CorrespondenceIds</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Sender)]
         public async Task<ActionResult<CorrespondenceOverviewExt>> InitializeCorrespondences(
             InitializeCorrespondencesExt request,
             [FromServices] InitializeCorrespondencesHandler handler,
@@ -66,6 +68,7 @@ namespace Altinn.Correspondence.API.Controllers
         [HttpPost]
         [Route("upload")]
         [RequestFormLimits(MultipartBodyLengthLimit = long.MaxValue)]
+        [Authorize(Policy = AuthorizationConstants.Sender)]
         public async Task<ActionResult<CorrespondenceOverviewExt>> UploadCorrespondences(
             [FromForm] InitializeCorrespondencesExt request,
             [FromForm] List<IFormFile> attachments,
@@ -183,6 +186,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>StatusId</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [Route("{correspondenceId}/markasread")]
         public async Task<ActionResult> MarkAsRead(
             Guid correspondenceId,
@@ -211,11 +215,12 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>OK</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [Route("{correspondenceId}/markasunread")]
         public async Task<ActionResult> MarkAsUnread(
-          Guid correspondenceId,
-          [FromServices] UpdateMarkAsUnreadHandler handler,
-          CancellationToken cancellationToken)
+            Guid correspondenceId,
+            [FromServices] UpdateMarkAsUnreadHandler handler,
+            CancellationToken cancellationToken)
         {
             _logger.LogInformation("Marking Correspondence as unread for {correspondenceId}", correspondenceId.ToString());
 
@@ -235,6 +240,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>StatusId</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [Route("{correspondenceId}/confirm")]
         public async Task<ActionResult> Confirm(
             Guid correspondenceId,
@@ -263,6 +269,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>StatusId</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [Route("{correspondenceId}/archive")]
         public async Task<ActionResult> Archive(
             Guid correspondenceId,

--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -1,4 +1,5 @@
 using Altinn.Common.PEP.Authorization;
+using Altinn.Correspondence.API.Configuration;
 using Altinn.Correspondence.API.Helpers;
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Core.Options;
@@ -101,6 +102,9 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
     services.AddAuthorization(options =>
     {
         options.DefaultPolicy = new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme).AddRequirements(new ScopeAccessRequirement("altinn:correspondence")).Build();
+        options.AddPolicy(AuthorizationConstants.Sender, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.SenderScope)).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
+        options.AddPolicy(AuthorizationConstants.Recipient, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.RecipientScope)).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
+        options.AddPolicy(AuthorizationConstants.SenderOrRecipient, policy => policy.AddRequirements(new ScopeAccessRequirement([AuthorizationConstants.SenderScope, AuthorizationConstants.RecipientScope])).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
     });
     services.AddEndpointsApiExplorer();
     services.AddSwaggerGen();

--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -101,7 +101,6 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
     services.AddTransient<IAuthorizationHandler, ScopeAccessHandler>();
     services.AddAuthorization(options =>
     {
-        options.DefaultPolicy = new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme).AddRequirements(new ScopeAccessRequirement("altinn:correspondence")).Build();
         options.AddPolicy(AuthorizationConstants.Sender, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.SenderScope)).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
         options.AddPolicy(AuthorizationConstants.Recipient, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.RecipientScope)).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
         options.AddPolicy(AuthorizationConstants.SenderOrRecipient, policy => policy.AddRequirements(new ScopeAccessRequirement([AuthorizationConstants.SenderScope, AuthorizationConstants.RecipientScope])).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));

--- a/src/Altinn.Correspondence.Application/InitializeAttachment/InitializeAttachmentCommandHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeAttachment/InitializeAttachmentCommandHandler.cs
@@ -24,7 +24,7 @@ public class InitializeAttachmentHandler : IHandler<InitializeAttachmentRequest,
 
     public async Task<OneOf<Guid, Error>> Process(InitializeAttachmentRequest request, CancellationToken cancellationToken)
     {
-        var hasAccess = await _altinnAuthorizationService.CheckUserAccess(request.Attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Open }, cancellationToken);
+        var hasAccess = await _altinnAuthorizationService.CheckUserAccess(request.Attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Send }, cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;

--- a/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
@@ -25,7 +25,7 @@ public class UploadAttachmentHandler(IAltinnAuthorizationService altinnAuthoriza
         {
             return Errors.AttachmentNotFound;
         }
-        var hasAccess = await _altinnAuthorizationService.CheckUserAccess(attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Open }, cancellationToken);
+        var hasAccess = await _altinnAuthorizationService.CheckUserAccess(attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Send }, cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;


### PR DESCRIPTION
Lagt til autoriseringsregler for attachment endepunkt

## Description
AuthorizationConstants er lagt til på lik måte som gjort i broker.
Ingen endringer i applikasjon har blitt gjort, utenom en liten endring i en if-sjekk.
Upload og Initialize har gått fra Open -> Send, slik at det er likt med correspondence

## Related Issue(s)
- #246
- #252 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
