### PR TITLE
Fix/download before publish

### DIFF
--- a/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
@@ -291,7 +291,7 @@ public class AttachmentControllerTests : IClassFixture<CustomWebApplicationFacto
         var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
         payload.Recipients = [payload.Recipients[0]];
         payload.Correspondence.Sender = _userId;
-        payload.Correspondence.VisibleFrom = DateTimeOffset.UtcNow.AddSeconds(10);
+        payload.Correspondence.VisibleFrom = DateTimeOffset.UtcNow.AddSeconds(2);
         var initializeCorrespondenceResponse = await (await uploadFailsClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions)).Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
         var correspondenceId = initializeCorrespondenceResponse.CorrespondenceIds.FirstOrDefault();
         var attachmentId = initializeCorrespondenceResponse.AttachmentIds.FirstOrDefault();

--- a/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Tests.Factories;
+using Altinn.Correspondence.Tests.Factories;
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;

--- a/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/AttachmentControllerTests.cs
@@ -15,6 +15,7 @@ public class AttachmentControllerTests : IClassFixture<CustomWebApplicationFacto
     private readonly CustomWebApplicationFactory _factory;
     private readonly HttpClient _client;
     private readonly JsonSerializerOptions _responseSerializerOptions;
+    private readonly string _userId = "0192:991825827";
 
     public AttachmentControllerTests(CustomWebApplicationFactory factory)
     {
@@ -140,6 +141,7 @@ public class AttachmentControllerTests : IClassFixture<CustomWebApplicationFacto
         var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
         payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
         payload.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
+        payload.Recipients = [_userId];
         var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
         var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
 

--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -610,6 +610,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
         payload.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
         payload.Recipients = [_userId]; // Change recipient to match HttpContext.User
+        payload.Correspondence.Sender = "0192:999999999";
 
         // Act
         var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
@@ -622,7 +623,32 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         Assert.NotNull(data);
     }
     [Fact]
-    public async Task DownloadAttachment_WhenNotARecipient_Fails()
+    public async Task DownloadAttachment_AsSender_Succeeds()
+    {
+        // Arrange
+        var attachment = InitializeAttachmentFactory.BasicAttachment();
+        var initializeResponse = await _client.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);
+
+        var attachmentId = await initializeResponse.Content.ReadAsStringAsync();
+        var uploadedAttachment = await (await UploadAttachment(attachmentId, new ByteArrayContent([1, 2, 3, 4]))).Content.ReadFromJsonAsync<AttachmentOverviewExt>(_responseSerializerOptions);
+
+        var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
+        payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
+        payload.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
+        payload.Correspondence.Sender = _userId; // Change sender to match HttpContext.User
+        payload.Recipients = ["0192:999999999"];
+        // Act
+        var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+        var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
+        var downloadResponse = await _client.GetAsync($"correspondence/api/v1/correspondence/{response?.CorrespondenceIds.FirstOrDefault()}/attachment/{attachmentId}/download");
+        var data = downloadResponse.Content.ReadAsByteArrayAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
+        Assert.NotNull(data);
+    }
+    [Fact]
+    public async Task DownloadAttachment_WhenNotARecipientOrSender_Fails()
     {
         // Arrange
         var attachment = InitializeAttachmentFactory.BasicAttachment();
@@ -637,6 +663,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
         payload.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
         payload.Recipients = ["0192:999999999"]; // Change recipient to invalid org
+        payload.Correspondence.Sender = "0192:999999999";
 
         // Act
         var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);

--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -596,6 +596,82 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         initializeCorrespondenceResponse.EnsureSuccessStatusCode();
         Assert.Equal(uploadedAttachment.AttachmentId.ToString(), response?.AttachmentIds?.FirstOrDefault().ToString());
     }
