### PR TITLE
Fixes from testing new Postman collection

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/InitializeCorrespondenceFactory.cs
@@ -72,7 +72,7 @@ internal static class InitializeCorrespondenceFactory
             IsReservable = true
         },
         Recipients = new List<string>(){
-            "0192:986252931",
+            "0192:991825827",
             "0192:986252932",
             "0192:986252933"
         },

--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -3,7 +3,7 @@
 		"_postman_id": "2f063075-488c-4b14-8616-76e6f4a7ffef",
 		"name": "Altinn.Correspondence.API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "7106668"
+		"_exporter_id": "34552244"
 	},
 	"item": [
 		{
@@ -1972,6 +1972,11 @@
 		{
 			"key": "correspondenceId",
 			"value": ""
+		},
+		{
+			"key": "local_testing",
+			"value": "http://localhost:5096",
+			"type": "string"
 		}
 	]
 }

--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -3,7 +3,7 @@
 		"_postman_id": "2f063075-488c-4b14-8616-76e6f4a7ffef",
 		"name": "Altinn.Correspondence.API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "34552244"
+		"_exporter_id": "7106668"
 	},
 	"item": [
 		{
@@ -1382,7 +1382,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{baseUrl}}/correspondence/api/v1/correspondence?from=2024-02-02T13:31:28.290518&to=2025-08-29T13:31:28.290518&offset=0&limit=30&status=2&resourceId={{resource_id}}",
+							"raw": "{{baseUrl}}/correspondence/api/v1/correspondence?from=2024-02-02T13:31:28.290518&to=2025-08-29T13:31:28.290518&offset=0&limit=30&status=2&resourceId={{resource_id}}&role=RecipientAndSender",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -1416,6 +1416,10 @@
 								{
 									"key": "resourceId",
 									"value": "{{resource_id}}"
+								},
+								{
+									"key": "role",
+									"value": "RecipientAndSender"
 								}
 							]
 						}
@@ -1987,11 +1991,6 @@
 		{
 			"key": "correspondenceId",
 			"value": ""
-		},
-		{
-			"key": "local_testing",
-			"value": "http://localhost:5096",
-			"type": "string"
 		}
 	]
 }

--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -198,73 +198,6 @@
 					"name": "actions",
 					"item": [
 						{
-							"name": "Download Attachment",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{recipient_token}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "GET",
-								"header": [],
-								"url": {
-									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/attachment/{{attachmentId}}/download",
-									"host": [
-										"{{baseUrl}}"
-									],
-									"path": [
-										"correspondence",
-										"api",
-										"v1",
-										"correspondence",
-										"{{correspondenceId}}",
-										"attachment",
-										"{{attachmentId}}",
-										"download"
-									]
-								}
-							},
-							"response": [
-								{
-									"name": "Success",
-									"originalRequest": {
-										"method": "GET",
-										"header": [],
-										"url": {
-											"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/download",
-											"host": [
-												"{{baseUrl}}"
-											],
-											"path": [
-												"correspondence",
-												"api",
-												"v1",
-												"attachment",
-												":attachmentId",
-												"download"
-											],
-											"variable": [
-												{
-													"key": "attachmentId"
-												}
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "text",
-									"header": [],
-									"cookie": [],
-									"body": ""
-								}
-							]
-						},
-						{
 							"name": "Mark As Read",
 							"request": {
 								"auth": {
@@ -669,6 +602,73 @@
 									],
 									"cookie": [],
 									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Download attachment",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{recipient_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/attachment/{{attachmentId}}/download",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"{{correspondenceId}}",
+										"attachment",
+										"{{attachmentId}}",
+										"download"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/download",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"correspondence",
+												"api",
+												"v1",
+												"attachment",
+												":attachmentId",
+												"download"
+											],
+											"variable": [
+												{
+													"key": "attachmentId"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": [],
+									"body": ""
 								}
 							]
 						},
@@ -1637,6 +1637,98 @@
 								"attachment",
 								"{{attachmentId}}",
 								"upload"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/upload",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"attachment",
+										":attachmentId",
+										"upload"
+									],
+									"variable": [
+										{
+											"key": "attachmentId"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Download attachment",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"content-type": true
+						},
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{sender_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/octet-stream"
+							}
+						],
+						"body": {
+							"mode": "file",
+							"file": {
+								"src": "postman-cloud:///1ef7ccd7-bbc9-40b0-b540-3c47a5226c58"
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/correspondence/api/v1/attachment/{{attachmentId}}/download",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"correspondence",
+								"api",
+								"v1",
+								"attachment",
+								"{{attachmentId}}",
+								"download"
 							]
 						}
 					},

--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -158,12 +158,12 @@
 				"basic": [
 					{
 						"key": "username",
-						"value": "autotest",
+						"value": "{{test_tools_username}}",
 						"type": "string"
 					},
 					{
 						"key": "password",
-						"value": "altinn8900bnn",
+						"value": "{{test_tools_password}}",
 						"type": "string"
 					}
 				]
@@ -198,7 +198,7 @@
 					"name": "actions",
 					"item": [
 						{
-							"name": "Archive",
+							"name": "Download Attachment",
 							"request": {
 								"auth": {
 									"type": "bearer",
@@ -210,29 +210,10 @@
 										}
 									]
 								},
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "Accept",
-										"value": "text/plain"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
-									"options": {
-										"raw": {
-											"headerFamily": "json",
-											"language": "json"
-										}
-									}
-								},
+								"method": "GET",
+								"header": [],
 								"url": {
-									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/archive",
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/attachment/{{attachmentId}}/download",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -242,7 +223,9 @@
 										"v1",
 										"correspondence",
 										"{{correspondenceId}}",
-										"archive"
+										"attachment",
+										"{{attachmentId}}",
+										"download"
 									]
 								}
 							},
