### PR TITLE
Rettet feil i MalwareScan

### DIFF
--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -94,7 +94,7 @@ public class MalwareScanResultHandler(
                     CorrespondenceId = correspondenceId,
                     Status = CorrespondenceStatus.ReadyForPublish,
                     StatusChanged = DateTime.UtcNow,
-                    StatusText = CorrespondenceStatus.Published.ToString()
+                    StatusText = CorrespondenceStatus.ReadyForPublish.ToString()
                 }
             );
         }


### PR DESCRIPTION
## Description
The field StatusText is set with value "Published" when it should be "ReadyForPublish"

## Related Issue(s)
- #354 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated status text for correspondence after publishing attachments to improve clarity.
	- Enhanced error logging for missing attachments to provide better insights.

These changes aim to improve the user experience by ensuring accurate status updates and clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->