### PR TITLE
add more info during failed cancellation of notification

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -9,6 +9,7 @@ using Altinn.Correspondence.Tests.Factories;
 using Altinn.Correspondence.Tests.Helpers;
 using Hangfire;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Slack.Webhooks;
@@ -1333,8 +1334,9 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var altinnNotificationServiceMock = new Mock<IAltinnNotificationService>();
         var slackClientMock = new Mock<ISlackClient>();
         var backgroundJobClient = new Mock<IBackgroundJobClient>();
+        var hostEnvironment = new Mock<IHostEnvironment>();
 
-        var cancelNotificationHandler = new CancelNotificationHandler(loggerMock.Object, altinnNotificationServiceMock.Object, slackClientMock.Object, backgroundJobClient.Object);
+        var cancelNotificationHandler = new CancelNotificationHandler(loggerMock.Object, altinnNotificationServiceMock.Object, slackClientMock.Object, backgroundJobClient.Object, hostEnvironment.Object);
         var notificationEntities = correspondence.Notifications;
         notificationEntities.ForEach(notification =>
         {
@@ -1345,7 +1347,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         // Act
         try
         {
-            await cancelNotificationHandler.CancelNotification(notificationEntities, retryAttempts: 10, default);
+            await cancelNotificationHandler.CancelNotification(Guid.Empty, notificationEntities, retryAttempts: 10, default);
         }
         catch
         {

--- a/src/Altinn.Correspondence.Application/CancelNotification/CancelNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Application/CancelNotification/CancelNotificationHandler.cs
@@ -6,6 +6,7 @@ using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
 using Hangfire;
 using Hangfire.Server;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Slack.Webhooks;
 
@@ -17,7 +18,8 @@ namespace Altinn.Correspondence.Application.CancelNotification
         private readonly ILogger<CancelNotificationHandler> _logger;
         private readonly IAltinnNotificationService _altinnNotificationService;
         private readonly ISlackClient _slackClient;
-        private readonly IBackgroundJobClient _backgroundJobClient; 
+        private readonly IBackgroundJobClient _backgroundJobClient;
+        private readonly IHostEnvironment _hostEnvironment;
         private const string TestChannel = "#test-varslinger";
         private const string RetryCountKey = "RetryCount";
         private const int MaxRetries = 10;
@@ -25,23 +27,27 @@ namespace Altinn.Correspondence.Application.CancelNotification
             ILogger<CancelNotificationHandler> logger,
             IAltinnNotificationService altinnNotificationService,
             ISlackClient slackClient,
-            IBackgroundJobClient backgroundJobClient)
+            IBackgroundJobClient backgroundJobClient,
+            IHostEnvironment hostEnvironment)
         {
             _logger = logger;
             _altinnNotificationService = altinnNotificationService;
             _slackClient = slackClient;
             _backgroundJobClient = backgroundJobClient;
+            _hostEnvironment = hostEnvironment;
         }
 
         [AutomaticRetry(Attempts = MaxRetries)]
-        public async Task Process(PerformContext context, List<CorrespondenceNotificationEntity> notificationEntities, CancellationToken cancellationToken = default)
+        public async Task Process(PerformContext context, Guid correspondenceId, List<CorrespondenceNotificationEntity> notificationEntities, CancellationToken cancellationToken = default)
         {
             var retryAttempts = context.GetJobParameter<int>(RetryCountKey);
             _logger.LogInformation("Cancelling notifications for purged correspondence. Retry attempt: {retryAttempts}", retryAttempts);
-            await CancelNotification(notificationEntities, retryAttempts, cancellationToken);
+            await CancelNotification(correspondenceId, notificationEntities, retryAttempts, cancellationToken);
         }
-        internal async Task CancelNotification(List<CorrespondenceNotificationEntity> notificationEntities, int retryAttempts, CancellationToken cancellationToken)
+        internal async Task CancelNotification(Guid correspondenceId, List<CorrespondenceNotificationEntity> notificationEntities, int retryAttempts, CancellationToken cancellationToken)
         {
+            var env = _hostEnvironment.EnvironmentName;
+            var error = $"Error while attempting to cancel notifications for correspondenceId: {correspondenceId} in environment: {env}.";
             foreach (var notification in notificationEntities)
             {
                 if (notification.RequestedSendTime <= DateTimeOffset.UtcNow) continue; // Notification has already been sent
@@ -49,18 +55,19 @@ namespace Altinn.Correspondence.Application.CancelNotification
                 string? notificationOrderId = notification.NotificationOrderId?.ToString();
 
                 if (string.IsNullOrWhiteSpace(notificationOrderId))
-                    {
-                        var error = $"Error while cancelling notification. NotificationOrderId is null for notificationId: {notification.Id}";
-                        if (retryAttempts == MaxRetries) SendSlackNotificationWithMessage(error);
-                        throw new Exception(error);
-                    }
+                {
+                    error += $"NotificationOrderId is null for notificationId: {notification.Id}";
+                    if (retryAttempts == MaxRetries) SendSlackNotificationWithMessage(error);
+                    throw new Exception(error);
+                }
                 bool isCancellationSuccessful = await _altinnNotificationService.CancelNotification(notificationOrderId, cancellationToken);
                 if (!isCancellationSuccessful)
                 {
-                    var error = $"Error while cancelling notification. Failed to cancel notification for notificationId: {notification.Id}";
+                    error += $"Cancellation unsuccessful for notificationId: {notification.Id}";
                     if (retryAttempts == MaxRetries) SendSlackNotificationWithMessage(error);
                     throw new Exception(error);
-                } else
+                }
+                else
                 {
                     _backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(notification.CorrespondenceId, DialogportenActorType.ServiceOwner, Core.Dialogporten.Mappers.DialogportenTextType.NotificationOrderCancelled));
                 }

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -78,7 +78,7 @@ public class PublishCorrespondenceHandler : IHandler<Guid, Task>
             eventType = AltinnEventType.CorrespondencePublishFailed;
             foreach (var notification in correspondence.Notifications)
             {
-                _backgroundJobClient.Enqueue<CancelNotificationHandler>(handler => handler.Process(null, correspondence.Notifications, cancellationToken));
+                _backgroundJobClient.Enqueue<CancelNotificationHandler>(handler => handler.Process(null, correspondenceId, correspondence.Notifications, cancellationToken));
             }
         }
         else

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -99,7 +99,7 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
         await _correspondenceStatusRepository.AddCorrespondenceStatus(newStatus, cancellationToken);
         await CheckAndPurgeAttachments(correspondenceId, cancellationToken);
         _backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(correspondenceId, newStatus.Status == CorrespondenceStatus.PurgedByRecipient ? DialogportenActorType.Recipient : DialogportenActorType.Sender, Core.Dialogporten.Mappers.DialogportenTextType.CorrespondencePurged, (newStatus.Status == CorrespondenceStatus.PurgedByRecipient ? "mottaker" : "avsender")));
-        _backgroundJobClient.Enqueue<CancelNotificationHandler>(handler => handler.Process(null, correspondence.Notifications, cancellationToken));
+        _backgroundJobClient.Enqueue<CancelNotificationHandler>(handler => handler.Process(null, correspondenceId, correspondence.Notifications, cancellationToken));
         return correspondenceId;
     }
 


### PR DESCRIPTION
Add more information about environment and correspondence in slack message.

## Description
Previously, only the notificationId was included in the slack message sent out from the hangfire job. After seeing it triggered first time, it was evident that more information about the error was beneficial for debugging purposes. As such, information about the environment which the error occured in is printed. The correspondenceId is also included. 

## Related Issue(s)
- #341 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