@@ -250,29 +233,10 @@
 								{
 									"name": "Success",
 									"originalRequest": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "Accept",
-												"value": "text/plain"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
-											"options": {
-												"raw": {
-													"headerFamily": "json",
-													"language": "json"
-												}
-											}
-										},
+										"method": "GET",
+										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
+											"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/download",
 											"host": [
 												"{{baseUrl}}"
 											],
@@ -280,22 +244,23 @@
 												"correspondence",
 												"api",
 												"v1",
-												"correspondence",
-												"upload"
+												"attachment",
+												":attachmentId",
+												"download"
+											],
+											"variable": [
+												{
+													"key": "attachmentId"
+												}
 											]
 										}
 									},
 									"status": "OK",
 									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Content-Type",
-											"value": "application/json"
-										}
-									],
+									"_postman_previewlanguage": "text",
+									"header": [],
 									"cookie": [],
-									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+									"body": ""
 								}
 							]
 						},
@@ -345,188 +310,6 @@
 										"correspondence",
 										"{{correspondenceId}}",
 										"markasread"
-									]
-								}
-							},
-							"response": [
-								{
-									"name": "Success",
-									"originalRequest": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "Accept",
-												"value": "text/plain"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
-											"options": {
-												"raw": {
-													"headerFamily": "json",
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
-											"host": [
-												"{{baseUrl}}"
-											],
-											"path": [
-												"correspondence",
-												"api",
-												"v1",
-												"correspondence",
-												"upload"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Content-Type",
-											"value": "application/json"
-										}
-									],
-									"cookie": [],
-									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
-								}
-							]
-						},
-						{
-							"name": "Purge",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{recipient_token}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "Accept",
-										"value": "text/plain"
-									}
-								],
-								"url": {
-									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/purge",
-									"host": [
-										"{{baseUrl}}"
-									],
-									"path": [
-										"correspondence",
-										"api",
-										"v1",
-										"correspondence",
-										"{{correspondenceId}}",
-										"purge"
-									]
-								}
-							},
-							"response": [
-								{
-									"name": "Success",
-									"originalRequest": {
-										"method": "GET",
-										"header": [
-											{
-												"key": "Accept",
-												"value": "text/plain"
-											}
-										],
-										"url": {
-											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/:correspondenceId/details",
-											"host": [
-												"{{baseUrl}}"
-											],
-											"path": [
-												"correspondence",
-												"api",
-												"v1",
-												"correspondence",
-												":correspondenceId",
-												"details"
-											],
-											"variable": [
-												{
-													"key": "correspondenceId"
-												}
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Content-Type",
-											"value": "application/json"
-										}
-									],
-									"cookie": [],
-									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"9585:149785773\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"NorwegianNO\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnAppInstance\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    }\n  ],\n  \"propertyList\": {\n    \"Excepteur36a\": \"<string>\",\n    \"officiaaf1\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Email\",\n      \"created\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Sms\",\n      \"created\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Archived\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Confirmed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Archived\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ],\n  \"notificationStatusHistory\": [\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
-								}
-							]
-						},
-						{
-							"name": "Confirm",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{recipient_token}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "Accept",
-										"value": "text/plain"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
-									"options": {
-										"raw": {
-											"headerFamily": "json",
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/confirm",
-									"host": [
-										"{{baseUrl}}"
-									],
-									"path": [
-										"correspondence",
-										"api",
-										"v1",
-										"correspondence",
-										"{{correspondenceId}}",
-										"confirm"
 									]
 								}
 							},
@@ -686,7 +469,7 @@
 							]
 						},
 						{
-							"name": "Download Attachment",
+							"name": "Confirm",
 							"request": {
 								"auth": {
 									"type": "bearer",
@@ -698,10 +481,29 @@
 										}
 									]
 								},