+    [Fact]
+    public async Task DownloadAttachment()
+    {
+        // Arrange
+        var attachment = InitializeAttachmentFactory.BasicAttachment();
+        var initializeResponse = await _client.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);
+
+        var attachmentId = await initializeResponse.Content.ReadAsStringAsync();
+        var uploadedAttachment = await (await UploadAttachment(attachmentId, new ByteArrayContent([1, 2, 3, 4]))).Content.ReadFromJsonAsync<AttachmentOverviewExt>(_responseSerializerOptions);
+
+        var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
+        payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
+        payload.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
+        payload.Recipients = [_userId]; // Change sender to match HttpContext.User
+
+        // Act
+        var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+        var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
+        var downloadResponse = await _client.GetAsync($"correspondence/api/v1/correspondence/{response?.CorrespondenceIds.FirstOrDefault()}/attachment/{attachmentId}/download");
+        var data = downloadResponse.Content.ReadAsByteArrayAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
+        Assert.NotNull(data);
+    }
+    [Fact]
+    public async Task DownloadAttachment_AsSender_Fails() // The endpoint requires a recipient token, this just ensures you have to be a recipient as well
+    {
+        // Arrange
+        var attachment = InitializeAttachmentFactory.BasicAttachment();
+        var initializeResponse = await _client.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);
+
+        var attachmentId = await initializeResponse.Content.ReadAsStringAsync();
+        var originalAttachmentData = new byte[] { 1, 2, 3, 4 };
+        var content = new ByteArrayContent(originalAttachmentData);
+        var uploadedAttachment = await (await UploadAttachment(attachmentId, content)).Content.ReadFromJsonAsync<AttachmentOverviewExt>(_responseSerializerOptions);
+
+        var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
+        payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
+        payload.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
+        payload.Correspondence.Sender = _userId; // Change sender to match HttpContext.User
+
+        // Act
+        var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+        var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
+        var downloadResponse = await _client.GetAsync($"correspondence/api/v1/correspondence/{response?.CorrespondenceIds.FirstOrDefault()}/attachment/{attachmentId}/download");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, downloadResponse.StatusCode);
+    }
+    [Fact]
+    public async Task DownloadAttachment_AsRecipient_WhenCorrespondenceUnavailable_Fails()
+    {
+        // Arrange
+        var attachment = InitializeAttachmentFactory.BasicAttachment();
+        var initializeResponse = await _client.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);
+        initializeResponse.EnsureSuccessStatusCode();
+
+        var attachmentId = await initializeResponse.Content.ReadAsStringAsync();
+        var originalAttachmentData = new byte[] { 1, 2, 3, 4 };
+        var content = new ByteArrayContent(originalAttachmentData);
+        var uploadedAttachment = await (await UploadAttachment(attachmentId, content)).Content.ReadFromJsonAsync<AttachmentOverviewExt>(_responseSerializerOptions);
+
+        var payload = InitializeCorrespondenceFactory.BasicCorrespondences();
+        payload.ExistingAttachments = new List<Guid> { uploadedAttachment.AttachmentId };
+        payload.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>();
+        payload.Correspondence.Sender = _userId; // Change sender to match HttpContext.User
+
+        // Act
+        var initializeCorrespondenceResponse = await _client.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+        var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>();
+        var downloadResponse = await _client.GetAsync($"correspondence/api/v1/correspondence/{response?.CorrespondenceIds.FirstOrDefault()}/attachment/{attachmentId}/download");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, downloadResponse.StatusCode);
+    }
 
     [Fact]
     public async Task Delete_Initialized_Correspondence_AsSender_Gives_OK()

--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Tests.Factories;
+using Altinn.Correspondence.Tests.Factories;
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application.GetCorrespondences;

--- a/Test/Altinn.Correspondence.Tests/Factories/InitializeAttachmentFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/InitializeAttachmentFactory.cs
@@ -2,7 +2,7 @@ using System.Text;
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.Tests.Helpers;
 
