### PR TITLE
Wrong parameter used for publishing event.

### DIFF
--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -15,14 +15,12 @@ public class MalwareScanResultHandler(
     IAttachmentRepository attachmentRepository,
     IAttachmentStatusRepository attachmentStatusRepository,
     IEventBus eventBus,
-    UploadHelper uploadHelper,
     ICorrespondenceRepository correspondenceRepository,
     ICorrespondenceStatusRepository correspondenceStatusRepository,
     ILogger<MalwareScanResultHandler> logger) : IHandler<ScanResultData, Task>
 {
     private readonly IAttachmentRepository _attachmentRepository = attachmentRepository;
     private readonly IAttachmentStatusRepository _attachmentStatusRepository = attachmentStatusRepository;
-    private readonly UploadHelper _uploadHelper = uploadHelper;
     private readonly ILogger<MalwareScanResultHandler> _logger = logger;
     private readonly IEventBus _eventBus = eventBus;
 
@@ -52,7 +50,7 @@ public class MalwareScanResultHandler(
                 StatusChanged = DateTimeOffset.UtcNow,
                 StatusText = AttachmentStatus.Published.ToString()
             }, cancellationToken);
-            await _eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.SendersReference, cancellationToken);
+            await _eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.Sender, cancellationToken);
             _logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
             await CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, cancellationToken);
             return Task.CompletedTask;
@@ -67,7 +65,7 @@ public class MalwareScanResultHandler(
                 StatusChanged = DateTimeOffset.UtcNow,
                 StatusText = $"Malware scan failed: {data.ScanResultType}: {data.ScanResultDetails}"
             }, cancellationToken);
-            await _eventBus.Publish(AltinnEventType.AttachmentUploadFailed, attachment.ResourceId, attachmentIdFromBlobUri, "Malware scan", attachment.SendersReference, cancellationToken);
+            await _eventBus.Publish(AltinnEventType.AttachmentUploadFailed, attachment.ResourceId, attachmentIdFromBlobUri, "Malware scan", attachment.Sender, cancellationToken);
             _logger.LogWarning("Malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
             return Task.CompletedTask;
         }


### PR DESCRIPTION
## Description
 SendersReference is a free-text field for the sender, not the sender itself.

## Related Issue(s)
- #315 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
