### PR TITLE
Revamped Postman collection to have less nested requests, easier auth…

### DIFF
--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "88b24a77-c1e4-464f-9e2f-4bca15cc93f8",
-		"name": "Altinn.Correspondence.API Rev2",
+		"_postman_id": "2f063075-488c-4b14-8616-76e6f4a7ffef",
+		"name": "Altinn.Correspondence.API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "7106668"
 	},
@@ -1001,16 +1001,6 @@
 									"type": "text"
 								},
 								{
-									"key": "Correspondence.externalReferences[1].referenceValue",
-									"value": "test",
-									"type": "text"
-								},
-								{
-									"key": "Correspondence.externalReferences[1].referenceType",
-									"value": "DialogPortenDialogID",
-									"type": "text"
-								},
-								{
 									"key": "Correspondence.propertyList.deserunt_12",
 									"value": "string",
 									"type": "text"
@@ -1957,22 +1947,22 @@
 		},
 		{
 			"key": "senderSsn",
-			"value": "Go to https://testdata.skatteetaten.no to find test data. Person should be dagl/\"daglig leder\").",
+			"value": "Go to https://tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
 			"type": "string"
 		},
 		{
 			"key": "senderOrgNo",
-			"value": "Go to https://testdata.skatteetaten.no to find test data. Person should be dagl/\"daglig leder\").",
+			"value": "Go to https://tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
 			"type": "string"
 		},
 		{
 			"key": "recipientSsn",
-			"value": "Go to https://testdata.skatteetaten.no to find test data. Person should be dagl/\"daglig leder\").",
+			"value": "Go to https://tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
 			"type": "string"
 		},
 		{
 			"key": "recipientOrgNo",
-			"value": "Go to https://testdata.skatteetaten.no to find test data. Person should be dagl/\"daglig leder\").",
+			"value": "Go to https://tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
 			"type": "string"
 		},
 		{

--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -1,1992 +1,14 @@
 {
 	"info": {
-		"_postman_id": "7fe8254e-0fb7-4907-a4f6-89cd244512e4",
-		"name": "Altinn.Correspondence.API",
+		"_postman_id": "88b24a77-c1e4-464f-9e2f-4bca15cc93f8",
+		"name": "Altinn.Correspondence.API Rev2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "7106668"
 	},
 	"item": [
 		{
-			"name": "correspondence",
+			"name": "Authentication",
 			"item": [
-				{
-					"name": "api",
-					"item": [
-						{
-							"name": "v1",
-							"item": [
-								{
-									"name": "attachment",
-									"item": [
-										{
-											"name": "{attachmentId}",
-											"item": [
-												{
-													"name": "upload",
-													"item": [
-														{
-															"name": "Upload",
-															"protocolProfileBehavior": {
-																"disabledSystemHeaders": {
-																	"content-type": true
-																}
-															},
-															"request": {
-																"auth": {
-																	"type": "bearer",
-																	"bearer": [
-																		{
-																			"key": "token",
-																			"value": "{{sender_token}}",
-																			"type": "string"
-																		}
-																	]
-																},
-																"method": "POST",
-																"header": [
-																	{
-																		"key": "Accept",
-																		"value": "application/octet-stream"
-																	}
-																],
-																"body": {
-																	"mode": "file",
-																	"file": {
-																		"src": ""
-																	}
-																},
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/attachment/{{attachmentId}}/upload",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"attachment",
-																		"{{attachmentId}}",
-																		"upload"
-																	]
-																}
-															},
-															"response": [
-																{
-																	"name": "Success",
-																	"originalRequest": {
-																		"method": "POST",
-																		"header": [
-																			{
-																				"key": "Accept",
-																				"value": "text/plain"
-																			}
-																		],
-																		"url": {
-																			"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/upload",
-																			"host": [
-																				"{{baseUrl}}"
-																			],
-																			"path": [
-																				"correspondence",
-																				"api",
-																				"v1",
-																				"attachment",
-																				":attachmentId",
-																				"upload"
-																			],
-																			"variable": [
-																				{
-																					"key": "attachmentId"
-																				}
-																			]
-																		}
-																	},
-																	"status": "OK",
-																	"code": 200,
-																	"_postman_previewlanguage": "json",
-																	"header": [
-																		{
-																			"key": "Content-Type",
-																			"value": "application/json"
-																		}
-																	],
-																	"cookie": [],
-																	"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-																}
-															]
-														}
-													]
-												},
-												{
-													"name": "details",
-													"item": [
-														{
-															"name": "Details",
-															"request": {
-																"auth": {
-																	"type": "bearer",
-																	"bearer": [
-																		{
-																			"key": "token",
-																			"value": "{{sender_token}}",
-																			"type": "string"
-																		}
-																	]
-																},
-																"method": "GET",
-																"header": [
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/attachment/{{attachmentId}}/details",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"attachment",
-																		"{{attachmentId}}",
-																		"details"
-																	]
-																}
-															},
-															"response": [
-																{
-																	"name": "Success",
-																	"originalRequest": {
-																		"method": "GET",
-																		"header": [
-																			{
-																				"key": "Accept",
-																				"value": "text/plain"
-																			}
-																		],
-																		"url": {
-																			"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/details",
-																			"host": [
-																				"{{baseUrl}}"
-																			],
-																			"path": [
-																				"correspondence",
-																				"api",
-																				"v1",
-																				"attachment",
-																				":attachmentId",
-																				"details"
-																			],
-																			"variable": [
-																				{
-																					"key": "attachmentId"
-																				}
-																			]
-																		}
-																	},
-																	"status": "OK",
-																	"code": 200,
-																	"_postman_previewlanguage": "json",
-																	"header": [
-																		{
-																			"key": "Content-Type",
-																			"value": "application/json"
-																		}
-																	],
-																	"cookie": [],
-																	"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"Deleted\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Failed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Deleted\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
-																}
-															]
-														}
-													]
-												},
-												{
-													"name": "purge",
-													"item": [
-														{
-															"name": "Purge",
-															"request": {
-																"auth": {
-																	"type": "bearer",
-																	"bearer": [
-																		{
-																			"key": "token",
-																			"value": "{{sender_token}}",
-																			"type": "string"
-																		}
-																	]
-																},
-																"method": "DELETE",
-																"header": [
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/attachment/{{attachmentId}}",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"attachment",
-																		"{{attachmentId}}"
-																	]
-																}
-															},
-															"response": [
-																{
-																	"name": "Success",
-																	"originalRequest": {
-																		"method": "DELETE",
-																		"header": [
-																			{
-																				"key": "Accept",
-																				"value": "text/plain"
-																			}
-																		],
-																		"url": {
-																			"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId",
-																			"host": [
-																				"{{baseUrl}}"
-																			],
-																			"path": [
-																				"correspondence",
-																				"api",
-																				"v1",
-																				"attachment",
-																				":attachmentId"
-																			],
-																			"variable": [
-																				{
-																					"key": "attachmentId"
-																				}
-																			]
-																		}
-																	},
-																	"status": "OK",
-																	"code": 200,
-																	"_postman_previewlanguage": "json",
-																	"header": [
-																		{
-																			"key": "Content-Type",
-																			"value": "application/json"
-																		}
-																	],
-																	"cookie": [],
-																	"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-																}
-															]
-														}
-													]
-												},
-												{
-													"name": "Get Attachment",
-													"request": {
-														"auth": {
-															"type": "bearer",
-															"bearer": [
-																{
-																	"key": "token",
-																	"value": "{{sender_token}}",
-																	"type": "string"
-																}
-															]
-														},
-														"method": "GET",
-														"header": [
-															{
-																"key": "Accept",
-																"value": "text/plain"
-															}
-														],
-														"url": {
-															"raw": "{{baseUrl}}/correspondence/api/v1/attachment/{{attachmentId}}",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"correspondence",
-																"api",
-																"v1",
-																"attachment",
-																"{{attachmentId}}"
-															]
-														}
-													},
-													"response": [
-														{
-															"name": "Success",
-															"originalRequest": {
-																"method": "GET",
-																"header": [
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"attachment",
-																		":attachmentId"
-																	],
-																	"variable": [
-																		{
-																			"key": "attachmentId"
-																		}
-																	]
-																}
-															},
-															"status": "OK",
-															"code": 200,
-															"_postman_previewlanguage": "json",
-															"header": [
-																{
-																	"key": "Content-Type",
-																	"value": "application/json"
-																}
-															],
-															"cookie": [],
-															"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-														}
-													]
-												}
-											]
-										},
-										{
-											"name": "Initialize Attachment",
-											"event": [
-												{
-													"listen": "test",
-													"script": {
-														"exec": [
-															"var attachmentId = pm.response.text().replace(/\\\"/g, \"\")\r",
-															"pm.collectionVariables.set(\"attachmentId\", attachmentId);\r",
-															""
-														],
-														"type": "text/javascript",
-														"packages": {}
-													}
-												}
-											],
-											"request": {
-												"auth": {
-													"type": "bearer",
-													"bearer": [
-														{
-															"key": "token",
-															"value": "{{sender_token}}",
-															"type": "string"
-														}
-													]
-												},
-												"method": "POST",
-												"header": [
-													{
-														"key": "Content-Type",
-														"value": "application/json"
-													},
-													{
-														"key": "Accept",
-														"value": "text/plain"
-													}
-												],
-												"body": {
-													"mode": "raw",
-													"raw": "{\n  \"dataType\": \"html\",\n  \"expirationTime\": \"2024-12-12\",\n  \"resourceId\": \"{{resource_id}}\",\n  \"name\": \"testFile\",\n  \"restrictionName\": \"testFile\",\n  \"sender\": \"0192:991825827\",\n  \"sendersReference\": \"1234\",\n  \"fileName\": \"test-file\",\n  \"isEncrypted\": false\n}",
-													"options": {
-														"raw": {
-															"headerFamily": "json",
-															"language": "json"
-														}
-													}
-												},
-												"url": {
-													"raw": "{{baseUrl}}/correspondence/api/v1/attachment",
-													"host": [
-														"{{baseUrl}}"
-													],
-													"path": [
-														"correspondence",
-														"api",
-														"v1",
-														"attachment"
-													]
-												}
-											},
-											"response": [
-												{
-													"name": "Success",
-													"originalRequest": {
-														"method": "POST",
-														"header": [
-															{
-																"key": "Content-Type",
-																"value": "application/json"
-															},
-															{
-																"key": "Accept",
-																"value": "text/plain"
-															}
-														],
-														"body": {
-															"mode": "raw",
-															"raw": "{\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"HumanReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\"\n}",
-															"options": {
-																"raw": {
-																	"headerFamily": "json",
-																	"language": "json"
-																}
-															}
-														},
-														"url": {
-															"raw": "{{baseUrl}}/correspondence/api/v1/attachment",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"correspondence",
-																"api",
-																"v1",
-																"attachment"
-															]
-														}
-													},
-													"status": "OK",
-													"code": 200,
-													"_postman_previewlanguage": "json",
-													"header": [
-														{
-															"key": "Content-Type",
-															"value": "application/json"
-														}
-													],
-													"cookie": [],
-													"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-												}
-											]
-										}
-									]
-								},
-								{
-									"name": "correspondence",
-									"item": [
-										{
-											"name": "upload",
-											"item": [
-												{
-													"name": "Upload correspondence",
-													"request": {
-														"auth": {
-															"type": "bearer",
-															"bearer": [
-																{
-																	"key": "token",
-																	"value": "{{sender_token}}",
-																	"type": "string"
-																}
-															]
-														},
-														"method": "POST",
-														"header": [
-															{
-																"key": "Content-Type",
-																"value": "application/json"
-															},
-															{
-																"key": "Accept",
-																"value": "text/plain"
-															}
-														],
-														"body": {
-															"mode": "formdata",
-															"formdata": [
-																{
-																	"key": "Recipients[0]",
-																	"value": "0192:991825827",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.ResourceId",
-																	"value": "{{resource_id}}",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.Sender",
-																	"value": "0192:991825827",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.sendersReference",
-																	"value": "1234",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.language",
-																	"value": "en",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.messageTitle",
-																	"value": "test asdf asdf",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.messageSummary",
-																	"value": "asdf asdfasdf",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.messageBody",
-																	"value": "test",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.attachments[0].DataLocationType",
-																	"value": "ExisitingExternalStorage",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.attachments[0].DataType",
-																	"value": "1",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.attachments[0].Name",
-																	"value": "testfile.txt",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.attachments[0].RestrictionName",
-																	"value": "1234",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.attachments[0].Sender",
-																	"value": "0192:991825827",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.attachments[0].SendersReference",
-																	"value": "1234",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.attachments[0].FileName",
-																	"value": "README.md",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.attachments[0].IsEncrypted",
-																	"value": "true",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.content.attachments[1].DataLocationType",
-																	"value": "ExisitingExternalStorage",
-																	"type": "text",
-																	"disabled": true
-																},
-																{
-																	"key": "Correspondence.content.attachments[1].DataType",
-																	"value": "1",
-																	"type": "text",
-																	"disabled": true
-																},
-																{
-																	"key": "Correspondence.content.attachments[1].Name",
-																	"value": "testfile2.txt",
-																	"type": "text",
-																	"disabled": true
-																},
-																{
-																	"key": "Correspondence.content.attachments[1].RestrictionName",
-																	"value": "1234",
-																	"type": "text",
-																	"disabled": true
-																},
-																{
-																	"key": "Correspondence.content.attachments[1].Sender",
-																	"value": "0192:991825827",
-																	"type": "text",
-																	"disabled": true
-																},
-																{
-																	"key": "Correspondence.content.attachments[1].SendersReference",
-																	"value": "1234",
-																	"type": "text",
-																	"disabled": true
-																},
-																{
-																	"key": "Correspondence.content.attachments[1].FileName",
-																	"value": "testfile2.txt",
-																	"type": "text",
-																	"disabled": true
-																},
-																{
-																	"key": "Correspondence.content.attachments[1].IsEncrypted",
-																	"value": "true",
-																	"type": "text",
-																	"disabled": true
-																},
-																{
-																	"key": "Correspondence.visibleFrom",
-																	"value": "2024-05-29T13:31:28.290518+00:00",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.allowSystemDeleteAfter",
-																	"value": "2025-05-29T13:31:28.290518+00:00",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.dueDateTime",
-																	"value": "2025-05-29T13:31:28.290518+00:00",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.externalReferences[0].referenceValue",
-																	"value": "test",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.externalReferences[0].referenceType",
-																	"value": "AltinnBrokerFileTransfer",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.externalReferences[1].referenceValue",
-																	"value": "test",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.externalReferences[1].referenceType",
-																	"value": "DialogPortenDialogID",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.propertyList.deserunt_12",
-																	"value": "string",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.propertyList.culpa_852",
-																	"value": "string",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.propertyList.anim5",
-																	"value": "string",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.replyOptions[0].linkURL",
-																	"value": "www.dgidir.no",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.replyOptions[0].linkText",
-																	"value": "dgidir",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.replyOptions[1].linkURL",
-																	"value": "www.dgidir.no",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.replyOptions[1].linkText",
-																	"value": "dgidir",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.notification.notificationTemplate",
-																	"value": "1",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.notification.notificationChannel",
-																	"value": "2",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.notification.SendReminder",
-																	"value": "true",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.notification.EmailBody",
-																	"value": "Test av varsling",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.notification.EmailSubject",
-																	"value": "Innholdet i ett testvarsel",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.notification.SmsBody",
-																	"value": "Dette er ett testvarsel",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.notification.ReminderEmailSubject",
-																	"value": "Revarsling ",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.notification.ReminderEmailBody",
-																	"value": "Dette er revarsling av ett testvaresel",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.notification.ReminderSmsBody",
-																	"value": "Dette er revarsel av ett test varsel",
-																	"type": "text"
-																},
-																{
-																	"key": "Correspondence.isReservable",
-																	"value": "true",
-																	"type": "text"
-																},
-																{
-																	"key": "Attachments",
-																	"type": "file",
-																	"src": ""
-																},
-																{
-																	"key": "existingAttachments[0]",
-																	"value": "",
-																	"type": "text",
-																	"disabled": true
-																}
-															]
-														},
-														"url": {
-															"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"correspondence",
-																"api",
-																"v1",
-																"correspondence",
-																"upload"
-															]
-														}
-													},
-													"response": [
-														{
-															"name": "Success",
-															"originalRequest": {
-																"method": "POST",
-																"header": [
-																	{
-																		"key": "Content-Type",
-																		"value": "application/json"
-																	},
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"body": {
-																	"mode": "raw",
-																	"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
-																	"options": {
-																		"raw": {
-																			"headerFamily": "json",
-																			"language": "json"
-																		}
-																	}
-																},
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"correspondence",
-																		"upload"
-																	]
-																}
-															},
-															"status": "OK",
-															"code": 200,
-															"_postman_previewlanguage": "json",
-															"header": [
-																{
-																	"key": "Content-Type",
-																	"value": "application/json"
-																}
-															],
-															"cookie": [],
-															"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-														}
-													]
-												}
-											]
-										},
-										{
-											"name": "{correspondenceId}",
-											"item": [
-												{
-													"name": "details",
-													"item": [
-														{
-															"name": "Details",
-															"request": {
-																"auth": {
-																	"type": "bearer",
-																	"bearer": [
-																		{
-																			"key": "token",
-																			"value": "{{sender_token}}",
-																			"type": "string"
-																		}
-																	]
-																},
-																"method": "GET",
-																"header": [
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/details",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"correspondence",
-																		"{{correspondenceId}}",
-																		"details"
-																	]
-																}
-															},
-															"response": [
-																{
-																	"name": "Success",
-																	"originalRequest": {
-																		"method": "GET",
-																		"header": [
-																			{
-																				"key": "Accept",
-																				"value": "text/plain"
-																			}
-																		],
-																		"url": {
-																			"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/:correspondenceId/details",
-																			"host": [
-																				"{{baseUrl}}"
-																			],
-																			"path": [
-																				"correspondence",
-																				"api",
-																				"v1",
-																				"correspondence",
-																				":correspondenceId",
-																				"details"
-																			],
-																			"variable": [
-																				{
-																					"key": "correspondenceId"
-																				}
-																			]
-																		}
-																	},
-																	"status": "OK",
-																	"code": 200,
-																	"_postman_previewlanguage": "json",
-																	"header": [
-																		{
-																			"key": "Content-Type",
-																			"value": "application/json"
-																		}
-																	],
-																	"cookie": [],
-																	"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"9585:149785773\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"NorwegianNO\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnAppInstance\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    }\n  ],\n  \"propertyList\": {\n    \"Excepteur36a\": \"<string>\",\n    \"officiaaf1\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Email\",\n      \"created\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Sms\",\n      \"created\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Archived\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Confirmed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Archived\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ],\n  \"notificationStatusHistory\": [\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
-																}
-															]
-														}
-													],
-													"description": "Details is available for both sender and recipient. The recipient can only retrieve details if the correspondence is Published. For each of the roles, the correct token must be used.\n\nAs recipient, the correspondence must also have the org number of the \"Recipient\" field be equal to the consumer. In this case it is 0192:991825827 (Digitaliseringsdirektoratet)"
-												},
-												{
-													"name": "archive",
-													"item": [
-														{
-															"name": "Archive",
-															"request": {
-																"auth": {
-																	"type": "bearer",
-																	"bearer": [
-																		{
-																			"key": "token",
-																			"value": "{{recipient_token}}",
-																			"type": "string"
-																		}
-																	]
-																},
-																"method": "POST",
-																"header": [
-																	{
-																		"key": "Content-Type",
-																		"value": "application/json"
-																	},
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"body": {
-																	"mode": "raw",
-																	"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
-																	"options": {
-																		"raw": {
-																			"headerFamily": "json",
-																			"language": "json"
-																		}
-																	}
-																},
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/archive",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"correspondence",
-																		"{{correspondenceId}}",
-																		"archive"
-																	]
-																}
-															},
-															"response": [
-																{
-																	"name": "Success",
-																	"originalRequest": {
-																		"method": "POST",
-																		"header": [
-																			{
-																				"key": "Content-Type",
-																				"value": "application/json"
-																			},
-																			{
-																				"key": "Accept",
-																				"value": "text/plain"
-																			}
-																		],
-																		"body": {
-																			"mode": "raw",
-																			"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
-																			"options": {
-																				"raw": {
-																					"headerFamily": "json",
-																					"language": "json"
-																				}
-																			}
-																		},
-																		"url": {
-																			"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
-																			"host": [
-																				"{{baseUrl}}"
-																			],
-																			"path": [
-																				"correspondence",
-																				"api",
-																				"v1",
-																				"correspondence",
-																				"upload"
-																			]
-																		}
-																	},
-																	"status": "OK",
-																	"code": 200,
-																	"_postman_previewlanguage": "json",
-																	"header": [
-																		{
-																			"key": "Content-Type",
-																			"value": "application/json"
-																		}
-																	],
-																	"cookie": [],
-																	"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-																}
-															]
-														}
-													]
-												},
-												{
-													"name": "markasread",
-													"item": [
-														{
-															"name": "Mark As Read",
-															"request": {
-																"auth": {
-																	"type": "bearer",
-																	"bearer": [
-																		{
-																			"key": "token",
-																			"value": "{{recipient_token}}",
-																			"type": "string"
-																		}
-																	]
-																},
-																"method": "POST",
-																"header": [
-																	{
-																		"key": "Content-Type",
-																		"value": "application/json"
-																	},
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"body": {
-																	"mode": "raw",
-																	"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
-																	"options": {
-																		"raw": {
-																			"headerFamily": "json",
-																			"language": "json"
-																		}
-																	}
-																},
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/markasread",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"correspondence",
-																		"{{correspondenceId}}",
-																		"markasread"
-																	]
-																}
-															},
-															"response": [
-																{
-																	"name": "Success",
-																	"originalRequest": {
-																		"method": "POST",
-																		"header": [
-																			{
-																				"key": "Content-Type",
-																				"value": "application/json"
-																			},
-																			{
-																				"key": "Accept",
-																				"value": "text/plain"
-																			}
-																		],
-																		"body": {
-																			"mode": "raw",
-																			"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
-																			"options": {
-																				"raw": {
-																					"headerFamily": "json",
-																					"language": "json"
-																				}
-																			}
-																		},
-																		"url": {
-																			"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
-																			"host": [
-																				"{{baseUrl}}"
-																			],
-																			"path": [
-																				"correspondence",
-																				"api",
-																				"v1",
-																				"correspondence",
-																				"upload"
-																			]
-																		}
-																	},
-																	"status": "OK",
-																	"code": 200,
-																	"_postman_previewlanguage": "json",
-																	"header": [
-																		{
-																			"key": "Content-Type",
-																			"value": "application/json"
-																		}
-																	],
-																	"cookie": [],
-																	"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-																}
-															]
-														}
-													]
-												},
-												{
-													"name": "purge",
-													"item": [
-														{
-															"name": "Purge",
-															"request": {
-																"auth": {
-																	"type": "bearer",
-																	"bearer": [
-																		{
-																			"key": "token",
-																			"value": "{{recipient_token}}",
-																			"type": "string"
-																		}
-																	]
-																},
-																"method": "DELETE",
-																"header": [
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/purge",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"correspondence",
-																		"{{correspondenceId}}",
-																		"purge"
-																	]
-																}
-															},
-															"response": [
-																{
-																	"name": "Success",
-																	"originalRequest": {
-																		"method": "GET",
-																		"header": [
-																			{
-																				"key": "Accept",
-																				"value": "text/plain"
-																			}
-																		],
-																		"url": {
-																			"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/:correspondenceId/details",
-																			"host": [
-																				"{{baseUrl}}"
-																			],
-																			"path": [
-																				"correspondence",
-																				"api",
-																				"v1",
-																				"correspondence",
-																				":correspondenceId",
-																				"details"
-																			],
-																			"variable": [
-																				{
-																					"key": "correspondenceId"
-																				}
-																			]
-																		}
-																	},
-																	"status": "OK",
-																	"code": 200,
-																	"_postman_previewlanguage": "json",
-																	"header": [
-																		{
-																			"key": "Content-Type",
-																			"value": "application/json"
-																		}
-																	],
-																	"cookie": [],
-																	"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"9585:149785773\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"NorwegianNO\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnAppInstance\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    }\n  ],\n  \"propertyList\": {\n    \"Excepteur36a\": \"<string>\",\n    \"officiaaf1\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Email\",\n      \"created\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Sms\",\n      \"created\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Archived\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Confirmed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Archived\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ],\n  \"notificationStatusHistory\": [\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
-																}
-															]
-														}
-													]
-												},
-												{
-													"name": "confirm",
-													"item": [
-														{
-															"name": "Confirm",
-															"request": {
-																"auth": {
-																	"type": "bearer",
-																	"bearer": [
-																		{
-																			"key": "token",
-																			"value": "{{recipient_token}}",
-																			"type": "string"
-																		}
-																	]
-																},
-																"method": "POST",
-																"header": [
-																	{
-																		"key": "Content-Type",
-																		"value": "application/json"
-																	},
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"body": {
-																	"mode": "raw",
-																	"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
-																	"options": {
-																		"raw": {
-																			"headerFamily": "json",
-																			"language": "json"
-																		}
-																	}
-																},
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/confirm",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"correspondence",
-																		"{{correspondenceId}}",
-																		"confirm"
-																	]
-																}
-															},
-															"response": [
-																{
-																	"name": "Success",
-																	"originalRequest": {
-																		"method": "POST",
-																		"header": [
-																			{
-																				"key": "Content-Type",
-																				"value": "application/json"
-																			},
-																			{
-																				"key": "Accept",
-																				"value": "text/plain"
-																			}
-																		],
-																		"body": {
-																			"mode": "raw",
-																			"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
-																			"options": {
-																				"raw": {
-																					"headerFamily": "json",
-																					"language": "json"
-																				}
-																			}
-																		},
-																		"url": {
-																			"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
-																			"host": [
-																				"{{baseUrl}}"
-																			],
-																			"path": [
-																				"correspondence",
-																				"api",
-																				"v1",
-																				"correspondence",
-																				"upload"
-																			]
-																		}
-																	},
-																	"status": "OK",
-																	"code": 200,
-																	"_postman_previewlanguage": "json",
-																	"header": [
-																		{
-																			"key": "Content-Type",
-																			"value": "application/json"
-																		}
-																	],
-																	"cookie": [],
-																	"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-																}
-															]
-														}
-													]
-												},
-												{
-													"name": "markasunread",
-													"item": [
-														{
-															"name": "Mark As Unread",
-															"request": {
-																"auth": {
-																	"type": "bearer",
-																	"bearer": [
-																		{
-																			"key": "token",
-																			"value": "{{recipient_token}}",
-																			"type": "string"
-																		}
-																	]
-																},
-																"method": "POST",
-																"header": [
-																	{
-																		"key": "Content-Type",
-																		"value": "application/json"
-																	},
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"body": {
-																	"mode": "raw",
-																	"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
-																	"options": {
-																		"raw": {
-																			"headerFamily": "json",
-																			"language": "json"
-																		}
-																	}
-																},
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/markasunread",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"correspondence",
-																		"{{correspondenceId}}",
-																		"markasunread"
-																	]
-																}
-															},
-															"response": [
-																{
-																	"name": "Success",
-																	"originalRequest": {
-																		"method": "POST",
-																		"header": [
-																			{
-																				"key": "Content-Type",
-																				"value": "application/json"
-																			},
-																			{
-																				"key": "Accept",
-																				"value": "text/plain"
-																			}
-																		],
-																		"body": {
-																			"mode": "raw",
-																			"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
-																			"options": {
-																				"raw": {
-																					"headerFamily": "json",
-																					"language": "json"
-																				}
-																			}
-																		},
-																		"url": {
-																			"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
-																			"host": [
-																				"{{baseUrl}}"
-																			],
-																			"path": [
-																				"correspondence",
-																				"api",
-																				"v1",
-																				"correspondence",
-																				"upload"
-																			]
-																		}
-																	},
-																	"status": "OK",
-																	"code": 200,
-																	"_postman_previewlanguage": "json",
-																	"header": [
-																		{
-																			"key": "Content-Type",
-																			"value": "application/json"
-																		}
-																	],
-																	"cookie": [],
-																	"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-																}
-															]
-														}
-													]
-												},
-												{
-													"name": "Get Correspondence",
-													"protocolProfileBehavior": {
-														"disableBodyPruning": true
-													},
-													"request": {
-														"auth": {
-															"type": "bearer",
-															"bearer": [
-																{
-																	"key": "token",
-																	"value": "{{recipient_token}}",
-																	"type": "string"
-																}
-															]
-														},
-														"method": "GET",
-														"header": [
-															{
-																"key": "Accept",
-																"value": "text/plain"
-															}
-														],
-														"body": {
-															"mode": "raw",
-															"raw": "",
-															"options": {
-																"raw": {
-																	"language": "json"
-																}
-															}
-														},
-														"url": {
-															"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"correspondence",
-																"api",
-																"v1",
-																"correspondence",
-																"{{correspondenceId}}"
-															]
-														}
-													},
-													"response": [
-														{
-															"name": "Success",
-															"originalRequest": {
-																"method": "GET",
-																"header": [
-																	{
-																		"key": "Accept",
-																		"value": "text/plain"
-																	}
-																],
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/:correspondenceId",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"correspondence",
-																		":correspondenceId"
-																	],
-																	"variable": [
-																		{
-																			"key": "correspondenceId"
-																		}
-																	]
-																}
-															},
-															"status": "OK",
-															"code": 200,
-															"_postman_previewlanguage": "json",
-															"header": [
-																{
-																	"key": "Content-Type",
-																	"value": "application/json"
-																}
-															],
-															"cookie": [],
-															"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-														}
-													]
-												}
-											]
-										},
-										{
-											"name": "download",
-											"item": [
-												{
-													"name": "Download Attachment",
-													"request": {
-														"auth": {
-															"type": "bearer",
-															"bearer": [
-																{
-																	"key": "token",
-																	"value": "{{recipient_token}}",
-																	"type": "string"
-																}
-															]
-														},
-														"method": "GET",
-														"header": [],
-														"url": {
-															"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/attachment/{{attachmentId}}/download",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"correspondence",
-																"api",
-																"v1",
-																"correspondence",
-																"{{correspondenceId}}",
-																"attachment",
-																"{{attachmentId}}",
-																"download"
-															]
-														}
-													},
-													"response": [
-														{
-															"name": "Success",
-															"originalRequest": {
-																"method": "GET",
-																"header": [],
-																"url": {
-																	"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/download",
-																	"host": [
-																		"{{baseUrl}}"
-																	],
-																	"path": [
-																		"correspondence",
-																		"api",
-																		"v1",
-																		"attachment",
-																		":attachmentId",
-																		"download"
-																	],
-																	"variable": [
-																		{
-																			"key": "attachmentId"
-																		}
-																	]
-																}
-															},
-															"status": "OK",
-															"code": 200,
-															"_postman_previewlanguage": "text",
-															"header": [],
-															"cookie": [],
-															"body": ""
-														}
-													]
-												}
-											]
-										},
-										{
-											"name": "Initialize Correspondence",
-											"event": [
-												{
-													"listen": "test",
-													"script": {
-														"exec": [
-															"var correspondence = pm.response.json()\r",
-															"pm.collectionVariables.set(\"correspondenceId\", correspondence.correspondenceIds[0]);\r",
-															"pm.collectionVariables.set(\"attachmentId\", correspondence.attachmentIds[0])\r",
-															""
-														],
-														"type": "text/javascript",
-														"packages": {}
-													}
-												}
-											],
-											"request": {
-												"auth": {
-													"type": "bearer",
-													"bearer": [
-														{
-															"key": "token",
-															"value": "{{sender_token}}",
-															"type": "string"
-														}
-													]
-												},
-												"method": "POST",
-												"header": [
-													{
-														"key": "Content-Type",
-														"value": "application/json"
-													},
-													{
-														"key": "Accept",
-														"value": "text/plain"
-													}
-												],
-												"body": {
-													"mode": "raw",
-													"raw": "{ \"Correspondence\": {\n\n  \"resourceId\": \"{{resource_id}}\",\n  \"sender\": \"0192:991825827\",\n  \"sendersReference\": \"1\",\n  \"content\": {\n    \"language\": \"no\",\n    \"messageTitle\": \"Meldingstittel\",\n    \"messageSummary\": \"Ett sammendrag for meldingen\",\n    \"messageBody\": \"# meldingsteksten. Som kan være plain text eller markdown \",\n    \"attachments\": [\n        {\n        \"dataType\": \"html\",\n        \"expirationTime\": \"2024-12-12\",\n        \"name\": \"1\",\n        \"restrictionName\": \"testFile23\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"test-fil32e\",\n        \"isEncrypted\": false,\n        \"dataLocationUrl\": \"\"\n        }\n    ]\n  },\n  \"visibleFrom\": \"2024-09-28T12:44:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-08-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"1\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"2\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"1\",\n    \"culpa_852\": \"2\",\n    \"anim5\": \"3\",\n    \"Æ*'1??`  \": \"asdfgklasjd\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"www.test.no\",\n      \"linkText\": \"test\"\n    },\n    {\n      \"linkURL\": \"test.no\",\n      \"linkText\": \"test\"\n    }\n  ],\n  \"notification\":\n    {\n      \"notificationTemplate\": 0,\n      \"notificationChannel\": 3,\n      \"SendReminder\": true,\n      \"EmailBody\": \"Test av varsel\",\n      \"EmailSubject\": \"Dette er innholdet i ett varsel\",\n      \"SmsBody\": \"Dette er innholdet i ett testvarsel\",\n      \"ReminderEmailBody\": \"Dette er test av revarsling \",\n      \"ReminderEmailSubject\": \"Test av revarsel\",\n      \"ReminderSmsBody\": \"Dette er en test av revarslingl\"\n    },\n  \"isReservable\": true\n},\n\"Recipients\": [\n       \"0192:311116789\"\n],\n\"existingAttachments\": [\n]\n}",													"options": {
-														"raw": {
-															"headerFamily": "json",
-															"language": "json"
-														}
-													}
-												},
-												"url": {
-													"raw": "{{baseUrl}}/correspondence/api/v1/correspondence",
-													"host": [
-														"{{baseUrl}}"
-													],
-													"path": [
-														"correspondence",
-														"api",
-														"v1",
-														"correspondence"
-													]
-												}
-											},
-											"response": [
-												{
-													"name": "Success",
-													"originalRequest": {
-														"method": "POST",
-														"header": [
-															{
-																"key": "Content-Type",
-																"value": "application/json"
-															},
-															{
-																"key": "Accept",
-																"value": "text/plain"
-															}
-														],
-														"body": {
-															"mode": "raw",
-															"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
-															"options": {
-																"raw": {
-																	"headerFamily": "json",
-																	"language": "json"
-																}
-															}
-														},
-														"url": {
-															"raw": "{{baseUrl}}/correspondence/api/v1/correspondence",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"correspondence",
-																"api",
-																"v1",
-																"correspondence"
-															]
-														}
-													},
-													"status": "OK",
-													"code": 200,
-													"_postman_previewlanguage": "json",
-													"header": [
-														{
-															"key": "Content-Type",
-															"value": "application/json"
-														}
-													],
-													"cookie": [],
-													"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-												}
-											]
-										},
-										{
-											"name": "Get Correspondences",
-											"event": [
-												{
-													"listen": "test",
-													"script": {
-														"exec": [
-															"var correspondence = pm.response.json()\r",
-															"pm.collectionVariables.set(\"correspondenceId\", correspondence.items[0]);"
-														],
-														"type": "text/javascript",
-														"packages": {}
-													}
-												}
-											],
-											"request": {
-												"auth": {
-													"type": "bearer",
-													"bearer": [
-														{
-															"key": "token",
-															"value": "{{recipient_token}}",
-															"type": "string"
-														}
-													]
-												},
-												"method": "GET",
-												"header": [
-													{
-														"key": "Content-Type",
-														"value": "application/json"
-													},
-													{
-														"key": "Accept",
-														"value": "text/plain"
-													}
-												],
-												"url": {
-													"raw": "{{baseUrl}}/correspondence/api/v1/correspondence?from=2024-02-02T13:31:28.290518&to=2025-08-29T13:31:28.290518&offset=0&limit=30&resourceId={{resource_id}}",
-													"host": [
-														"{{baseUrl}}"
-													],
-													"path": [
-														"correspondence",
-														"api",
-														"v1",
-														"correspondence"
-													],
-													"query": [
-														{
-															"key": "from",
-															"value": "2024-02-02T13:31:28.290518"
-														},
-														{
-															"key": "to",
-															"value": "2025-08-29T13:31:28.290518"
-														},
-														{
-															"key": "offset",
-															"value": "0"
-														},
-														{
-															"key": "limit",
-															"value": "30"
-														},
-														{
-															"key": "status",
-															"value": "2"
-														},
-														{
-															"key": "resourceId",
-															"value": "{{resource_id}}"
-														}
-													]
-												}
-											},
-											"response": [
-												{
-													"name": "Success",
-													"originalRequest": {
-														"method": "POST",
-														"header": [
-															{
-																"key": "Content-Type",
-																"value": "application/json"
-															},
-															{
-																"key": "Accept",
-																"value": "text/plain"
-															}
-														],
-														"body": {
-															"mode": "raw",
-															"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
-															"options": {
-																"raw": {
-																	"headerFamily": "json",
-																	"language": "json"
-																}
-															}
-														},
-														"url": {
-															"raw": "{{baseUrl}}/correspondence/api/v1/correspondence",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"correspondence",
-																"api",
-																"v1",
-																"correspondence"
-															]
-														}
-													},
-													"status": "OK",
-													"code": 200,
-													"_postman_previewlanguage": "json",
-													"header": [
-														{
-															"key": "Content-Type",
-															"value": "application/json"
-														}
-													],
-													"cookie": [],
-													"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "authentication",
-			"item": [
-				{
-					"name": "Install Postman Utility (Initialize)",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code should be 200\", function () {",
-									"    pm.response.to.have.status(200)",
-									"    pm.globals.set(\"pmlib_code\", responseBody)",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
-					"request": {
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "https://joolfe.github.io/postman-util-lib/dist/bundle.js",
-							"protocol": "https",
-							"host": [
-								"joolfe",
-								"github",
-								"io"
-							],
-							"path": [
-								"postman-util-lib",
-								"dist",
-								"bundle.js"
-							]
-						},
-						"description": "Load the postman-util-lib from github.io and load into postman global variable."
-					},
-					"response": []
-				},
-				{
-					"name": "Login to Maskinporten (Initialize)",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"    eval(pm.variables.get(\"pmlib_code\"))\r",
-									"    const jwt = pmlib.jwtSign(\r",
-									"    jwk = JSON.parse(pm.variables.get(\"client_jwk\")), \r",
-									"    payload = {\r",
-									"        \"aud\": \"https://test.maskinporten.no/\",\r",
-									"        \"scope\": \"altinn:testtools/tokengenerator/personal\",\r",
-									"        \"iss\": pm.variables.get(\"client_id\")\r",
-									"    }, \r",
-									"    header = {\r",
-									"        \"kid\": pm.variables.get(\"client_kid\")\r",
-									"    }, \r",
-									"    exp = 120, \r",
-									"    alg = 'RS256');\r",
-									"pm.variables.set('sender_jwt', jwt);\r",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var responseData = JSON.parse(responseBody);\r",
-									"pm.globals.set(\"test_token\", responseData.access_token);\r",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "urlencoded",
-							"urlencoded": [
-								{
-									"key": "grant_type",
-									"value": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-									"type": "text"
-								},
-								{
-									"key": "assertion",
-									"value": "{{sender_jwt}}",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "https://test.maskinporten.no/token",
-							"protocol": "https",
-							"host": [
-								"test",
-								"maskinporten",
-								"no"
-							],
-							"path": [
-								"token"
-							]
-						}
-					},
-					"response": []
-				},
 				{
 					"name": "Authenticate as sender",
 					"event": [
@@ -2003,20 +25,10 @@
 						}
 					],
 					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{test_token}}",
-									"type": "string"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=altinn:correspondence.write&org=ttd&consumerOrgNo=991825827&orgNo=991825827&userId=1&partyId=1&pid=29858397535",
+							"raw": "https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=altinn:correspondence.write&org=ttd&consumerOrgNo={{senderOrgNo}}&orgNo={{senderOrgNo}}&userId=1&partyId=1&pid={{senderSsn}}&ttl=43200",
 							"protocol": "https",
 							"host": [
 								"altinn-testtools-token-generator",
@@ -2042,11 +54,11 @@
 								},
 								{
 									"key": "consumerOrgNo",
-									"value": "991825827"
+									"value": "{{senderOrgNo}}"
 								},
 								{
 									"key": "orgNo",
-									"value": "991825827"
+									"value": "{{senderOrgNo}}"
 								},
 								{
 									"key": "userId",
@@ -2058,7 +70,11 @@
 								},
 								{
 									"key": "pid",
-									"value": "29858397535"
+									"value": "{{senderSsn}}"
+								},
+								{
+									"key": "ttl",
+									"value": "43200"
 								}
 							]
 						}
@@ -2080,20 +96,10 @@
 						}
 					],
 					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{test_token}}",