-namespace Altinn.Correspondece.Tests.Factories;
+namespace Altinn.Correspondence.Tests.Factories;
 internal static class InitializeAttachmentFactory
 {
     internal static InitializeAttachmentExt BasicAttachment() => new InitializeAttachmentExt()

--- a/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
@@ -1,7 +1,7 @@
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 
-namespace Altinn.Correspondece.Tests.Factories;
+namespace Altinn.Correspondence.Tests.Factories;
 internal static class InitializeCorrespondenceFactory
 {
     internal static InitializeCorrespondencesExt BasicCorrespondences(string? url = null) => new InitializeCorrespondencesExt()

--- a/Test/Altinn.Correspondence.Tests/Helpers/UploadFailsWebApplicationFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/UploadFailsWebApplicationFactory.cs
@@ -30,7 +30,7 @@ public class UploadFailsWebApplicationFactory : WebApplicationFactory<Program>
             var storageMock = new Mock<IStorageRepository>();
             storageMock.Setup(x => x.UploadAttachment(It.IsAny<AttachmentEntity>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>())).Callback(() =>
             {
-                Thread.Sleep(15000);
+                Thread.Sleep(5000);
             });
             services.AddScoped(_ => storageMock.Object);
         });

--- a/Test/Altinn.Correspondence.Tests/MalwareScanResultControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/MalwareScanResultControllerTests.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Net.Http.Headers;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.API.Models;
-using Altinn.Correspondece.Tests.Factories;
+using Altinn.Correspondence.Tests.Factories;
 
 namespace Altinn.Correspondence.Tests;
 