-								"method": "GET",
-								"header": [],
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
 								"url": {
-									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/attachment/{{attachmentId}}/download",
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/confirm",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -711,9 +513,197 @@
 										"v1",
 										"correspondence",
 										"{{correspondenceId}}",
-										"attachment",
-										"{{attachmentId}}",
-										"download"
+										"confirm"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "text/plain"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"correspondence",
+												"api",
+												"v1",
+												"correspondence",
+												"upload"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Archive",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{recipient_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"recipient\": \"1234\",\n  \"resourceId\": \"1234\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"1234\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"test asdf asdf>\",\n    \"messageSummary\": \"asdf asdfasdf\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"1\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"file\",\n        \"restrictionName\": \"1234\",\n        \"sendersReference\": \"1234\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": true,\n        \"checksum\": \"12345123412341234123412341234123\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"allowSystemDeleteAfter\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"2025-05-29T13:31:28.290518+00:00\"\n    }\n  ],\n  \"isReservable\": true\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/archive",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"{{correspondenceId}}",
+										"archive"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "text/plain"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"8536:031145332\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExisitingExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      },\n      {\n        \"dataLocationType\": \"ExistingCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogID\"\n    }\n  ],\n  \"propertyList\": {\n    \"deserunt_12\": \"<string>\",\n    \"culpa_852\": \"<string>\",\n    \"anim5\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/upload",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"correspondence",
+												"api",
+												"v1",
+												"correspondence",
+												"upload"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"0913:541697724\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"English\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"MachineReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Initialized\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"DialogPortenDialogElementID\"\n    }\n  ],\n  \"propertyList\": {\n    \"euf\": \"<string>\",\n    \"eu_34\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Published\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Purge",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{recipient_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "text/plain"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/{{correspondenceId}}/purge",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"correspondence",
+										"api",
+										"v1",
+										"correspondence",
+										"{{correspondenceId}}",
+										"purge"
 									]
 								}
 							},
@@ -722,9 +712,14 @@
 									"name": "Success",
 									"originalRequest": {
 										"method": "GET",
-										"header": [],
+										"header": [
+											{
+												"key": "Accept",
+												"value": "text/plain"
+											}
+										],
 										"url": {
-											"raw": "{{baseUrl}}/correspondence/api/v1/attachment/:attachmentId/download",
+											"raw": "{{baseUrl}}/correspondence/api/v1/correspondence/:correspondenceId/details",
 											"host": [
 												"{{baseUrl}}"
 											],
@@ -732,23 +727,28 @@
 												"correspondence",
 												"api",
 												"v1",
-												"attachment",
-												":attachmentId",
-												"download"
+												"correspondence",
+												":correspondenceId",
+												"details"
 											],
 											"variable": [
 												{
-													"key": "attachmentId"
+													"key": "correspondenceId"
 												}
 											]
 										}
 									},
 									"status": "OK",
 									"code": 200,
