### PR TITLE
Reduce RequestSendTime from 7 days to 1 hour for Notification Reminder when testing

### DIFF
--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -289,14 +289,16 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
             notifications.Add(new NotificationOrderRequest
             {
                 IgnoreReservation = correspondence.IgnoreReservation,
-                Recipients = new List<Recipient>{
-            new Recipient{
-                OrganizationNumber = orgNr,
-                NationalIdentityNumber = personNr
-            },
-        },
+                Recipients = new List<Recipient>
+                {
+                    new Recipient
+                    {
+                        OrganizationNumber = orgNr,
+                        NationalIdentityNumber = personNr
+                    },
+                },
                 ResourceId = correspondence.ResourceId,
-                RequestedSendTime = correspondence.RequestedPublishTime.UtcDateTime.AddDays(7),
+                RequestedSendTime = _hostEnvironment.IsProduction() ? correspondence.RequestedPublishTime.UtcDateTime.AddDays(7) : correspondence.RequestedPublishTime.UtcDateTime.AddHours(1),
                 ConditionEndpoint = CreateConditonEndpoint(correspondence.Id.ToString()),
                 SendersReference = correspondence.SendersReference,
                 NotificationChannel = notification.ReminderNotificationChannel ?? notification.NotificationChannel,


### PR DESCRIPTION
Reduce wait for reminder notification when not in production

## Description
One hour added instead of 7 days

## Related Issue(s)
- #322 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