--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -487,7 +487,7 @@
 											"name": "upload",
 											"item": [
 												{
-													"name": "Upload Correspondece",
+													"name": "Upload correspondence",
 													"request": {
 														"auth": {
 															"type": "bearer",

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -325,7 +325,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <returns></returns>
         [HttpGet]
         [Route("{correspondenceId}/attachment/{attachmentId}/download")]
-        [Authorize(Policy = AuthorizationConstants.Recipient)]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         public async Task<ActionResult> DownloadAttachmentData(
             Guid correspondenceId,
             Guid attachmentId,

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Core.Models;

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -38,7 +38,7 @@ public static class DependencyInjection
 
         services.AddScoped<InitializeCorrespondenceHelper>();
         services.AddScoped<UploadHelper>();
-        services.AddScoped<GetCorrespondenceHelper>();
+        services.AddScoped<UserClaimsHelper>();
         services.AddScoped<PublishCorrespondenceHandler>();
     }
 }

--- a/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;

--- a/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
@@ -42,13 +42,14 @@ public class DownloadAttachmentHandler : IHandler<DownloadAttachmentRequest, Str
         {
             return Errors.NoAccessToResource;
         }
-        var userId = _userClaimsHelper.GetUserID();
-        if (userId != correspondence.Recipient && userId != correspondence.Sender)
+        bool isRecipient = _userClaimsHelper.GetUserID() == correspondence.Recipient;
+        bool isSender = _userClaimsHelper.GetUserID() == correspondence.Sender;
+        if (!isRecipient && !isSender)
         {
             return Errors.CorrespondenceNotFound;
         }
         var latestStatus = await _correspondenceStatusRepository.GetLatestStatusByCorrespondenceId(request.CorrespondenceId, cancellationToken);
-        if (!latestStatus.Status.IsAvailableForRecipient())
+        if (isRecipient && !latestStatus.Status.IsAvailableForRecipient())
         {
             return Errors.CorrespondenceNotFound;
         }

--- a/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
@@ -42,8 +42,8 @@ public class DownloadAttachmentHandler : IHandler<DownloadAttachmentRequest, Str
         {
             return Errors.NoAccessToResource;
         }
-        bool isRecipient = _userClaimsHelper.GetUserID() == correspondence.Recipient;
-        if (!isRecipient)
+        var userId = _userClaimsHelper.GetUserID();
+        if (userId != correspondence.Recipient && userId != correspondence.Sender)
         {
             return Errors.CorrespondenceNotFound;
         }

--- a/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Correspondence.Core.Models.Enums;
+﻿using System.Runtime.CompilerServices;
+using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using OneOf;
 
@@ -6,19 +8,30 @@ namespace Altinn.Correspondence.Application.DownloadAttachment;
 
 public class DownloadAttachmentHandler : IHandler<DownloadAttachmentRequest, Stream>
 {
+    private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
+    private readonly ICorrespondenceRepository _correspondenceRepository;
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly IStorageRepository _storageRepository;
     private readonly IAttachmentRepository _attachmentRepository;
+    private readonly UserClaimsHelper _userClaimsHelper;
 
-    public DownloadAttachmentHandler(IAltinnAuthorizationService altinnAuthorizationService, IStorageRepository storageRepository, IAttachmentRepository attachmentRepository)
+    public DownloadAttachmentHandler(IAltinnAuthorizationService altinnAuthorizationService, IStorageRepository storageRepository, IAttachmentRepository attachmentRepository, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, UserClaimsHelper userClaimsHelper)
     {
+        _correspondenceRepository = correspondenceRepository;
+        _correspondenceStatusRepository = correspondenceStatusRepository;
         _altinnAuthorizationService = altinnAuthorizationService;
         _storageRepository = storageRepository;
         _attachmentRepository = attachmentRepository;
+        _userClaimsHelper = userClaimsHelper;
     }
 
     public async Task<OneOf<Stream, Error>> Process(DownloadAttachmentRequest request, CancellationToken cancellationToken)
     {
+        var correspondence = await _correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, false, false, cancellationToken);
+        if (correspondence is null)
+        {
+            return Errors.CorrespondenceNotFound;
+        }
         var attachment = await _attachmentRepository.GetAttachmentByCorrespondenceIdAndAttachmentId(request.CorrespondenceId, request.AttachmentId, cancellationToken);
         if (attachment is null)
         {
@@ -29,7 +42,16 @@ public class DownloadAttachmentHandler : IHandler<DownloadAttachmentRequest, Str
         {
             return Errors.NoAccessToResource;
         }
-
+        bool isRecipient = _userClaimsHelper.GetUserID() == correspondence.Recipient;
+        if (!isRecipient)
+        {
+            return Errors.CorrespondenceNotFound;
+        }
+        var latestStatus = await _correspondenceStatusRepository.GetLatestStatusByCorrespondenceId(request.CorrespondenceId, cancellationToken);
+        if (!latestStatus.Status.IsAvailableForRecipient())
+        {
+            return Errors.CorrespondenceNotFound;
+        }
         var attachmentStream = await _storageRepository.DownloadAttachment((Guid)attachment.Id, cancellationToken);
         return attachmentStream;
     }

--- a/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAttachment/DownloadAttachmentHandler.cs
@@ -28,7 +28,7 @@ public class DownloadAttachmentHandler : IHandler<DownloadAttachmentRequest, Str
 
     public async Task<OneOf<Stream, Error>> Process(DownloadAttachmentRequest request, CancellationToken cancellationToken)
     {
-        var correspondence = await _correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, false, false, cancellationToken);
+        var correspondence = await _correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, cancellationToken);
         if (correspondence is null)
         {
             return Errors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsHandler.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using OneOf;

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using OneOf;

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
@@ -9,9 +9,9 @@ public class GetCorrespondencesHandler : IHandler<GetCorrespondencesRequest, Get
 {
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly ICorrespondenceRepository _correspondenceRepository;
-    private readonly GetCorrespondenceHelper _getCorrespondenceHelper;
+    private readonly UserClaimsHelper _getCorrespondenceHelper;
 
-    public GetCorrespondencesHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, GetCorrespondenceHelper getCorrespondenceHelper)
+    public GetCorrespondencesHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, UserClaimsHelper getCorrespondenceHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _correspondenceRepository = correspondenceRepository;

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
@@ -9,13 +9,13 @@ public class GetCorrespondencesHandler : IHandler<GetCorrespondencesRequest, Get
 {
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly ICorrespondenceRepository _correspondenceRepository;
-    private readonly UserClaimsHelper _getCorrespondenceHelper;
+    private readonly UserClaimsHelper _userClaimsHelper;
 
-    public GetCorrespondencesHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, UserClaimsHelper getCorrespondenceHelper)
+    public GetCorrespondencesHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, UserClaimsHelper userClaimsHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _correspondenceRepository = correspondenceRepository;
-        _getCorrespondenceHelper = getCorrespondenceHelper;
+        _userClaimsHelper = userClaimsHelper;
     }
 
     public async Task<OneOf<GetCorrespondencesResponse, Error>> Process(GetCorrespondencesRequest request, CancellationToken cancellationToken)
@@ -34,7 +34,7 @@ public class GetCorrespondencesHandler : IHandler<GetCorrespondencesRequest, Get
         var limit = request.Limit == 0 ? 50 : request.Limit;
         DateTimeOffset? to = request.To != null ? ((DateTimeOffset)request.To).ToUniversalTime() : null;
         DateTimeOffset? from = request.From != null ? ((DateTimeOffset)request.From).ToUniversalTime() : null;
-        string? orgNo = _getCorrespondenceHelper.GetUserID();
+        string? orgNo = _userClaimsHelper.GetUserID();
         if (orgNo is null)
         {
             return Errors.CouldNotFindOrgNo;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -11,14 +11,14 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly ICorrespondenceRepository _correspondenceRepository;
     private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
-    private readonly UserClaimsHelper _getCorrespondenceHelper;
+    private readonly UserClaimsHelper _userClaimsHelper;
 
-    public GetCorrespondenceDetailsHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, UserClaimsHelper getCorrespondenceHelper)
+    public GetCorrespondenceDetailsHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, UserClaimsHelper userClaimsHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _correspondenceRepository = correspondenceRepository;
         _correspondenceStatusRepository = correspondenceStatusRepository;
-        _getCorrespondenceHelper = getCorrespondenceHelper;
+        _userClaimsHelper = userClaimsHelper;
     }
 
     public async Task<OneOf<GetCorrespondenceDetailsResponse, Error>> Process(Guid correspondenceId, CancellationToken cancellationToken)
@@ -42,7 +42,7 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
             return Errors.CorrespondenceNotFound;
         }
 
-        var userOrgNo = _getCorrespondenceHelper.GetUserID();
+        var userOrgNo = _userClaimsHelper.GetUserID();
         bool isRecipient = correspondence.Recipient == userOrgNo;
 
         if (isRecipient && latestStatus.Status >= CorrespondenceStatus.Published)

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -11,9 +11,9 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly ICorrespondenceRepository _correspondenceRepository;
     private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
-    private readonly GetCorrespondenceHelper _getCorrespondenceHelper;
+    private readonly UserClaimsHelper _getCorrespondenceHelper;
 
-    public GetCorrespondenceDetailsHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, GetCorrespondenceHelper getCorrespondenceHelper)
+    public GetCorrespondenceDetailsHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, UserClaimsHelper getCorrespondenceHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _correspondenceRepository = correspondenceRepository;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -11,14 +11,14 @@ public class GetCorrespondenceOverviewHandler : IHandler<Guid, GetCorrespondence
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly ICorrespondenceRepository _CorrespondenceRepository;
     private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