-									"_postman_previewlanguage": "text",
-									"header": [],
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
 									"cookie": [],
-									"body": ""
+									"body": "{\n  \"recipient\": \"<string>\",\n  \"resourceId\": \"<string>\",\n  \"sender\": \"9585:149785773\",\n  \"sendersReference\": \"<string>\",\n  \"content\": {\n    \"language\": \"NorwegianNO\",\n    \"messageTitle\": \"<string>\",\n    \"messageSummary\": \"<string>\",\n    \"attachments\": [\n      {\n        \"dataLocationType\": \"ExternalStorage\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      },\n      {\n        \"dataLocationType\": \"AltinnCorrespondenceAttachment\",\n        \"dataType\": \"<string>\",\n        \"intendedPresentation\": \"HumanReadable\",\n        \"name\": \"<string>\",\n        \"restrictionName\": \"<string>\",\n        \"sendersReference\": \"<string>\",\n        \"fileName\": \"<string>\",\n        \"isEncrypted\": \"<boolean>\",\n        \"checksum\": \"<string>\",\n        \"dataLocationUrl\": \"<string>\",\n        \"attachmentId\": \"<uuid>\",\n        \"createdDateTime\": \"<dateTime>\",\n        \"status\": \"Published\",\n        \"statusText\": \"<string>\",\n        \"StatusChangedDateTime\": \"<dateTime>\"\n      }\n    ]\n  },\n  \"visibleFrom\": \"<dateTime>\",\n  \"allowSystemDeleteAfter\": \"<dateTime>\",\n  \"dueDateTime\": \"<dateTime>\",\n  \"externalReferences\": [\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnAppInstance\"\n    },\n    {\n      \"referenceValue\": \"<string>\",\n      \"referenceType\": \"AltinnBrokerFileTransfer\"\n    }\n  ],\n  \"propertyList\": {\n    \"Excepteur36a\": \"<string>\",\n    \"officiaaf1\": \"<string>\"\n  },\n  \"replyOptions\": [\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    },\n    {\n      \"linkURL\": \"<string>\",\n      \"linkText\": \"<string>\"\n    }\n  ],\n  \"notifications\": [\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Email\",\n      \"created\": \"<dateTime>\"\n    },\n    {\n      \"notificationTemplate\": \"<string>\",\n      \"customTextToken\": \"<string>\",\n      \"sendersReference\": \"<string>\",\n      \"requestedSendTime\": \"<dateTime>\",\n      \"notificationId\": \"<uuid>\",\n      \"notificationChannel\": \"Sms\",\n      \"created\": \"<dateTime>\"\n    }\n  ],\n  \"isReservable\": \"<boolean>\",\n  \"correspondenceId\": \"<uuid>\",\n  \"created\": \"<dateTime>\",\n  \"status\": \"Archived\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Confirmed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Archived\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ],\n  \"notificationStatusHistory\": [\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"<string>\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
 								}
 							]
 						}
