### PR TITLE
Feat/get latest status extensionmethod

### DIFF
--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Core.Models;
@@ -19,9 +20,9 @@ internal static class CorrespondenceAttachmentMapper
             Checksum = attachment.Attachment.Checksum,
             DataLocationType = (AttachmentDataLocationTypeExt)attachment.Attachment.DataLocationType,
             RestrictionName = attachment.Attachment.RestrictionName,
-            Status = (AttachmentStatusExt)attachment.Attachment.Statuses.OrderByDescending(s => s.StatusChanged).FirstOrDefault()!.Status,
-            StatusText = attachment.Attachment.Statuses.OrderByDescending(s => s.StatusChanged).FirstOrDefault()!.StatusText,
-            StatusChanged = attachment.Attachment.Statuses.OrderByDescending(s => s.StatusChanged).FirstOrDefault()!.StatusChanged,
+            Status = (AttachmentStatusExt)attachment.Attachment.GetLatestStatus()!.Status,
+            StatusText = attachment.Attachment.GetLatestStatus()!.StatusText,
+            StatusChanged = attachment.Attachment.GetLatestStatus()!.StatusChanged,
             Created = attachment.Created,
             ExpirationTime = attachment.ExpirationTime
         };

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -42,4 +42,5 @@ public static class Errors
     public static Error CantPurgeCorrespondence = new Error(34, "You must be a sender or recipient in order to purge correspondence", HttpStatusCode.BadRequest);
     public static Error CantUploadToNonInitializedCorrespondence = new Error(35, "Cannot upload attachment to a correspondence that is not initialized", HttpStatusCode.BadRequest);
     public static Error CorrespondenceFailedDuringUpload = new Error(36, "Correspondence status failed during uploading of attachment", HttpStatusCode.BadRequest);
+    public static Error LatestStatusIsNull = new Error(37, "Could not retrieve latest status for correspondence", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsHandler.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using OneOf;
@@ -30,7 +31,7 @@ public class GetAttachmentDetailsHandler : IHandler<Guid, GetAttachmentDetailsRe
             return Errors.NoAccessToResource;
         }
         var correspondenceIds = await _correspondenceRepository.GetCorrespondenceIdsByAttachmentId(attachmentId, cancellationToken);