-    private readonly UserClaimsHelper _getCorrespondenceHelper;
+    private readonly UserClaimsHelper _userClaimsHelper;
 
-    public GetCorrespondenceOverviewHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository CorrespondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, UserClaimsHelper getCorrespondenceHelper)
+    public GetCorrespondenceOverviewHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository CorrespondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, UserClaimsHelper userClaimsHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _CorrespondenceRepository = CorrespondenceRepository;
         _correspondenceStatusRepository = correspondenceStatusRepository;
-        _getCorrespondenceHelper = getCorrespondenceHelper;
+        _userClaimsHelper = userClaimsHelper;
     }
 
     public async Task<OneOf<GetCorrespondenceOverviewResponse, Error>> Process(Guid CorrespondenceId, CancellationToken cancellationToken)
@@ -42,7 +42,7 @@ public class GetCorrespondenceOverviewHandler : IHandler<Guid, GetCorrespondence
             return Errors.CorrespondenceNotFound;
         }
 
-        var userOrgNo = _getCorrespondenceHelper.GetUserID();
+        var userOrgNo = _userClaimsHelper.GetUserID();
         bool isRecipient = correspondence.Recipient == userOrgNo;
 
         if (isRecipient && latestStatus.Status == CorrespondenceStatus.Published)

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -11,9 +11,9 @@ public class GetCorrespondenceOverviewHandler : IHandler<Guid, GetCorrespondence
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly ICorrespondenceRepository _CorrespondenceRepository;
     private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