@@ -795,7 +795,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"Correspondence\": {\n        \"resourceId\": \"{{resource_id}}\",\n        \"sender\": \"0192:{{senderOrgNo}}\",\n        \"sendersReference\": \"1\",\n        \"content\": {\n        \"language\": \"nb\",\n        \"messageTitle\": \"Meldingstittel\",\n        \"messageSummary\": \"Ett sammendrag for meldingen\",\n        \"messageBody\": \"# meldingsteksten. Som kan være plain text eller markdown \",\n        \"attachments\": [\n                {\n                \"dataType\": \"html\",\n                \"expirationTime\": \"2024-12-12\",\n                \"name\": \"1\",\n                \"restrictionName\": \"testFile23\",\n                \"sendersReference\": \"1234\",\n                \"fileName\": \"test-fil32e\",\n                \"isEncrypted\": false,\n                \"dataLocationUrl\": \"\"\n                }\n            ]\n        },\n        \"visibleFrom\": \"2024-09-28T12:44:28.290518+00:00\",\n        \"allowSystemDeleteAfter\": \"2025-08-29T13:31:28.290518+00:00\",\n        \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n        \"externalReferences\": [\n            {\n                \"referenceValue\": \"1\",\n                \"referenceType\": \"AltinnBrokerFileTransfer\"\n            }\n        ],\n        \"propertyList\": {\n            \"deserunt_12\": \"1\",\n            \"culpa_852\": \"2\",\n            \"anim5\": \"3\",\n            \"Æ*'1??`  \": \"asdfgklasjd\"\n        },\n        \"replyOptions\": [\n            {\n                \"linkURL\": \"www.test.no\",\n                \"linkText\": \"test\"\n            },\n            {\n                \"linkURL\": \"test.no\",\n                \"linkText\": \"test\"\n            }\n        ],\n        \"notification\":\n        {\n            \"notificationTemplate\": 0,\n            \"notificationChannel\": 3,\n            \"SendReminder\": true,\n            \"EmailBody\": \"Test av varsel\",\n            \"EmailSubject\": \"Dette er innholdet i ett varsel\",\n            \"SmsBody\": \"Dette er innholdet i ett testvarsel\",\n            \"ReminderEmailBody\": \"Dette er test av revarsling \",\n            \"ReminderEmailSubject\": \"Test av revarsel\",\n            \"ReminderSmsBody\": \"Dette er en test av revarslingl\"\n        },\n        \"isReservable\": true\n    },\n    \"Recipients\": [\n        \"0192:311116789\"\n    ],\n    \"existingAttachments\": []\n}",
+							"raw": "{\n    \"Correspondence\": {\n        \"resourceId\": \"{{resource_id}}\",\n        \"sender\": \"0192:{{senderOrgNo}}\",\n        \"sendersReference\": \"1\",\n        \"content\": {\n            \"language\": \"nb\",\n            \"messageTitle\": \"Meldingstittel\",\n            \"messageSummary\": \"Ett sammendrag for meldingen\",\n            \"messageBody\": \"# meldingsteksten. Som kan være plain text eller markdown \",\n            \"attachments\": [\n                {\n                    \"dataType\": \"html\",\n                    \"expirationTime\": \"2024-12-12\",\n                    \"name\": \"1\",\n                    \"restrictionName\": \"testFile23\",\n                    \"sendersReference\": \"1234\",\n                    \"fileName\": \"test-fil32e\",\n                    \"isEncrypted\": false,\n                    \"dataLocationUrl\": \"\"\n                }\n            ]\n        },\n        \"visibleFrom\": \"2024-09-28T12:44:28.290518+00:00\",\n        \"allowSystemDeleteAfter\": \"2025-08-29T13:31:28.290518+00:00\",\n        \"dueDateTime\": \"2025-05-29T13:31:28.290518+00:00\",\n        \"externalReferences\": [\n            {\n                \"referenceValue\": \"1\",\n                \"referenceType\": \"AltinnBrokerFileTransfer\"\n            }\n        ],\n        \"propertyList\": {\n            \"deserunt_12\": \"1\",\n            \"culpa_852\": \"2\",\n            \"anim5\": \"3\",\n            \"Æ*'1??`  \": \"asdfgklasjd\"\n        },\n        \"replyOptions\": [\n            {\n                \"linkURL\": \"www.test.no\",\n                \"linkText\": \"test\"\n            },\n            {\n                \"linkURL\": \"test.no\",\n                \"linkText\": \"test\"\n            }\n        ],\n        \"notification\": {\n            \"notificationTemplate\": 0,\n            \"notificationChannel\": 3,\n            \"SendReminder\": true,\n            \"EmailBody\": \"Test av varsel\",\n            \"EmailSubject\": \"Dette er innholdet i ett varsel\",\n            \"SmsBody\": \"Dette er innholdet i ett testvarsel\",\n            \"ReminderEmailBody\": \"Dette er test av revarsling \",\n            \"ReminderEmailSubject\": \"Test av revarsel\",\n            \"ReminderSmsBody\": \"Dette er en test av revarslingl\"\n        },\n        \"isReservable\": true\n    },\n    \"Recipients\": [\n        \"0192:{{recipientOrgNo}}\"\n    ],\n    \"existingAttachments\": []\n}",
 							"options": {
 								"raw": {
 									"headerFamily": "json",
@@ -870,6 +870,21 @@
 				},
 				{
 					"name": "Initialize and Upload",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var correspondence = pm.response.json()\r",
+									"pm.collectionVariables.set(\"correspondenceId\", correspondence.correspondenceIds[0]);\r",
+									"pm.collectionVariables.set(\"attachmentId\", correspondence.attachmentIds[0])\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
 					"request": {
 						"auth": {
 							"type": "bearer",
@@ -1502,7 +1517,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"dataType\": \"html\",\n  \"expirationTime\": \"2024-12-12\",\n  \"resourceId\": \"{{resource_id}}\",\n  \"name\": \"testFile\",\n  \"restrictionName\": \"testFile\",\n  \"sender\": \"0192:991825827\",\n  \"sendersReference\": \"1234\",\n  \"fileName\": \"test-file\",\n  \"isEncrypted\": false\n}",
+							"raw": "{\n  \"dataType\": \"html\",\n  \"expirationTime\": \"2024-12-12\",\n  \"resourceId\": \"{{resource_id}}\",\n  \"name\": \"testFile\",\n  \"restrictionName\": \"testFile\",\n  \"sender\": \"0192:{{senderOrgNo}}\",\n  \"sendersReference\": \"1234\",\n  \"fileName\": \"test-file\",\n  \"isEncrypted\": false\n}",
 							"options": {
 								"raw": {
 									"headerFamily": "json",
@@ -1603,7 +1618,7 @@
 						"body": {
 							"mode": "file",
 							"file": {
-								"src": ""
+								"src": "postman-cloud:///1ef7ccd7-bbc9-40b0-b540-3c47a5226c58"
 							}
 						},
 						"url": {
@@ -1947,22 +1962,22 @@
 		},
 		{
 			"key": "senderSsn",
-			"value": "Go to https://tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
+			"value": "Go to https://info.tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
 			"type": "string"
 		},
 		{
 			"key": "senderOrgNo",
-			"value": "Go to https://tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
+			"value": "Go to https://info.tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
 			"type": "string"
 		},
 		{
 			"key": "recipientSsn",
-			"value": "Go to https://tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
+			"value": "Go to https://info.tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
 			"type": "string"
 		},
 		{
 			"key": "recipientOrgNo",
-			"value": "Go to https://tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
+			"value": "Go to https://info.tt02.altinn.no/ and login to get test data. Person should be dagl/\"daglig leder\").",
 			"type": "string"
 		},
 		{

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -160,6 +160,7 @@ namespace Altinn.Correspondence.API.Controllers
             [FromQuery] DateTimeOffset? to,
             [FromServices] GetCorrespondencesHandler handler,
             [FromQuery] CorrespondenceStatusExt? status,
+            [FromQuery, RequiredEnum] CorrespondencesRoleType role,
             CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Get correspondences for receiver");
@@ -168,11 +169,11 @@ namespace Altinn.Correspondence.API.Controllers
             {
                 ResourceId = resourceId,
                 From = from,
+                To = to,
                 Limit = limit,
                 Offset = offset,
                 Status = status is null ? null : (CorrespondenceStatus)status,
-                To = to
-
+                Role = role,
             }, cancellationToken);
 
             return commandResult.Match(

--- a/src/Altinn.Correspondence.API/Models/RequiredEnumAttribute.cs
+++ b/src/Altinn.Correspondence.API/Models/RequiredEnumAttribute.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Correspondence.API.Models;
+public class RequiredEnumAttribute : ValidationAttribute
+{
+    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    {
+        if (value == null || !Enum.IsDefined(value.GetType(), value))
+        {
+            var fieldName = validationContext.DisplayName;
+            return new ValidationResult($"The {fieldName} field is required.");
+        }
+        return ValidationResult.Success;
+    }
+}

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
@@ -25,12 +25,10 @@ public class GetCorrespondencesHandler : IHandler<GetCorrespondencesRequest, Get
         {
             return Errors.NoAccessToResource;
         }
-
         if (request.Limit < 0 || request.Offset < 0)
         {
             return Errors.OffsetAndLimitIsNegative;
         }
-
         var limit = request.Limit == 0 ? 50 : request.Limit;
         DateTimeOffset? to = request.To != null ? ((DateTimeOffset)request.To).ToUniversalTime() : null;
         DateTimeOffset? from = request.From != null ? ((DateTimeOffset)request.From).ToUniversalTime() : null;
@@ -39,8 +37,7 @@ public class GetCorrespondencesHandler : IHandler<GetCorrespondencesRequest, Get
         {
             return Errors.CouldNotFindOrgNo;
         }
-        var correspondences = await _correspondenceRepository.GetCorrespondences(request.ResourceId, request.Offset, limit, from, to, request.Status, orgNo, cancellationToken);
-
+        var correspondences = await _correspondenceRepository.GetCorrespondences(request.ResourceId, request.Offset, limit, from, to, request.Status, orgNo, request.Role, cancellationToken);
         var response = new GetCorrespondencesResponse
         {
             Items = correspondences.Item1,

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesRequest.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesRequest.cs
@@ -14,4 +14,5 @@ public class GetCorrespondencesRequest
 
     public CorrespondenceStatus? Status { get; set; }
 
+    public required CorrespondencesRoleType Role { get; set; }
 }

--- a/src/Altinn.Correspondence.Core/Models/Enums/CorrespondencesRoleType.cs
+++ b/src/Altinn.Correspondence.Core/Models/Enums/CorrespondencesRoleType.cs
@@ -1,0 +1,21 @@
+namespace Altinn.Correspondence.Core.Models.Enums;
+/// <summary>
+/// Defines how to filter the correspondences returned by the GetCorrespondences endpoint
+/// </summary>
+public enum CorrespondencesRoleType
+{
+    /// <summary>
+    /// Only return the correspondences where the consumer is the recipient of the correspondence
+    /// </summary>
+    Recipient,
+
+    /// <summary>
+    /// Only return the correspondences where the consumer is the sender of the correspondence
+    /// </summary>
+    Sender,
+
+    /// <summary>
+    /// Only return the correspondences where the consumer is the recipient or sender of the correspondence
+    /// </summary>
+    RecipientAndSender,
+}

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -17,6 +17,7 @@ namespace Altinn.Correspondence.Core.Repositories
             DateTimeOffset? to,
             CorrespondenceStatus? status,
             string orgNo,
+            CorrespondencesRoleType role,
             CancellationToken cancellationToken);
 
         Task<CorrespondenceEntity?> GetCorrespondenceById(

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -1,37 +1,63 @@
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Altinn.Correspondence.Persistence.Helpers
 {
     public static class QueryExtensions
     {
-        public static IQueryable<CorrespondenceEntity> WithValidStatuses(this IQueryable<CorrespondenceEntity> query, CorrespondenceStatus? status, string orgNo)
+        public static IQueryable<CorrespondenceEntity> FilterBySenderOrRecipient(this IQueryable<CorrespondenceEntity> query, string orgNo, CorrespondencesRoleType role)
         {
-            var blacklistedStatuesSender = new List<CorrespondenceStatus?>
+            return role switch
+            {
+                CorrespondencesRoleType.RecipientAndSender => query.Where(c => c.Sender == orgNo || c.Recipient == orgNo),
+                CorrespondencesRoleType.Recipient => query.Where(c => c.Recipient == orgNo),
+                CorrespondencesRoleType.Sender => query.Where(c => c.Sender == orgNo),
+                _ => query.Where(c => false),
+            };
+        }
+
+        public static IQueryable<CorrespondenceEntity> FilterByStatus(this IQueryable<CorrespondenceEntity> query, CorrespondenceStatus? status, string orgNo, CorrespondencesRoleType role)
+        {
+            var blacklistSender = new List<CorrespondenceStatus?> // TODO: any missing? or should not be here?
             {
                 CorrespondenceStatus.Archived,
                 CorrespondenceStatus.PurgedByAltinn,
-                CorrespondenceStatus.PurgedByRecipient
+                CorrespondenceStatus.PurgedByRecipient,
             };
-            var blacklistedStatuesRecipient = new List<CorrespondenceStatus?>
+
+            var blacklistRecipient = new List<CorrespondenceStatus?> // TODO: any missing? or should not be here?
             {
                 CorrespondenceStatus.Initialized,
                 CorrespondenceStatus.ReadyForPublish,
-                CorrespondenceStatus.Archived,
                 CorrespondenceStatus.PurgedByAltinn,
-                CorrespondenceStatus.PurgedByRecipient
+                CorrespondenceStatus.PurgedByRecipient,
+                CorrespondenceStatus.Failed,
             };
-            if (status == null) // No status specified, return all except blacklisted
+
+            // Helper functions for common query patterns
+            IQueryable<CorrespondenceEntity> FilterForSender()
             {
-                return query.Where(correspondence => correspondence.Recipient.Contains(orgNo) ? // If org is a recipient
-                !blacklistedStatuesRecipient.Contains(correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status) : 
-                !blacklistedStatuesSender.Contains(correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status));
+                return query.Where(c => c.Sender == orgNo &&
+                    status.HasValue ?
+                    (!blacklistSender.Contains(status)) && status == c.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status :
+                    (!blacklistSender.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status)));
             }
-            else
+
+            IQueryable<CorrespondenceEntity> FilterForRecipient()
             {
-                return query
-                .Where(correspondence => correspondence.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status == status);
+                return query.Where(c => c.Recipient == orgNo &&
+                    status.HasValue ?
+                    (!blacklistRecipient.Contains(status)) && status == c.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status :
+                    (!blacklistRecipient.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status)));
             }
+            return role switch
+            {
+                CorrespondencesRoleType.Sender => FilterForSender(),
+                CorrespondencesRoleType.Recipient => FilterForRecipient(),
+                CorrespondencesRoleType.RecipientAndSender => FilterForSender().Union(FilterForRecipient()),
+                _ => throw new ArgumentException("Invalid CorrespondencesRoleType")
+            };
         }
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -31,14 +31,16 @@ namespace Altinn.Correspondence.Persistence.Repositories
             DateTimeOffset? to,
             CorrespondenceStatus? status,
             string orgNo,
+            CorrespondencesRoleType role,
             CancellationToken cancellationToken)
         {
             var correspondences = _context.Correspondences
                 .Where(c => c.ResourceId == resourceId)             // Correct id
                 .Where(c => from == null || c.VisibleFrom > from)   // From date filter
                 .Where(c => to == null || c.VisibleFrom < to)       // To date filter
+                .FilterBySenderOrRecipient(orgNo, role)             // Filter by role
+                .FilterByStatus(status, orgNo, role)                // Filter by status
                 .OrderByDescending(c => c.VisibleFrom)              // Sort by visibleFrom
-                .WithValidStatuses(status, orgNo)                   // Filter by status
                 .Select(c => c.Id);
 
             var totalItems = await correspondences.CountAsync(cancellationToken);


### PR DESCRIPTION
## Description
Lots of small errors. Non-parameterized values, missing post-request scripts, fixed url to Altinn TT02.

Most significantly, and debatable, changed order of operations:
<img width="174" alt="image" src="https://github.com/user-attachments/assets/f2a0b0aa-bd90-4f5b-8bb8-8acd217613da">

It used to be:

<img width="175" alt="image" src="https://github.com/user-attachments/assets/b32caa51-c20e-4a0d-bb60-96a375448528">

The idea is to group the actions more logically for what features they are related to (and secondary sorted by where in typical correspondence state flow they occur).

## Related Issue(s)
- #281 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
