### PR TITLE
Feat/update auth policies

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -394,14 +394,15 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var correspondenceList = await _client.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resource}&offset=0&limit=10");
 
         // Assert
-        Assert.Equal(correspondenceList?.Pagination.TotalItems, 1); // Receiver only sees the one that is published
+        var expected = 2 - 1; // Receiver only sees the one that is published
+        Assert.Equal(correspondenceList?.Pagination.TotalItems, expected);
     }
     [Fact]
     public async Task GetCorrespondences_WithoutStatusSpecified_AsSender_ReturnsAllExceptBlacklisted()
     {
         // Arrange
         var resource = Guid.NewGuid().ToString();
-        var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
+        var payload = InitializeCorrespondenceFactory.BasicCorrespondences(); // One initialized
         payload.Correspondence.ResourceId = resource;
         payload.Correspondence.Sender = _userId;
 
@@ -413,7 +414,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var correspondenceList = await _client.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resource}&offset=0&limit=10");
 
         // Assert
-        var expected = payload.Recipients.Count - 1;
+        var expected = payload.Recipients.Count - 1; // One was deleted
         Assert.Equal(correspondenceList?.Pagination.TotalItems, expected);
     }
     [Fact]

--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -2011,7 +2011,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=altinn:correspondence&org=ttd&orgNo=991825827&userId=1&partyId=1&pid=22069343112",
+							"raw": "https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=altinn:correspondence.write&org=ttd&orgNo=991825827&userId=1&partyId=1&pid=22069343112",
 							"protocol": "https",
 							"host": [
 								"altinn-testtools-token-generator",
@@ -2029,7 +2029,7 @@
 								},
 								{
 									"key": "scopes",
-									"value": "altinn:correspondence"
+									"value": "altinn:correspondence.write"
 								},
 								{
 									"key": "org",
@@ -2084,7 +2084,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=altinn:correspondence&org=ttd&orgNo=986252932&userId=2&partyId=2&pid=22069343112",
+							"raw": "https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=altinn:correspondence.read&org=ttd&orgNo=986252932&userId=2&partyId=2&pid=22069343112",
 							"protocol": "https",
 							"host": [
 								"altinn-testtools-token-generator",
@@ -2102,7 +2102,7 @@
 								},
 								{
 									"key": "scopes",
-									"value": "altinn:correspondence"
+									"value": "altinn:correspondence.read"
 								},
 								{
 									"key": "org",

--- a/src/Altinn.Correspondence.API/Configuration/AuthorizationConstants.cs
+++ b/src/Altinn.Correspondence.API/Configuration/AuthorizationConstants.cs
@@ -1,0 +1,11 @@
+namespace Altinn.Correspondence.API.Configuration;
+
+public static class AuthorizationConstants
+{
+    public const string Sender = "Sender";
+    public const string Recipient = "Recipient";
+    public const string SenderOrRecipient = "SenderOrRecipient";
+
+    public const string SenderScope = "altinn:correspondence.write";
+    public const string RecipientScope = "altinn:correspondence.read";
+}

--- a/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Correspondence.API.Models;
+﻿using Altinn.Correspondence.API.Configuration;
+using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.GetAttachmentDetails;
 using Altinn.Correspondence.Application.GetAttachmentOverview;
@@ -24,6 +25,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <remarks>Only required if the attachment is to be shared, otherwise this is done as part of the Initialize Correspondence operation</remarks>
     /// <returns></returns>
     [HttpPost]
+    [Authorize(Policy = AuthorizationConstants.Sender)]
     public async Task<ActionResult<Guid>> InitializeAttachment(InitializeAttachmentExt InitializeAttachmentExt, [FromServices] InitializeAttachmentHandler handler, CancellationToken cancellationToken)
     {
         var commandRequest = InitializeAttachmentMapper.MapToRequest(InitializeAttachmentExt);
@@ -43,6 +45,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     [HttpPost]
     [Route("{attachmentId}/upload")]
     [Consumes("application/octet-stream")]
+    [Authorize(Policy = AuthorizationConstants.Sender)]
     public async Task<ActionResult<AttachmentOverviewExt>> UploadAttachmentData(
         Guid attachmentId,
         [FromServices] UploadAttachmentHandler uploadAttachmentHandler,
@@ -76,6 +79,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <returns>AttachmentOverviewExt</returns>
     [HttpGet]
     [Route("{attachmentId}")]
+    [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
     public async Task<ActionResult<AttachmentOverviewExt>> GetAttachmentOverview(
         Guid attachmentId,
         [FromServices] GetAttachmentOverviewHandler handler,
@@ -97,6 +101,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <returns></returns>
     [HttpGet]
     [Route("{attachmentId}/details")]
+    [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
     public async Task<ActionResult<AttachmentDetailsExt>> GetAttachmentDetails(
         Guid attachmentId,
         [FromServices] GetAttachmentDetailsHandler handler,
@@ -122,6 +127,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <returns></returns>
     [HttpDelete]
     [Route("{attachmentId}")]
+    [Authorize(Policy = AuthorizationConstants.Recipient)]
     public async Task<ActionResult<AttachmentOverviewExt>> DeleteAttachment(
         Guid attachmentId,
         [FromServices] PurgeAttachmentHandler handler,

--- a/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
@@ -127,7 +127,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <returns></returns>
     [HttpDelete]
     [Route("{attachmentId}")]
-    [Authorize(Policy = AuthorizationConstants.Recipient)]
+    [Authorize(Policy = AuthorizationConstants.Sender)]
     public async Task<ActionResult<AttachmentOverviewExt>> DeleteAttachment(
         Guid attachmentId,
         [FromServices] PurgeAttachmentHandler handler,

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -122,12 +122,12 @@ namespace Altinn.Correspondence.API.Controllers
         /// Get more detailed information about the Correspondence and its current status as well as noticiation statuses, if available
         /// </summary>
         /// <remarks>
-        /// Meant for Senders that want a complete overview of the status and history of the Correspondence
+        /// Meant for Senders that want a complete overview of the status and history of the Correspondence, but also available for Receivers
         /// </remarks>
         /// <returns>Detailed information about the correspondence with current status and status history</returns>
         [HttpGet]
         [Route("{correspondenceId}/details")]
-        [Authorize(Policy = AuthorizationConstants.Sender)]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         public async Task<ActionResult<CorrespondenceDetailsExt>> GetCorrespondenceDetails(
             Guid correspondenceId,
             [FromServices] GetCorrespondenceDetailsHandler handler,
@@ -147,11 +147,11 @@ namespace Altinn.Correspondence.API.Controllers
         /// Gets a list of Correspondences for the authenticated user
         /// </summary>
         /// <remarks>
-        /// Meant for Receivers
+        /// Meant for Receivers, but also available for Senders to track Correspondences
         /// </remarks>
         /// <returns>A list of Correspondence ids and pagination metadata</returns>
         [HttpGet]
-        [Authorize(Policy = AuthorizationConstants.Recipient)]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         public async Task<ActionResult<CorrespondencesExt>> GetCorrespondences(
             [FromQuery] string resourceId,
             [FromQuery] int offset,

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -102,6 +102,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <returns></returns>
         [HttpGet]
         [Route("{correspondenceId}")]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         public async Task<ActionResult<CorrespondenceOverviewExt>> GetCorrespondenceOverview(
             Guid correspondenceId,
             [FromServices] GetCorrespondenceOverviewHandler handler,
@@ -126,6 +127,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <returns>Detailed information about the correspondence with current status and status history</returns>
         [HttpGet]
         [Route("{correspondenceId}/details")]
+        [Authorize(Policy = AuthorizationConstants.Sender)]
         public async Task<ActionResult<CorrespondenceDetailsExt>> GetCorrespondenceDetails(
             Guid correspondenceId,
             [FromServices] GetCorrespondenceDetailsHandler handler,
@@ -149,6 +151,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>A list of Correspondence ids and pagination metadata</returns>
         [HttpGet]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         public async Task<ActionResult<CorrespondencesExt>> GetCorrespondences(
             [FromQuery] string resourceId,
             [FromQuery] int offset,
@@ -299,6 +302,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <returns>Ok</returns>
         [HttpDelete]
         [Route("{correspondenceId}/purge")]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         public async Task<ActionResult> Purge(
             Guid correspondenceId,
             [FromServices] PurgeCorrespondenceHandler handler,
@@ -321,6 +325,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <returns></returns>
         [HttpGet]
         [Route("{correspondenceId}/attachment/{attachmentId}/download")]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         public async Task<ActionResult> DownloadAttachmentData(
             Guid correspondenceId,
             Guid attachmentId,

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Correspondence.API.Models;
+﻿using Altinn.Correspondence.API.Configuration;
+using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.DownloadAttachment;
@@ -38,6 +39,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>CorrespondenceIds</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Sender)]
         public async Task<ActionResult<CorrespondenceOverviewExt>> InitializeCorrespondences(
             InitializeCorrespondencesExt request,
             [FromServices] InitializeCorrespondencesHandler handler,
@@ -66,6 +68,7 @@ namespace Altinn.Correspondence.API.Controllers
         [HttpPost]
         [Route("upload")]
         [RequestFormLimits(MultipartBodyLengthLimit = long.MaxValue)]
+        [Authorize(Policy = AuthorizationConstants.Sender)]
         public async Task<ActionResult<CorrespondenceOverviewExt>> UploadCorrespondences(
             [FromForm] InitializeCorrespondencesExt request,
             [FromForm] List<IFormFile> attachments,
@@ -183,6 +186,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>StatusId</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [Route("{correspondenceId}/markasread")]
         public async Task<ActionResult> MarkAsRead(
             Guid correspondenceId,
@@ -211,11 +215,12 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>OK</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [Route("{correspondenceId}/markasunread")]
         public async Task<ActionResult> MarkAsUnread(
-          Guid correspondenceId,
-          [FromServices] UpdateMarkAsUnreadHandler handler,
-          CancellationToken cancellationToken)
+            Guid correspondenceId,
+            [FromServices] UpdateMarkAsUnreadHandler handler,
+            CancellationToken cancellationToken)
         {
             _logger.LogInformation("Marking Correspondence as unread for {correspondenceId}", correspondenceId.ToString());
 
@@ -235,6 +240,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>StatusId</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [Route("{correspondenceId}/confirm")]
         public async Task<ActionResult> Confirm(
             Guid correspondenceId,
@@ -263,6 +269,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <returns>StatusId</returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [Route("{correspondenceId}/archive")]
         public async Task<ActionResult> Archive(
             Guid correspondenceId,

--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -1,4 +1,5 @@
 using Altinn.Common.PEP.Authorization;
+using Altinn.Correspondence.API.Configuration;
 using Altinn.Correspondence.API.Helpers;
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Core.Options;
@@ -101,6 +102,9 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
     services.AddAuthorization(options =>
     {
         options.DefaultPolicy = new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme).AddRequirements(new ScopeAccessRequirement("altinn:correspondence")).Build();
+        options.AddPolicy(AuthorizationConstants.Sender, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.SenderScope)).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
+        options.AddPolicy(AuthorizationConstants.Recipient, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.RecipientScope)).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
+        options.AddPolicy(AuthorizationConstants.SenderOrRecipient, policy => policy.AddRequirements(new ScopeAccessRequirement([AuthorizationConstants.SenderScope, AuthorizationConstants.RecipientScope])).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
     });
     services.AddEndpointsApiExplorer();
     services.AddSwaggerGen();

--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -101,7 +101,6 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
     services.AddTransient<IAuthorizationHandler, ScopeAccessHandler>();
     services.AddAuthorization(options =>
     {
-        options.DefaultPolicy = new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme).AddRequirements(new ScopeAccessRequirement("altinn:correspondence")).Build();
         options.AddPolicy(AuthorizationConstants.Sender, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.SenderScope)).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
         options.AddPolicy(AuthorizationConstants.Recipient, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.RecipientScope)).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));
         options.AddPolicy(AuthorizationConstants.SenderOrRecipient, policy => policy.AddRequirements(new ScopeAccessRequirement([AuthorizationConstants.SenderScope, AuthorizationConstants.RecipientScope])).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme));

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -37,4 +37,7 @@ public static class Errors
     public static Error AllowSystemDeletePriorVisibleFrom = new Error(29, "AllowSystemDelete cannot be prior to VisibleFrom", HttpStatusCode.BadRequest);
     public static Error AllowSystemDeletePriorDueDate = new Error(30, "AllowSystemDelete cannot be prior to DueDateTime", HttpStatusCode.BadRequest);
     public static Error CouldNotFindOrgNo = new Error(31, "Could not identify orgnumber from user", HttpStatusCode.Unauthorized);
+    public static Error CantPurgeCorrespondenceSender = new Error(32, "Cannot delete correspondence that has been published", HttpStatusCode.BadRequest);
+    public static Error CantPurgeCorrespondenceRecipient = new Error(33, "Cannot delete correspondence that has not been delivered", HttpStatusCode.Unauthorized);
+    public static Error CantPurgeCorrespondence = new Error(34, "You must be a sender or recipient in order to purge correspondence", HttpStatusCode.Unauthorized);
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -36,4 +36,5 @@ public static class Errors
     public static Error AllowSystemDeletePriorToday = new Error(28, "AllowSystemDelete cannot be prior to today", HttpStatusCode.BadRequest);
     public static Error AllowSystemDeletePriorVisibleFrom = new Error(29, "AllowSystemDelete cannot be prior to VisibleFrom", HttpStatusCode.BadRequest);
     public static Error AllowSystemDeletePriorDueDate = new Error(30, "AllowSystemDelete cannot be prior to DueDateTime", HttpStatusCode.BadRequest);
+    public static Error CouldNotFindOrgNo = new Error(31, "Could not identify orgnumber from user", HttpStatusCode.Unauthorized);
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -38,6 +38,6 @@ public static class Errors
     public static Error AllowSystemDeletePriorDueDate = new Error(30, "AllowSystemDelete cannot be prior to DueDateTime", HttpStatusCode.BadRequest);
     public static Error CouldNotFindOrgNo = new Error(31, "Could not identify orgnumber from user", HttpStatusCode.Unauthorized);
     public static Error CantPurgeCorrespondenceSender = new Error(32, "Cannot delete correspondence that has been published", HttpStatusCode.BadRequest);
-    public static Error CantPurgeCorrespondenceRecipient = new Error(33, "Cannot delete correspondence that has not been delivered", HttpStatusCode.Unauthorized);
-    public static Error CantPurgeCorrespondence = new Error(34, "You must be a sender or recipient in order to purge correspondence", HttpStatusCode.Unauthorized);
+    public static Error CantPurgeCorrespondenceRecipient = new Error(33, "Cannot delete correspondence that has not been delivered", HttpStatusCode.BadRequest);
+    public static Error CantPurgeCorrespondence = new Error(34, "You must be a sender or recipient in order to purge correspondence", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using OneOf;
@@ -8,11 +9,13 @@ public class GetCorrespondencesHandler : IHandler<GetCorrespondencesRequest, Get
 {
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly ICorrespondenceRepository _correspondenceRepository;
+    private readonly GetCorrespondenceHelper _getCorrespondenceHelper;
 
-    public GetCorrespondencesHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository)
+    public GetCorrespondencesHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, GetCorrespondenceHelper getCorrespondenceHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _correspondenceRepository = correspondenceRepository;
+        _getCorrespondenceHelper = getCorrespondenceHelper;
     }
 
     public async Task<OneOf<GetCorrespondencesResponse, Error>> Process(GetCorrespondencesRequest request, CancellationToken cancellationToken)
@@ -31,7 +34,12 @@ public class GetCorrespondencesHandler : IHandler<GetCorrespondencesRequest, Get
         var limit = request.Limit == 0 ? 50 : request.Limit;
         DateTimeOffset? to = request.To != null ? ((DateTimeOffset)request.To).ToUniversalTime() : null;
         DateTimeOffset? from = request.From != null ? ((DateTimeOffset)request.From).ToUniversalTime() : null;
-        var correspondences = await _correspondenceRepository.GetCorrespondences(request.ResourceId, request.Offset, limit, from, to, request.Status, cancellationToken);
+        string? orgNo = _getCorrespondenceHelper.GetUserID();
+        if (orgNo is null)
+        {
+            return Errors.CouldNotFindOrgNo;
+        }
+        var correspondences = await _correspondenceRepository.GetCorrespondences(request.ResourceId, request.Offset, limit, from, to, request.Status, orgNo, cancellationToken);
 
         var response = new GetCorrespondencesResponse
         {

--- a/src/Altinn.Correspondence.Application/InitializeAttachment/InitializeAttachmentCommandHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeAttachment/InitializeAttachmentCommandHandler.cs
@@ -24,7 +24,7 @@ public class InitializeAttachmentHandler : IHandler<InitializeAttachmentRequest,
 
     public async Task<OneOf<Guid, Error>> Process(InitializeAttachmentRequest request, CancellationToken cancellationToken)
     {
-        var hasAccess = await _altinnAuthorizationService.CheckUserAccess(request.Attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Open }, cancellationToken);
+        var hasAccess = await _altinnAuthorizationService.CheckUserAccess(request.Attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Send }, cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
@@ -16,8 +17,9 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
     private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
     private readonly IStorageRepository _storageRepository;
     private readonly IEventBus _eventBus;
+    private readonly GetCorrespondenceHelper _getCorrespondenceHelper;
 
-    public PurgeCorrespondenceHandler(IAltinnAuthorizationService altinnAuthorizationService, IAttachmentRepository attachmentRepository, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, IStorageRepository storageRepository, IAttachmentStatusRepository attachmentStatusRepository, IEventBus eventBus)
+    public PurgeCorrespondenceHandler(IAltinnAuthorizationService altinnAuthorizationService, IAttachmentRepository attachmentRepository, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, IStorageRepository storageRepository, IAttachmentStatusRepository attachmentStatusRepository, IEventBus eventBus, GetCorrespondenceHelper getCorrespondenceHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _attachmentRepository = attachmentRepository;
@@ -26,6 +28,7 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
         _storageRepository = storageRepository;
         _attachmentStatusRepository = attachmentStatusRepository;
         _eventBus = eventBus;
+        _getCorrespondenceHelper = getCorrespondenceHelper;
     }
 
     public async Task<OneOf<Guid, Error>> Process(Guid correspondenceId, CancellationToken cancellationToken)
@@ -42,17 +45,55 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
         {
             return Errors.CorrespondenceAlreadyPurged;
         }
-
-        // TODO: sender should only be able to delete correspondence if it is not published
-        // Receiver should be able to delete correspondence if it is published
-
-        var newStatus = new CorrespondenceStatusEntity()
+        
+        string orgNo = _getCorrespondenceHelper.GetUserID();
+        if (orgNo is null)
         {
-            CorrespondenceId = correspondenceId,
-            Status = CorrespondenceStatus.PurgedByRecipient, // Todo: select status based on user role
-            StatusChanged = DateTimeOffset.UtcNow,
-            StatusText = CorrespondenceStatus.PurgedByRecipient.ToString()
-        };
+            return Errors.CouldNotFindOrgNo;
+        }
+
+        var latestStatus = correspondence.Statuses?.OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+        if (latestStatus == null)
+        {
+            return Errors.CorrespondenceNotFound;
+        }
+
+        var newStatus = new CorrespondenceStatusEntity();
+
+        if (correspondence.Sender == orgNo)
+        {
+            if (latestStatus.Status >= CorrespondenceStatus.Published)
+            {
+                return Errors.CantPurgeCorrespondenceSender;
+            }
+
+            newStatus = new CorrespondenceStatusEntity()
+            {
+                CorrespondenceId = correspondenceId,
+                Status = CorrespondenceStatus.PurgedByAltinn,
+                StatusChanged = DateTimeOffset.UtcNow,
+                StatusText = CorrespondenceStatus.PurgedByAltinn.ToString()
+            };
+        }
+        else if (correspondence.Recipient == orgNo)
+        {
+            if (latestStatus.Status < CorrespondenceStatus.Published)
+            {
+                return Errors.CantPurgeCorrespondenceRecipient;
+            }
+            newStatus = new CorrespondenceStatusEntity()
+            {
+                CorrespondenceId = correspondenceId,
+                Status = CorrespondenceStatus.PurgedByRecipient,
+                StatusChanged = DateTimeOffset.UtcNow,
+                StatusText = CorrespondenceStatus.PurgedByRecipient.ToString()
+            };
+        }
+        else
+        {
+            return Errors.CantPurgeCorrespondence;
+        }
+
         await _eventBus.Publish(AltinnEventType.CorrespondencePurged, correspondence.ResourceId, correspondenceId.ToString(), "correspondence", correspondence.Sender, cancellationToken);
         await _correspondenceStatusRepository.AddCorrespondenceStatus(newStatus, cancellationToken);
         await CheckAndPurgeAttachments(correspondenceId, cancellationToken);

--- a/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
@@ -25,7 +25,7 @@ public class UploadAttachmentHandler(IAltinnAuthorizationService altinnAuthoriza
         {
             return Errors.AttachmentNotFound;
         }
-        var hasAccess = await _altinnAuthorizationService.CheckUserAccess(attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Open }, cancellationToken);
+        var hasAccess = await _altinnAuthorizationService.CheckUserAccess(attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Send }, cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -16,6 +16,7 @@ namespace Altinn.Correspondence.Core.Repositories
             DateTimeOffset? from,
             DateTimeOffset? to,
             CorrespondenceStatus? status,
+            string orgNo,
             CancellationToken cancellationToken);
 
         Task<CorrespondenceEntity?> GetCorrespondenceById(

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -5,18 +5,27 @@ namespace Altinn.Correspondence.Persistence.Helpers
 {
     public static class QueryExtensions
     {
-
-        public static IQueryable<CorrespondenceEntity> WithValidStatuses(this IQueryable<CorrespondenceEntity> query, CorrespondenceStatus? status)
+        public static IQueryable<CorrespondenceEntity> WithValidStatuses(this IQueryable<CorrespondenceEntity> query, CorrespondenceStatus? status, string orgNo)
         {
-            var blacklistedStatues = new List<CorrespondenceStatus?>
+            var blacklistedStatuesSender = new List<CorrespondenceStatus?>
             {
+                CorrespondenceStatus.Archived,
+                CorrespondenceStatus.PurgedByAltinn,
+                CorrespondenceStatus.PurgedByRecipient
+            };
+            var blacklistedStatuesRecipient = new List<CorrespondenceStatus?>
+            {
+                CorrespondenceStatus.Initialized,
+                CorrespondenceStatus.ReadyForPublish,
                 CorrespondenceStatus.Archived,
                 CorrespondenceStatus.PurgedByAltinn,
                 CorrespondenceStatus.PurgedByRecipient
             };
             if (status == null) // No status specified, return all except blacklisted
             {
-                return query.Where(correspondence => !blacklistedStatues.Contains(correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status));
+                return query.Where(correspondence => correspondence.Recipient.Contains(orgNo) ? // If org is a recipient
+                !blacklistedStatuesRecipient.Contains(correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status) : 
+                !blacklistedStatuesSender.Contains(correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status));
             }
             else
             {

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -30,6 +30,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
             DateTimeOffset? from,
             DateTimeOffset? to,
             CorrespondenceStatus? status,
+            string orgNo,
             CancellationToken cancellationToken)
         {
             var correspondences = _context.Correspondences
@@ -37,7 +38,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .Where(c => from == null || c.VisibleFrom > from)   // From date filter
                 .Where(c => to == null || c.VisibleFrom < to)       // To date filter
                 .OrderByDescending(c => c.VisibleFrom)              // Sort by visibleFrom
-                .WithValidStatuses(status)                          // Filter by status
+                .WithValidStatuses(status, orgNo)                   // Filter by status
                 .Select(c => c.Id);
 
             var totalItems = await correspondences.CountAsync(cancellationToken);


### PR DESCRIPTION
Legge til autorisasjonsregler for attachment og correspondence endepunkt.

## Description
Lik som i Broker er det blitt lagt inn autoriseringspolicies for Sender og Recipient på hvert av endepunktene. Noen av disse endepunktene er tilgjengelige for begge to. 
**OBS**: Etter denne merges inn trenger man ny token med scopes `altinn:correspondence.write` og `altinn:correspondence.read` for sender og receiver hhv. 

Endringer i applikasjonslogikk som er gjort:
- correspondence/purge blir PurgedByRecipient dersom mottaker gjorde kallet etter den har blitt publisert og PurgedByAltinn dersom avsender gjorde kallet før den var publisert. Ellers returnerer en feil
- correspondences returnerer kun de som har blitt publisert dersom det er mottaker som gjorde kallet. 

## Related Issue(s)
- #246
- #252 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