-    private readonly GetCorrespondenceHelper _getCorrespondenceHelper;
+    private readonly UserClaimsHelper _getCorrespondenceHelper;
 
-    public GetCorrespondenceOverviewHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository CorrespondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, GetCorrespondenceHelper getCorrespondenceHelper)
+    public GetCorrespondenceOverviewHandler(IAltinnAuthorizationService altinnAuthorizationService, ICorrespondenceRepository CorrespondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, UserClaimsHelper getCorrespondenceHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _CorrespondenceRepository = CorrespondenceRepository;

--- a/src/Altinn.Correspondence.Application/Helpers/AttachmentExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/AttachmentExtensions.cs
@@ -1,5 +1,5 @@
 using Altinn.Correspondence.Core.Models;
-namespace Altinn.Correspondece.Application.Helpers;
+namespace Altinn.Correspondence.Application.Helpers;
 public static class AttachmentStatusExtensions
 {
     public static AttachmentStatusEntity? GetLatestStatus(this AttachmentEntity attachment)

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -1,11 +1,11 @@
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
-namespace Altinn.Correspondece.Application.Helpers;
+namespace Altinn.Correspondence.Application.Helpers;
 public static class CorrespondenceStatusExtensions
 {
-    public static CorrespondenceStatusEntity? GetLatestStatus(this CorrespondenceEntity correspondece)
+    public static CorrespondenceStatusEntity? GetLatestStatus(this CorrespondenceEntity correspondence)
     {
-        var statusEntity = correspondece.Statuses
+        var statusEntity = correspondence.Statuses
             .Where(s => s.Status != CorrespondenceStatus.Fetched)
             .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
         return statusEntity;

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceStatusExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceStatusExtensions.cs
@@ -1,0 +1,18 @@
+using Altinn.Correspondence.Core.Models.Enums;
+
+public static class CorrespondenceStatusExtensions
+{
+    public static bool IsPurged(this CorrespondenceStatus correspondenceStatus)
+    {
+        return correspondenceStatus == CorrespondenceStatus.PurgedByRecipient || correspondenceStatus == CorrespondenceStatus.PurgedByAltinn;
+    }
+    public static bool IsAvailableForRecipient(this CorrespondenceStatus correspondenceStatus)
+    {
+        List<CorrespondenceStatus> validStatuses =
+        [
+            CorrespondenceStatus.Published, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
+            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved
+        ];
+        return validStatuses.Contains(correspondenceStatus);
+    }
+}

--- a/src/Altinn.Correspondence.Application/Helpers/UploadHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/UploadHelper.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Application.UploadAttachment;
 using Altinn.Correspondence.Core.Exceptions;
 using Altinn.Correspondence.Core.Models;

--- a/src/Altinn.Correspondence.Application/Helpers/UserClaimsHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/UserClaimsHelper.cs
@@ -3,11 +3,11 @@ using Microsoft.AspNetCore.Http;
 
 namespace Altinn.Correspondence.Application.Helpers
 {
-    public class GetCorrespondenceHelper
+    public class UserClaimsHelper
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public GetCorrespondenceHelper(IHttpContextAccessor httpContextAccessor)
+        public UserClaimsHelper(IHttpContextAccessor httpContextAccessor)
         {
             _httpContextAccessor = httpContextAccessor;
         }

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Correspondece.Application.Helpers;
+﻿using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;

--- a/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Correspondece.Application.Helpers;
+﻿using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -1,5 +1,4 @@
 using Altinn.Correspondence.Application.Helpers;
-using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -17,9 +17,9 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
     private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
     private readonly IStorageRepository _storageRepository;
     private readonly IEventBus _eventBus;
-    private readonly GetCorrespondenceHelper _getCorrespondenceHelper;
+    private readonly UserClaimsHelper _getCorrespondenceHelper;
 
-    public PurgeCorrespondenceHandler(IAltinnAuthorizationService altinnAuthorizationService, IAttachmentRepository attachmentRepository, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, IStorageRepository storageRepository, IAttachmentStatusRepository attachmentStatusRepository, IEventBus eventBus, GetCorrespondenceHelper getCorrespondenceHelper)
+    public PurgeCorrespondenceHandler(IAltinnAuthorizationService altinnAuthorizationService, IAttachmentRepository attachmentRepository, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, IStorageRepository storageRepository, IAttachmentStatusRepository attachmentStatusRepository, IEventBus eventBus, UserClaimsHelper getCorrespondenceHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _attachmentRepository = attachmentRepository;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -17,9 +17,9 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
     private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
     private readonly IStorageRepository _storageRepository;
     private readonly IEventBus _eventBus;
-    private readonly UserClaimsHelper _getCorrespondenceHelper;
+    private readonly UserClaimsHelper _userClaimsHelper;
 
-    public PurgeCorrespondenceHandler(IAltinnAuthorizationService altinnAuthorizationService, IAttachmentRepository attachmentRepository, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, IStorageRepository storageRepository, IAttachmentStatusRepository attachmentStatusRepository, IEventBus eventBus, UserClaimsHelper getCorrespondenceHelper)
+    public PurgeCorrespondenceHandler(IAltinnAuthorizationService altinnAuthorizationService, IAttachmentRepository attachmentRepository, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, IStorageRepository storageRepository, IAttachmentStatusRepository attachmentStatusRepository, IEventBus eventBus, UserClaimsHelper userClaimsHelper)
     {
         _altinnAuthorizationService = altinnAuthorizationService;
         _attachmentRepository = attachmentRepository;
@@ -28,7 +28,7 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
         _storageRepository = storageRepository;
         _attachmentStatusRepository = attachmentStatusRepository;
         _eventBus = eventBus;
-        _getCorrespondenceHelper = getCorrespondenceHelper;
+        _userClaimsHelper = userClaimsHelper;
     }
 
     public async Task<OneOf<Guid, Error>> Process(Guid correspondenceId, CancellationToken cancellationToken)
@@ -46,7 +46,7 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
             return Errors.CorrespondenceAlreadyPurged;
         }
         
-        string orgNo = _getCorrespondenceHelper.GetUserID();
+        string orgNo = _userClaimsHelper.GetUserID();
         if (orgNo is null)
         {
             return Errors.CouldNotFindOrgNo;

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHandler.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;

--- a/src/Altinn.Correspondence.Application/UpdateMarkUnread/UpdateMarkAsUnreadHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateMarkUnread/UpdateMarkAsUnreadHandler.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;

--- a/src/Altinn.Correspondence.Integrations/Hangfire/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Integrations/Hangfire/DependencyInjection.cs
@@ -13,6 +13,6 @@ public static class DependencyInjection
                 c => c.UseConnectionFactory(services.BuildServiceProvider().GetService<IConnectionFactory>())
             )
         );
-        services.AddHangfireServer();
+        services.AddHangfireServer(options => options.SchedulePollingInterval = TimeSpan.FromSeconds(2));
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceStatusRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceStatusRepository.cs
@@ -1,7 +1,5 @@
 using Altinn.Correspondence.Core.Models;
-using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
-using Microsoft.EntityFrameworkCore;
 
 namespace Altinn.Correspondence.Persistence.Repositories
 {

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceStatusRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceStatusRepository.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.Core.Models;
+using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,6 +27,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
         {
             var status = await _context.CorrespondenceStatuses
                 .Where(s => s.CorrespondenceId == CorrespondenceId)
+                .Where(s => s.Status != CorrespondenceStatus.Fetched)
                 .OrderByDescending(s => s.StatusChanged)
                 .FirstAsync(cancellationToken);
 


### PR DESCRIPTION
Ensure download by recipient cannot happen before correspondence is published and not purged

## Description
This PR contains logic which ensures that in order to download attachments for a correspondence. The user either has to be a recipient or a sender of the correspondence. Furthermore, if the user is a recipient, the correspondence has to be published and not purged yet.

Other changes:
- A lot of files are changed because of a typo I found in a namespace.
- `_getCorrespondenceHelper` -> `_userClaimsHelper`

I am planning on adding validation on scopes and tokens, but realized that would cause more changes and decided to take it in another PR. 

## Related Issue(s)
- #247
- #181 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
