### PR TITLE
Do not update "Status" with "Fetched", only add Fetched to StatusHistory

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -491,7 +491,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         Assert.Equal(response.Status, CorrespondenceStatusExt.Initialized);
     }
     [Fact]
-    public async Task GetCorrespondenceDetails_AsReceiver_UpdatesStatusToFetched()
+    public async Task GetCorrespondenceDetails_AsReceiver_AddsFetchedStatusToHistory()
     {
         // Arrange
         var initialCorrespondence = InitializeCorrespondenceFactory.BasicCorrespondenceWithoutAttachments();
@@ -506,8 +506,9 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
 
         // Assert
         var response = await getCorrespondenceDetailsResponse.Content.ReadFromJsonAsync<CorrespondenceDetailsExt>(_responseSerializerOptions);
+        var expectedFetchedStatuses = 1;
+        Assert.Equal(response.StatusHistory.Where(s => s.Status == CorrespondenceStatusExt.Fetched).Count(), expectedFetchedStatuses);
         Assert.Contains(response.StatusHistory, item => item.Status == CorrespondenceStatusExt.Published);
-        Assert.Contains(response.StatusHistory, item => item.Status == CorrespondenceStatusExt.Fetched);
         Assert.Equal(response.Status, CorrespondenceStatusExt.Published);
     }
 

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -45,7 +45,7 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
         var userOrgNo = _getCorrespondenceHelper.GetUserID();
         bool isRecipient = correspondence.Recipient == userOrgNo;
 
-        if (isRecipient && latestStatus.Status >= CorrespondenceStatus.Published) // etter publish, men før purged
+        if (isRecipient && latestStatus.Status >= CorrespondenceStatus.Published)
         {
             await _correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
             {

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -33,7 +33,10 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
         {
             return Errors.NoAccessToResource;
         }
-        var latestStatus = correspondence.Statuses?.OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+        var latestStatus = correspondence.Statuses?
+            .OrderByDescending(s => s.StatusChanged)
+            .SkipWhile(s => s.Status == CorrespondenceStatus.Fetched)
+            .FirstOrDefault();
         if (latestStatus == null)
         {
             return Errors.CorrespondenceNotFound;
@@ -42,21 +45,14 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
         var userOrgNo = _getCorrespondenceHelper.GetUserID();
         bool isRecipient = correspondence.Recipient == userOrgNo;
 
-        if (isRecipient && latestStatus.Status == CorrespondenceStatus.Published)
+        if (isRecipient && latestStatus.Status >= CorrespondenceStatus.Published) // etter publish, men før purged
         {
-            latestStatus = new CorrespondenceStatusEntity{
+            await _correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
+            {
                 CorrespondenceId = correspondence.Id,
                 Status = CorrespondenceStatus.Fetched,
                 StatusText = CorrespondenceStatus.Fetched.ToString(),
                 StatusChanged = DateTime.Now
-            };
-        
-            await _correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
-            {
-                CorrespondenceId = correspondence.Id,
-                Status = latestStatus.Status,
-                StatusText = latestStatus.StatusText,
-                StatusChanged = latestStatus.StatusChanged
             }, cancellationToken);
         }
 


### PR DESCRIPTION
GetCorrespondenceOverview and GetCorrespondenceDetails only adds Fetched to StatusHistory, not change current Status on Correspondence object

## Description
Previously the `GetCorrespondenceOverview` and `GetCorrespondenceDetails` endpoints would add Fetched to the StatusHistory, **_and_** update the current status to Fetched. We do not Fetched to ever be a status for a correspondence, but rather just keep an overview of whether or not a correspondence has been fetched by the recipient. This is reflected in StatusHistory, which is now populated with a `Fetched` status every time the recipient calls the Get overview and details endpoint. This entry also contains the timestamp of when it was fetched.

## Related Issue(s)
- #253

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