-        var attachmentStatus = attachment.Statuses.OrderByDescending(s => s.StatusChanged).First();
+        var attachmentStatus = attachment.GetLatestStatus();
 
         var response = new GetAttachmentDetailsResponse
         {

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using OneOf;
@@ -31,7 +32,7 @@ public class GetAttachmentOverviewHandler : IHandler<Guid, GetAttachmentOverview
         {
             return Errors.NoAccessToResource;
         }
-        var attachmentStatus = await _attachmentStatusRepository.GetLatestStatusByAttachmentId(attachmentId, cancellationToken);
+        var attachmentStatus = attachment.GetLatestStatus();
         var correspondenceIds = await _correspondenceRepository.GetCorrespondenceIdsByAttachmentId(attachmentId, cancellationToken);
 
         var response = new GetAttachmentOverviewResponse

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
@@ -22,7 +22,7 @@ public class GetAttachmentOverviewHandler : IHandler<Guid, GetAttachmentOverview
 
     public async Task<OneOf<GetAttachmentOverviewResponse, Error>> Process(Guid attachmentId, CancellationToken cancellationToken)
     {
-        var attachment = await _attachmentRepository.GetAttachmentById(attachmentId, false, cancellationToken);
+        var attachment = await _attachmentRepository.GetAttachmentById(attachmentId, true, cancellationToken);
         if (attachment == null)
         {
             return Errors.AttachmentNotFound;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
@@ -33,10 +34,7 @@ public class GetCorrespondenceDetailsHandler : IHandler<Guid, GetCorrespondenceD
         {
             return Errors.NoAccessToResource;
         }
-        var latestStatus = correspondence.Statuses?
-            .OrderByDescending(s => s.StatusChanged)
-            .SkipWhile(s => s.Status == CorrespondenceStatus.Fetched)
-            .FirstOrDefault();
+        var latestStatus = correspondence.GetLatestStatus();
         if (latestStatus == null)
         {
             return Errors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
@@ -33,10 +34,7 @@ public class GetCorrespondenceOverviewHandler : IHandler<Guid, GetCorrespondence
         {
             return Errors.NoAccessToResource;
         }
-        var latestStatus = correspondence.Statuses?
-            .OrderByDescending(s => s.StatusChanged)
-            .SkipWhile(s => s.Status == CorrespondenceStatus.Fetched)
-            .FirstOrDefault();
+        var latestStatus = correspondence.GetLatestStatus();
         if (latestStatus == null)
         {
             return Errors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/Helpers/AttachmentExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/AttachmentExtensions.cs
@@ -2,9 +2,9 @@ using Altinn.Correspondence.Core.Models;
 namespace Altinn.Correspondece.Application.Helpers;
 public static class AttachmentStatusExtensions
 {
-    public static AttachmentStatusEntity? GetLatestStatus(this AttachmentEntity correspondece)
+    public static AttachmentStatusEntity? GetLatestStatus(this AttachmentEntity attachment)
     {
-        var statusEntity = correspondece.Statuses
+        var statusEntity = attachment.Statuses
             .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
         return statusEntity;
     }

--- a/src/Altinn.Correspondence.Application/Helpers/AttachmentExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/AttachmentExtensions.cs
@@ -1,0 +1,11 @@
+using Altinn.Correspondence.Core.Models;
+namespace Altinn.Correspondece.Application.Helpers;
+public static class AttachmentStatusExtensions
+{
+    public static AttachmentStatusEntity? GetLatestStatus(this AttachmentEntity correspondece)
+    {
+        var statusEntity = correspondece.Statuses
+            .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+        return statusEntity;
+    }
+}

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -1,0 +1,26 @@
+using Altinn.Correspondence.Core.Models;
+using Altinn.Correspondence.Core.Models.Enums;
+namespace Altinn.Correspondece.Application.Helpers;
+public static class CorrespondenceStatusExtensions
+{
+    public static CorrespondenceStatusEntity? GetLatestStatus(this CorrespondenceEntity correspondece)
+    {
+        var statusEntity = correspondece.Statuses
+            .Where(s => s.Status != CorrespondenceStatus.Fetched)
+            .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+        return statusEntity;
+    }
+    public static bool IsPurged(this CorrespondenceStatus correspondenceStatus)
+    {
+        return correspondenceStatus == CorrespondenceStatus.PurgedByRecipient || correspondenceStatus == CorrespondenceStatus.PurgedByAltinn;
+    }
+    public static bool IsAvailableForRecipient(this CorrespondenceStatus correspondenceStatus)
+    {
+        List<CorrespondenceStatus> validStatuses =
+        [
+            CorrespondenceStatus.Published, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
+            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved
+        ];
+        return validStatuses.Contains(correspondenceStatus);
+    }
+}

--- a/src/Altinn.Correspondence.Application/Helpers/UploadHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/UploadHelper.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.Application.UploadAttachment;
 using Altinn.Correspondence.Core.Exceptions;
 using Altinn.Correspondence.Core.Models;
@@ -146,7 +147,7 @@ namespace Altinn.Correspondence.Application.Helpers
             var correspondences = await _correspondenceRepository.GetCorrespondencesByAttachmentId(attachmentId, true);
             foreach (var correspondence in correspondences ?? [])
             {
-                var latestStatus = correspondence.Statuses.OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+                var latestStatus = correspondence.GetLatestStatus();
                 if (latestStatus?.Status == CorrespondenceStatus.Initialized) continue;
                 return Errors.CantUploadToNonInitializedCorrespondence;
             }

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Correspondence.Core.Models;
+﻿using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
@@ -38,11 +39,11 @@ public class PublishCorrespondenceHandler : IHandler<Guid, Task>
         {
             errorMessage = "Correspondence " + correspondenceId + " not found when publishing";
         }
-        else if (correspondence.Statuses.OrderByDescending(s => s.StatusChanged).First().Status != CorrespondenceStatus.ReadyForPublish)
+        else if (correspondence.GetLatestStatus()?.Status != CorrespondenceStatus.ReadyForPublish)
         {
             errorMessage = $"Correspondence {correspondenceId} not ready for publish";
         }
-        else if (correspondence.Content == null || correspondence.Content.Attachments.Any(a => a.Attachment?.Statuses.OrderByDescending(s => s.StatusChanged).First().Status != AttachmentStatus.Published))
+        else if (correspondence.Content == null || correspondence.Content.Attachments.Any(a => a.Attachment?.GetLatestStatus()?.Status != AttachmentStatus.Published))
         {
             errorMessage = $"Correspondence {correspondenceId} has attachments not published";
         }

--- a/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
@@ -40,9 +40,8 @@ public class PurgeAttachmentHandler(IAltinnAuthorizationService altinnAuthorizat
             .All(correspondence =>
             {
                 var latestStatus = correspondence.GetLatestStatus();
-
-                return latestStatus.Status == CorrespondenceStatus.PurgedByRecipient ||
-                       latestStatus.Status == CorrespondenceStatus.PurgedByAltinn;
+                if (latestStatus is null) return false;
+                return latestStatus.Status.IsPurged();
             });
         if (correspondences.Count == 0 || isCorrespondencePurged)
 

--- a/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Correspondence.Core.Models;
+﻿using Altinn.Correspondece.Application.Helpers;
+using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
@@ -38,12 +39,10 @@ public class PurgeAttachmentHandler(IAltinnAuthorizationService altinnAuthorizat
         bool isCorrespondencePurged = correspondences
             .All(correspondence =>
             {
-                var latestStatus = correspondence.Statuses
-                    .OrderByDescending(status => status.StatusChanged)
-                    .First().Status;
+                var latestStatus = correspondence.GetLatestStatus();
 
-                return latestStatus == CorrespondenceStatus.PurgedByRecipient ||
-                       latestStatus == CorrespondenceStatus.PurgedByAltinn;
+                return latestStatus.Status == CorrespondenceStatus.PurgedByRecipient ||
+                       latestStatus.Status == CorrespondenceStatus.PurgedByAltinn;
             });
         if (correspondences.Count == 0 || isCorrespondencePurged)
 

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
@@ -52,7 +53,7 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
             return Errors.CouldNotFindOrgNo;
         }
 
-        var latestStatus = correspondence.Statuses?.OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+        var latestStatus = correspondence.GetLatestStatus();
         if (latestStatus == null)
         {
             return Errors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -42,7 +42,7 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
             return Errors.NoAccessToResource;
         }
 
-        if (correspondence.Statuses.Any(status => status.Status == CorrespondenceStatus.PurgedByRecipient || status.Status == CorrespondenceStatus.PurgedByAltinn))
+        if (correspondence.Statuses.Any(status => status.Status.IsPurged()))
         {
             return Errors.CorrespondenceAlreadyPurged;
         }

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHandler.cs
@@ -36,11 +36,15 @@ public class UpdateCorrespondenceStatusHandler : IHandler<UpdateCorrespondenceSt
             return Errors.NoAccessToResource;
         }
         var currentStatus = correspondence.GetLatestStatus();
-        if ((request.Status == CorrespondenceStatus.Confirmed || request.Status == CorrespondenceStatus.Read) && currentStatus?.Status < CorrespondenceStatus.Published)
+        if (currentStatus is null)
+        {
+            return Errors.LatestStatusIsNull;
+        }
+        if ((request.Status == CorrespondenceStatus.Confirmed || request.Status == CorrespondenceStatus.Read) && currentStatus!.Status < CorrespondenceStatus.Published)
         {
             return Errors.CorrespondenceNotPublished;
         }
-        if (currentStatus?.Status == CorrespondenceStatus.PurgedByRecipient || currentStatus?.Status == CorrespondenceStatus.PurgedByAltinn)
+        if (currentStatus!.Status.IsPurged())
         {
             return Errors.CorrespondencePurged;
         }

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHandler.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
@@ -34,7 +35,7 @@ public class UpdateCorrespondenceStatusHandler : IHandler<UpdateCorrespondenceSt
         {
             return Errors.NoAccessToResource;
         }
-        var currentStatus = correspondence.Statuses.OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+        var currentStatus = correspondence.GetLatestStatus();
         if ((request.Status == CorrespondenceStatus.Confirmed || request.Status == CorrespondenceStatus.Read) && currentStatus?.Status < CorrespondenceStatus.Published)
         {
             return Errors.CorrespondenceNotPublished;

--- a/src/Altinn.Correspondence.Application/UpdateMarkUnread/UpdateMarkAsUnreadHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateMarkUnread/UpdateMarkAsUnreadHandler.cs
@@ -32,7 +32,11 @@ public class UpdateMarkAsUnreadHandler : IHandler<Guid, Guid>
         {
             return Errors.CorrespondenceHasNotBeenRead;
         }
-        if (currentStatus?.Status == CorrespondenceStatus.PurgedByRecipient || currentStatus?.Status == CorrespondenceStatus.PurgedByAltinn)
+        if (currentStatus is null)
+        {
+            return Errors.LatestStatusIsNull;
+        }
+        if (currentStatus!.Status.IsPurged())
         {
             return Errors.CorrespondencePurged;
         }

--- a/src/Altinn.Correspondence.Application/UpdateMarkUnread/UpdateMarkAsUnreadHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateMarkUnread/UpdateMarkAsUnreadHandler.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondece.Application.Helpers;
 using Altinn.Correspondence.Core.Models;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
@@ -26,7 +27,7 @@ public class UpdateMarkAsUnreadHandler : IHandler<Guid, Guid>
             return Errors.CorrespondenceNotFound;
         }
 
-        var currentStatus = correspondence.Statuses.OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+        var currentStatus = correspondence.GetLatestStatus();
         if (!correspondence.Statuses.Any(s => s.Status == CorrespondenceStatus.Read))
         {
             return Errors.CorrespondenceHasNotBeenRead;

--- a/src/Altinn.Correspondence.Core/Repositories/IAttachmentStatusRepository.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IAttachmentStatusRepository.cs
@@ -5,6 +5,5 @@ namespace Altinn.Correspondence.Core.Repositories
     public interface IAttachmentStatusRepository
     {
         Task<Guid> AddAttachmentStatus(AttachmentStatusEntity attachment, CancellationToken cancellationToken);
-        Task<AttachmentStatusEntity> GetLatestStatusByAttachmentId(Guid attachmentId, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceStatusRepository.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceStatusRepository.cs
@@ -5,9 +5,6 @@ namespace Altinn.Correspondence.Core.Repositories
     public interface ICorrespondenceStatusRepository
     {
         Task<Guid> AddCorrespondenceStatus(CorrespondenceStatusEntity Correspondence, CancellationToken cancellationToken);
-
-        Task<CorrespondenceStatusEntity> GetLatestStatusByCorrespondenceId(Guid CorrespondenceId, CancellationToken cancellationToken);
-
         Task<List<Guid>> AddCorrespondenceStatuses(List<CorrespondenceStatusEntity> statuses, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/AttachmentStatusRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/AttachmentStatusRepository.cs
@@ -14,15 +14,5 @@ namespace Altinn.Correspondence.Persistence.Repositories
             await _context.SaveChangesAsync();
             return status.Id;
         }
-
-        public async Task<AttachmentStatusEntity> GetLatestStatusByAttachmentId(Guid attachmentId, CancellationToken cancellationToken)
-        {
-            var status = await _context.AttachmentStatuses
-                .Where(s => s.AttachmentId == attachmentId)
-                .OrderByDescending(s => s.StatusChanged)
-                .FirstAsync(cancellationToken);
-
-            return status;
-        }
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceStatusRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceStatusRepository.cs
@@ -22,14 +22,5 @@ namespace Altinn.Correspondence.Persistence.Repositories
             return statuses.Select(s => s.Id).ToList();
         }
 
-        public async Task<CorrespondenceStatusEntity> GetLatestStatusByCorrespondenceId(Guid CorrespondenceId, CancellationToken cancellationToken)
-        {
-            var status = await _context.CorrespondenceStatuses
-                .Where(s => s.CorrespondenceId == CorrespondenceId)
-                .OrderByDescending(s => s.StatusChanged)
-                .FirstAsync(cancellationToken);
-
-            return status;
-        }
     }
 }


### PR DESCRIPTION
Add extension methods for Correspondence and Attachment 

## Description
Previously there was a lot of duplicate code regarding getting the latest status for correspondence and attachment. This was often done using standard filtering on date. However, in the statusRepository classes there are methods of retrieving them there. As each of these calls are asynchronous, another approach is to add extension methods. Extension methods helps with removing a lot of the duplicate code and is arguably easier to read and comprehend compared. 

Additions:
- CorrespondenceExtensions.cs
- AttachmentExtensions.cs

I considered creating extensions for the Status objects instead of the whole correspondence and attachment objects, and possibly returning `CorrespondenceStatus` (as opposed to `CorrespondenceStatusEntity`). However after looking at the code, retrieving latest status always uses the correspondence/attachment (meaning they are always available), and latest status is typically used with the actual `Status`, but also the fields `StatusChanged` and `StatusText`

Deletions:
- GetLatestStatusByCorrespondenceId
- GetLatestStatusByAttachmentId

As these are not used, they have been temporarily removed. There may come a time where we only want the latest status and no other fields. 
## Related Issue(s)
- #267 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