-									"type": "string"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=altinn:correspondence.read&org=ttd&consumerOrgNo=311141015&orgNo=311141015&pid=01882949180",
+							"raw": "https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=altinn:correspondence.read&org=ttd&consumerOrgNo={{recipientOrgNo}}&orgNo={{recipientOrgNo}}&pid={{recipientSsn}}&ttl=43200&userId=1&partyId=1",
 							"protocol": "https",
 							"host": [
 								"altinn-testtools-token-generator",
@@ -2119,234 +125,28 @@
 								},
 								{
 									"key": "consumerOrgNo",
-									"value": "311141015"
+									"value": "{{recipientOrgNo}}"
 								},
 								{
 									"key": "orgNo",
-									"value": "311141015"
-								},
-								{
-									"key": "userId",
-									"value": "2",
-									"disabled": true
-								},
-								{
-									"key": "partyId",
-									"value": "2",
-									"disabled": true
+									"value": "{{recipientOrgNo}}"
 								},
 								{
 									"key": "pid",
-									"value": "01882949180"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Authenticate as service owner",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.globals.set(\"serviceowner_token\", responseBody);"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{test_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=tt02&scopes=altinn:resourceregistry/resource.write&org=ttd&orgNo=986252932&userId=2&partyId=2&pid=22069343112",
-							"protocol": "https",
-							"host": [
-								"altinn-testtools-token-generator",
-								"azurewebsites",
-								"net"
-							],
-							"path": [
-								"api",
-								"GetPersonalToken"
-							],
-							"query": [
-								{
-									"key": "env",
-									"value": "tt02"
+									"value": "{{recipientSsn}}"
 								},
 								{
-									"key": "scopes",
-									"value": "altinn:resourceregistry/resource.write"
-								},
-								{
-									"key": "org",
-									"value": "ttd"
-								},
-								{
-									"key": "orgNo",
-									"value": "986252932"
+									"key": "ttl",
+									"value": "43200"
 								},
 								{
 									"key": "userId",
-									"value": "2"
+									"value": "1"
 								},
 								{
 									"key": "partyId",
-									"value": "2"
-								},
-								{
-									"key": "pid",
-									"value": "22069343112"
+									"value": "1"
 								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "resourceregistry",
-			"item": [
-				{
-					"name": "Create Resource",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"identifier\": \"{{resource_id}}\",\r\n    \"title\": {\r\n        \"en\": \"Altinn Correspondence - Test\",\r\n        \"nb\": \"Altinn Correspondence - Test\",\r\n        \"nn\": \"Altinn Correspondence - Test\"\r\n    },\r\n    \"description\": {\r\n        \"en\": \"Altinn Correspondence test resource\",\r\n        \"nb-no\": \"Altinn Correspondence testressurs\",\r\n        \"nn-no\": \"Altinn Correspondence testressurs\"\r\n    },\r\n    \"description\": {\r\n        \"en\": \"Access to Altinn Correspondence test resource\",\r\n        \"nb\": \"Tilgang til Altinn Correspondence testressurs\",\r\n        \"nn\": \"Tilgang til Altinn Correspondence testressurs\"\r\n    },\r\n    \"homepage\": \"https://www.digdir.no/\",\r\n    \"status\": \"Active\",\r\n    \"contactPoints\": [],\r\n    \"isPartOf\": \"Altinn\",\r\n    \"resourceReferences\": [],\r\n    \"delegable\": false,\r\n    \"visible\": false,\r\n    \"hasCompetentAuthority\": {\r\n        \"organization\": \"991825827\",\r\n        \"orgcode\": \"TTD\",\r\n        \"name\": {\r\n            \"en\": \"Testdepartementet\",\r\n            \"nb-no\": \"Testdepartementet\",\r\n            \"nn-no\": \"Testdepartementet\"\r\n        }\r\n    },\r\n    \"keywords\": [],\r\n    \"limitedByRRR\": false,\r\n    \"selfIdentifiedUserEnabled\": false,\r\n    \"enterpriseUserEnabled\": false,\r\n    \"resourceType\": \"GenericAccessResource\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "https://platform.tt02.altinn.no/resourceregistry/api/v1/resource",
-							"protocol": "https",
-							"host": [
-								"platform",
-								"tt02",
-								"altinn",
-								"no"
-							],
-							"path": [
-								"resourceregistry",
-								"api",
-								"v1",
-								"resource"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get resource",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "https://platform.tt02.altinn.no/resourceregistry/api/v1/resource/{{resource_id}}",
-							"protocol": "https",
-							"host": [
-								"platform",
-								"tt02",
-								"altinn",
-								"no"
-							],
-							"path": [
-								"resourceregistry",
-								"api",
-								"v1",
-								"resource",
-								"{{resource_id}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Set resource policy",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "policyFile",
-									"type": "file",
-									"src": "/C:/Workspace/altinn-correspondence/Test/Altinn.Correspondence.Tests/Data/altinn-correspondence-test-resource-1.xml"
-								}
-							]
-						},
-						"url": {
-							"raw": "https://platform.tt02.altinn.no/resourceregistry/api/v1/resource/{{resource_id}}/policy",
-							"protocol": "https",
-							"host": [
-								"platform",
-								"tt02",
-								"altinn",
-								"no"
-							],
-							"path": [
-								"resourceregistry",
-								"api",
-								"v1",
-								"resource",
-								"{{resource_id}}",
-								"policy"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get resource policy",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "https://platform.tt02.altinn.no/resourceregistry/api/v1/resource/{{resource_id}}/policy",
-							"protocol": "https",
-							"host": [
-								"platform",
-								"tt02",
-								"altinn",
-								"no"
-							],
-							"path": [
-								"resourceregistry",
-								"api",
-								"v1",
-								"resource",
-								"{{resource_id}}",
-								"policy"
 							]
 						}
 					},
@@ -2354,11 +154,16 @@
 				}
 			],
 			"auth": {
-				"type": "bearer",
-				"bearer": [
+				"type": "basic",
+				"basic": [
 					{
-						"key": "token",
-						"value": "{{serviceowner_token}}",
+						"key": "username",
+						"value": "autotest",
+						"type": "string"
+					},
+					{
+						"key": "password",
+						"value": "altinn8900bnn",
 						"type": "string"
 					}
 				]
@@ -2385,6 +190,1729 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Correspondence",
+			"item": [
+				{
+					"name": "actions",
+					"item": [
+						{
+							"name": "Archive",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{recipient_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/archive",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"{{correspondenceId}}",
+										"archive"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "text/plain"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"correspondence",
+												"api",
+												"v1",
+												"correspondence",
+												"upload"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Mark As Read",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{recipient_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/markasread",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"{{correspondenceId}}",
+										"markasread"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "text/plain"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"correspondence",
+												"api",
+												"v1",
+												"correspondence",
+												"upload"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Purge",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{recipient_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/purge",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"{{correspondenceId}}",
+										"purge"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "text/plain"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/:correspondenceId/details",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"correspondence",
+												"api",
+												"v1",
+												"correspondence",
+												":correspondenceId",
+												"details"
+											],
+											"variable": [
+												{
+													"key": "correspondenceId"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"9585:149785773\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"NorwegianNO\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnAppInstance\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    }\n  ],\n  \"propertyList\": {\n    \"Excepteur36a\": \"<string>\",\n    \"officiaaf1\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Email\",\n      \"created\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Sms\",\n      \"created\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Archived\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Confirmed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Archived\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ],\n  \"notificationStatusHistory\": [\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Confirm",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{recipient_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/confirm",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"{{correspondenceId}}",
+										"confirm"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "text/plain"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"correspondence",
+												"api",
+												"v1",
+												"correspondence",
+												"upload"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Mark As Unread",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{recipient_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/markasunread",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"{{correspondenceId}}",
+										"markasunread"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "text/plain"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"correspondence",
+												"api",
+												"v1",
+												"correspondence",
+												"upload"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Download Attachment",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{recipient_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/attachment/{{attachmentId}}/download",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"{{correspondenceId}}",
+										"attachment",
+										"{{attachmentId}}",
+										"download"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/download",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"correspondence",
+												"api",
+												"v1",
+												"attachment",
+												":attachmentId",
+												"download"
+											],
+											"variable": [
+												{
+													"key": "attachmentId"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Initialize",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var correspondence = pm.response.json()\r",
+									"pm.collectionVariables.set(\"correspondenceId\", correspondence.correspondenceIds[0]);\r",
+									"pm.collectionVariables.set(\"attachmentId\", correspondence.attachmentIds[0])\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{sender_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "text/plain"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"Correspondence\": {\n        \"resourceId\": \"{{resource_id}}\",\n        \"sender\": \"0192:{{senderOrgNo}}\",\n        \"sendersReference\": \"1\",\n        \"content\": {\n        \"language\": \"nb\",\n        \"messageTitle\": \"Meldingstittel\",\n        \"messageSummary\": \"Ett sammendrag for meldingen\",\n        \"messageBody\": \"# meldingsteksten. Som kan være plain text eller markdown \",\n        \"attachments\": [\n                {\n                \"dataType\": \"html\",\n                \"expirationTime\": \"2024-12-12\",\n                \"name\": \"1\",\n                \"restrictionName\": \"testFile23\",\n                \"sendersReference\": \"1234\",\n                \"fileName\": \"test-fil32e\",\n                \"isEncrypted\": false,\n                \"dataLocationUrl\": \"\"\n                }\n            ]\n        },\n        \"visibleFrom\": \"2024-09-28T12:44:28.290518+00:00\",\n        \"allowSystemDeleteAfter\": \"2025-08-29T13:31:28.290518+00:00\",\n        \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n        \"externalReferences\": [\n            {\n                \"referenceValue\": \"1\",\n                \"referenceType\": \"AltinnBrokerFileTransfer\"\n            }\n        ],\n        \"propertyList\": {\n            \"deserunt_12\": \"1\",\n            \"culpa_852\": \"2\",\n            \"anim5\": \"3\",\n            \"Æ*'1??`  \": \"asdfgklasjd\"\n        },\n        \"replyOptions\": [\n            {\n                \"linkURL\": \"www.test.no\",\n                \"linkText\": \"test\"\n            },\n            {\n                \"linkURL\": \"test.no\",\n                \"linkText\": \"test\"\n            }\n        ],\n        \"notification\":\n        {\n            \"notificationTemplate\": 0,\n            \"notificationChannel\": 3,\n            \"SendReminder\": true,\n            \"EmailBody\": \"Test av varsel\",\n            \"EmailSubject\": \"Dette er innholdet i ett varsel\",\n            \"SmsBody\": \"Dette er innholdet i ett testvarsel\",\n            \"ReminderEmailBody\": \"Dette er test av revarsling \",\n            \"ReminderEmailSubject\": \"Test av revarsel\",\n            \"ReminderSmsBody\": \"Dette er en test av revarslingl\"\n        },\n        \"isReservable\": true\n    },\n    \"Recipients\": [\n        \"0192:311116789\"\n    ],\n    \"existingAttachments\": []\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/correspondence",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"correspondence"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Initialize and Upload",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{sender_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "text/plain"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "Recipients[0]",
+									"value": "0192:{{recipientOrgNo}}",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.ResourceId",
+									"value": "{{resource_id}}",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.Sender",
+									"value": "0192:{{senderOrgNo}}",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.sendersReference",
+									"value": "1234",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.language",
+									"value": "en",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.messageTitle",
+									"value": "New version",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.messageSummary",
+									"value": "Maybe not so new",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.messageBody",
+									"value": "But current",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.attachments[0].DataLocationType",
+									"value": "ExisitingExternalStorage",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.attachments[0].DataType",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.attachments[0].Name",
+									"value": "testfile.txt",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.attachments[0].RestrictionName",
+									"value": "1234",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.attachments[0].Sender",
+									"value": "0192:{{senderOrgNo}}",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.attachments[0].SendersReference",
+									"value": "1234",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.attachments[0].FileName",
+									"value": "version.txt",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.content.attachments[0].IsEncrypted",
+									"value": "true",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.visibleFrom",
+									"value": "2024-05-29T13:31:28.290518+00:00",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.allowSystemDeleteAfter",
+									"value": "2025-05-29T13:31:28.290518+00:00",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.dueDateTime",
+									"value": "2025-05-29T13:31:28.290518+00:00",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.externalReferences[0].referenceValue",
+									"value": "test",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.externalReferences[0].referenceType",
+									"value": "AltinnBrokerFileTransfer",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.externalReferences[1].referenceValue",
+									"value": "test",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.externalReferences[1].referenceType",
+									"value": "DialogPortenDialogID",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.propertyList.deserunt_12",
+									"value": "string",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.propertyList.culpa_852",
+									"value": "string",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.propertyList.anim5",
+									"value": "string",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.replyOptions[0].linkURL",
+									"value": "www.dgidir.no",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.replyOptions[0].linkText",
+									"value": "dgidir",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.replyOptions[1].linkURL",
+									"value": "www.dgidir.no",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.replyOptions[1].linkText",
+									"value": "dgidir",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.notification.notificationTemplate",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.notification.notificationChannel",
+									"value": "2",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.notification.SendReminder",
+									"value": "true",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.notification.EmailBody",
+									"value": "Test av varsling",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.notification.EmailSubject",
+									"value": "Innholdet i ett testvarsel",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.notification.SmsBody",
+									"value": "Dette er ett testvarsel",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.notification.ReminderEmailSubject",
+									"value": "Revarsling ",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.notification.ReminderEmailBody",
+									"value": "Dette er revarsling av ett testvarsel",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.notification.ReminderSmsBody",
+									"value": "Dette er revarsel av ett test varsel",
+									"type": "text"
+								},
+								{
+									"key": "Correspondence.isReservable",
+									"value": "true",
+									"type": "text"
+								},
+								{
+									"key": "Attachments",
+									"type": "file",
+									"src": "postman-cloud:///1ef7ccd7-bbc9-40b0-b540-3c47a5226c58"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"correspondence",
+								"upload"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"upload"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Overview",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{recipient_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "text/plain"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"correspondence",
+								"{{correspondenceId}}"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/:correspondenceId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										":correspondenceId"
+									],
+									"variable": [
+										{
+											"key": "correspondenceId"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Details",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{sender_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "text/plain"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/details",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"correspondence",
+								"{{correspondenceId}}",
+								"details"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/:correspondenceId/details",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										":correspondenceId",
+										"details"
+									],
+									"variable": [
+										{
+											"key": "correspondenceId"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"9585:149785773\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"NorwegianNO\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnAppInstance\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    }\n  ],\n  \"propertyList\": {\n    \"Excepteur36a\": \"<string>\",\n    \"officiaaf1\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Email\",\n      \"created\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Sms\",\n      \"created\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Archived\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Confirmed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Archived\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ],\n  \"notificationStatusHistory\": [\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
+						}
+					]
+				},
+				{
+					"name": "Search",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var correspondence = pm.response.json()\r",
+									"pm.collectionVariables.set(\"correspondenceId\", correspondence.items[0]);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{recipient_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "text/plain"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/correspondence?from=2024-02-02T13:31:28.290518&to=2025-08-29T13:31:28.290518&offset=0&limit=30&status=2&resourceId={{resource_id}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"correspondence"
+							],
+							"query": [
+								{
+									"key": "from",
+									"value": "2024-02-02T13:31:28.290518"
+								},
+								{
+									"key": "to",
+									"value": "2025-08-29T13:31:28.290518"
+								},
+								{
+									"key": "offset",
+									"value": "0"
+								},
+								{
+									"key": "limit",
+									"value": "30"
+								},
+								{
+									"key": "status",
+									"value": "2"
+								},
+								{
+									"key": "resourceId",
+									"value": "{{resource_id}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Attachment",
+			"item": [
+				{
+					"name": "Initialize Batch Attachment",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var attachmentId = pm.response.text().replace(/\\\"/g, \"\")\r",
+									"pm.collectionVariables.set(\"attachmentId\", attachmentId);\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{sender_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "text/plain"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"dataType\": \"html\",\n  \"expirationTime\": \"2024-12-12\",\n  \"resourceId\": \"{{resource_id}}\",\n  \"name\": \"testFile\",\n  \"restrictionName\": \"testFile\",\n  \"sender\": \"0192:991825827\",\n  \"sendersReference\": \"1234\",\n  \"fileName\": \"test-file\",\n  \"isEncrypted\": false\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/attachment",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"attachment"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"HumanReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/attachment",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"attachment"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Upload",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"content-type": true
+						}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{sender_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/octet-stream"
+							}
+						],
+						"body": {
+							"mode": "file",
+							"file": {
+								"src": ""
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/attachment/{{attachmentId}}/upload",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"attachment",
+								"{{attachmentId}}",
+								"upload"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/upload",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"attachment",
+										":attachmentId",
+										"upload"
+									],
+									"variable": [
+										{
+											"key": "attachmentId"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Overview",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{sender_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "text/plain"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/attachment/{{attachmentId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"attachment",
+								"{{attachmentId}}"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"attachment",
+										":attachmentId"
+									],
+									"variable": [
+										{
+											"key": "attachmentId"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Details",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{sender_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "text/plain"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/attachment/{{attachmentId}}/details",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"attachment",
+								"{{attachmentId}}",
+								"details"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/details",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"attachment",
+										":attachmentId",
+										"details"
+									],
+									"variable": [
+										{
+											"key": "attachmentId"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"Deleted\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Failed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Deleted\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
+						}
+					]
+				},
+				{
+					"name": "Purge",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{sender_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "text/plain"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/attachment/{{attachmentId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"attachment",
+								"{{attachmentId}}"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"attachment",
+										":attachmentId"
+									],
+									"variable": [
+										{
+											"key": "attachmentId"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+						}
+					]
+				}
+			]
 		}
 	],
 	"event": [
@@ -2409,37 +1937,51 @@
 	],
 	"variable": [
 		{
-			"key": "attachmentId",
-			"value": ""
-		},
-		{
 			"key": "baseUrl",
 			"value": "https://platform.tt02.altinn.no"
-		},
-		{
-			"key": "correspondenceId",
-			"value": "",
-			"type": "string"
-		},
-		{
-			"key": "client_id",
-			"value": "Your Maskinporten \"Integrasjons-ID\" (from https://sjolvbetjening.samarbeid.digdir.no/integrations)",
-			"type": "string"
-		},
-		{
-			"key": "client_kid",
-			"value": "Your Maskinporten client key kid. Can also be found in the JWK.",
-			"type": "string"
-		},
-		{
-			"key": "client_jwk",
-			"value": "Input your Maskinporten JWK here. Should be on the form: \n{\n        \"p\": \"....\",\n        \"kty\": \"RSA\",\n        \"q\": \"....\",\n        \"d\": \"...\",\n        \"e\": \"AQAB\",\n        \"use\": \"sig\",\n        \"kid\": \"client_kid\",\n        \"qi\": \"....\",\n        \"dp\": \"...\",\n        \"alg\": \"RS256\",\n        \"dq\": \"....\",\n        \"n\": \"....\"\n    }",
-			"type": "string"
 		},
 		{
 			"key": "resource_id",
 			"value": "dagl-correspondence",
 			"type": "string"
+		},
+		{
+			"key": "test_tools_username",
+			"value": "Altinnpedia or contact us@#produkt-melding",
+			"type": "string"
+		},
+		{
+			"key": "test_tools_password",
+			"value": "Altinnpedia or contact us@#produkt-melding",
+			"type": "string"
+		},
+		{
+			"key": "senderSsn",
+			"value": "Go to https://testdata.skatteetaten.no to find test data. Person should be dagl/\"daglig leder\").",
+			"type": "string"
+		},
+		{
+			"key": "senderOrgNo",
+			"value": "Go to https://testdata.skatteetaten.no to find test data. Person should be dagl/\"daglig leder\").",
+			"type": "string"
+		},
+		{
+			"key": "recipientSsn",
+			"value": "Go to https://testdata.skatteetaten.no to find test data. Person should be dagl/\"daglig leder\").",
+			"type": "string"
+		},
+		{
+			"key": "recipientOrgNo",
+			"value": "Go to https://testdata.skatteetaten.no to find test data. Person should be dagl/\"daglig leder\").",
+			"type": "string"
+		},
+		{
+			"key": "attachmentId",
+			"value": ""
+		},
+		{
+			"key": "correspondenceId",
+			"value": ""
 		}
 	]
 }


### PR DESCRIPTION
## Description
<img width="236" alt="image" src="https://github.com/user-attachments/assets/abda4b96-f597-479c-b5fe-fcd4896aa78c">

Re-organized the requests to minimize nesting. Less clicks needed.
Removed requests to other API's. These functions (ResourceRegistry etc) are now available in GUI.
Changed to use basic authentication (username:password) for the test tokens instead of a Maskinporten integration. The credentials can be found here https://pedia.altinn.cloud/altinn-2/testing/tools/altinntokengenerator/ .

We now use testdata from Tenor to make it possible to test across team boundaries
https://testdata.skatteetaten.no/
Find a company here with a daglig leder and fill out the Postman variables.
(can also just go to af.tt.altinn.no/TestId/"Hent tilfeldig daglig leder")

## Related Issue(s)
- #281 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
