### PR TITLE
Use correct base url in callbacks

### DIFF
--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -71,9 +71,9 @@ var containerAppEnvVars = [
     value: 'true'
   }
   { name: 'MaskinportenSettings__EncodedJwk', secretRef: 'maskinporten-jwk' }
+  { name: 'GeneralSettings__CorrespondenceBaseUrl', value: correspondenceBaseUrl }
   { name: 'GeneralSettings__SlackUrl', secretRef: 'slack-url' }
   { name: 'DialogportenSettings__Issuer', value: dialogportenIssuer }
-  { name: 'DialogportenSettings__CorrespondenceBaseUrl', value: correspondenceBaseUrl }
   { name: 'IdportenSettings__Issuer', value: idportenIssuer }
   { name: 'IdportenSettings__ClientId', secretRef: 'idporten-client-id' }
   { name: 'IdportenSettings__ClientSecret', secretRef: 'idporten-client-secret' }

--- a/src/Altinn.Correspondence.API/Auth/CascadeAuthenticationHandler.cs
+++ b/src/Altinn.Correspondence.API/Auth/CascadeAuthenticationHandler.cs
@@ -16,7 +16,7 @@ public class CascadeAuthenticationHandler : AuthenticationHandler<Authentication
     private readonly IAuthenticationSchemeProvider _schemeProvider;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IDistributedCache _cache;
-    private readonly DialogportenSettings _dialogportenSettings;
+    private readonly GeneralSettings _generalSettings;
     private readonly IdportenTokenValidator _tokenValidator;
 
     public CascadeAuthenticationHandler(
@@ -26,13 +26,13 @@ public class CascadeAuthenticationHandler : AuthenticationHandler<Authentication
         ISystemClock clock,
         IAuthenticationSchemeProvider schemeProvider,
         IHttpContextAccessor httpContextAccessor,
-        IOptions<DialogportenSettings> dialogportenSettings,
+        IOptions<GeneralSettings> generalSettings,
         IdportenTokenValidator tokenValidator,
         IDistributedCache cache)
         : base(options, logger, encoder, clock)
     {
         _httpContextAccessor = httpContextAccessor;
-        _dialogportenSettings = dialogportenSettings.Value;
+        _generalSettings = generalSettings.Value;
         _schemeProvider = schemeProvider;
         _tokenValidator = tokenValidator;
         _cache = cache;
@@ -109,7 +109,7 @@ public class CascadeAuthenticationHandler : AuthenticationHandler<Authentication
         });
 
         var redirectUrl = properties?.Items["endpoint"] ?? throw new SecurityTokenMalformedException("Should have had an endpoint");
-        redirectUrl = AppendSessionToUrl($"{_dialogportenSettings.CorrespondenceBaseUrl.TrimEnd('/')}{redirectUrl}", sessionId);
+        redirectUrl = AppendSessionToUrl($"{_generalSettings.CorrespondenceBaseUrl.TrimEnd('/')}{redirectUrl}", sessionId);
         Response.Redirect(redirectUrl);
     }
 

--- a/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
@@ -22,6 +22,8 @@ namespace Altinn.Correspondence.API.Auth
             config.GetSection(nameof(IdportenSettings)).Bind(idPortenSettings);
             var dialogportenSettings = new DialogportenSettings();
             config.GetSection(nameof(DialogportenSettings)).Bind(dialogportenSettings);
+            var generalSettings = new GeneralSettings();
+            config.GetSection(nameof(GeneralSettings)).Bind(generalSettings);
             services.AddDistributedMemoryCache();
             services.AddTransient<IdportenTokenValidator>();
             services
@@ -100,7 +102,7 @@ namespace Altinn.Correspondence.API.Auth
                     {
                         OnRedirectToIdentityProvider = context =>
                         {
-                            context.ProtocolMessage.RedirectUri = $"{dialogportenSettings.CorrespondenceBaseUrl.TrimEnd('/')}{options.CallbackPath}";
+                            context.ProtocolMessage.RedirectUri = $"{generalSettings.CorrespondenceBaseUrl.TrimEnd('/')}{options.CallbackPath}";
                             return Task.CompletedTask;
                         },
                         OnTokenValidated = async context =>
@@ -112,7 +114,7 @@ namespace Altinn.Correspondence.API.Auth
                                 {
                                     AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5)
                                 });
-                            context.Properties.RedirectUri = CascadeAuthenticationHandler.AppendSessionToUrl($"{dialogportenSettings.CorrespondenceBaseUrl.TrimEnd('/')}{context.Properties.RedirectUri}", sessionId);
+                            context.Properties.RedirectUri = CascadeAuthenticationHandler.AppendSessionToUrl($"{generalSettings.CorrespondenceBaseUrl.TrimEnd('/')}{context.Properties.RedirectUri}", sessionId);
                         }
                     };
                 });

--- a/src/Altinn.Correspondence.API/appsettings.Development.json
+++ b/src/Altinn.Correspondence.API/appsettings.Development.json
@@ -24,8 +24,7 @@
     "ExhangeToAltinnToken": true
   },
   "DialogportenSettings": {
-    "Issuer": "https://platform.tt02.altinn.no/dialogporten/api/v1",
-    "CorrespondenceBaseUrl": "https://localhost:7241/"
+    "Issuer": "https://platform.tt02.altinn.no/dialogporten/api/v1"
   },
   "IdportenSettings": {
     "Issuer": "https://test.idporten.no",
@@ -33,6 +32,7 @@
     "ClientSecret": "clientSecret"
   },
   "GeneralSettings": {
-    "SlackUrl": ""
+    "SlackUrl": "",
+    "CorrespondenceBaseUrl": "https://localhost:7241/"
   }
 }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -20,7 +20,6 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
 {
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
     private readonly IAltinnNotificationService _altinnNotificationService;
-    private readonly IOptions<AltinnOptions> _altinnOptions;
     private readonly ICorrespondenceRepository _correspondenceRepository;
     private readonly ICorrespondenceNotificationRepository _correspondenceNotificationRepository;
     private readonly INotificationTemplateRepository _notificationTemplateRepository;
@@ -30,10 +29,10 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
     private readonly IDialogportenService _dialogportenService;
     private readonly UserClaimsHelper _userClaimsHelper;
     private readonly IHostEnvironment _hostEnvironment;
+    private readonly GeneralSettings _generalSettings;
 
-    public InitializeCorrespondencesHandler(IOptions<AltinnOptions> altinnOptions, InitializeCorrespondenceHelper initializeCorrespondenceHelper, IAltinnAuthorizationService altinnAuthorizationService, IAltinnNotificationService altinnNotificationService, ICorrespondenceRepository correspondenceRepository, ICorrespondenceNotificationRepository correspondenceNotificationRepository, INotificationTemplateRepository notificationTemplateRepository, IEventBus eventBus, IBackgroundJobClient backgroundJobClient, UserClaimsHelper userClaimsHelper, IDialogportenService dialogportenService, IHostEnvironment hostEnvironment)
+    public InitializeCorrespondencesHandler(InitializeCorrespondenceHelper initializeCorrespondenceHelper, IAltinnAuthorizationService altinnAuthorizationService, IAltinnNotificationService altinnNotificationService, ICorrespondenceRepository correspondenceRepository, ICorrespondenceNotificationRepository correspondenceNotificationRepository, INotificationTemplateRepository notificationTemplateRepository, IEventBus eventBus, IBackgroundJobClient backgroundJobClient, UserClaimsHelper userClaimsHelper, IDialogportenService dialogportenService, IHostEnvironment hostEnvironment, IOptions<GeneralSettings> generalSettings)
     {
-        _altinnOptions = altinnOptions;
         _initializeCorrespondenceHelper = initializeCorrespondenceHelper;
         _altinnAuthorizationService = altinnAuthorizationService;
         _altinnNotificationService = altinnNotificationService;
@@ -45,6 +44,7 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
         _dialogportenService = dialogportenService;
         _userClaimsHelper = userClaimsHelper;
         _hostEnvironment = hostEnvironment;
+        _generalSettings = generalSettings.Value;
     }
 
     public async Task<OneOf<InitializeCorrespondencesResponse, Error>> Process(InitializeCorrespondencesRequest request, CancellationToken cancellationToken)
@@ -364,7 +364,7 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
     }
     private Uri CreateConditonEndpoint(string correspondenceId)
     {
-        return new Uri($"{_altinnOptions.Value.PlatformGatewayUrl}correspondence/api/v1/correspondence/{correspondenceId}/notification/check");
+        return new Uri($"{_generalSettings.CorrespondenceBaseUrl.TrimEnd('/')}/correspondence/api/v1/correspondence/{correspondenceId}/notification/check");
     }
     private string CreateMessageFromToken(string message, string? token = "")
     {

--- a/src/Altinn.Correspondence.Core/Options/DialogportenSettings.cs
+++ b/src/Altinn.Correspondence.Core/Options/DialogportenSettings.cs
@@ -3,7 +3,5 @@
     public class DialogportenSettings
     {
         public string Issuer { get; set; } = string.Empty;
-       
-        public string CorrespondenceBaseUrl { get; set; } = string.Empty;
     }
 }

--- a/src/Altinn.Correspondence.Core/Options/GeneralSettings.cs
+++ b/src/Altinn.Correspondence.Core/Options/GeneralSettings.cs
@@ -1,0 +1,8 @@
+namespace Altinn.Correspondence.Core.Options;
+
+public class GeneralSettings
+{
+    public string SlackUrl { get; set; } = "";
+
+    public string CorrespondenceBaseUrl { get; set; } = string.Empty;
+}

--- a/src/Altinn.Correspondence.Integrations/Altinn/Events/AltinnEventBus.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Events/AltinnEventBus.cs
@@ -1,30 +1,25 @@
-﻿using System.Net.Http.Json;
-using System.Text.Json;
-using System.Text.RegularExpressions;
-using Altinn.Correspondence.Core.Options;
-using Altinn.Correspondence.Core.Repositories;
+﻿using Altinn.Correspondence.Core.Options;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
 using Altinn.Correspondence.Integrations.Altinn.Events.Helpers;
-using Altinn.Correspondence.Repositories;
-
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace Altinn.Correspondence.Integrations.Altinn.Events;
 public class AltinnEventBus : IEventBus
 {
-    private readonly AltinnOptions _altinnOptions;
+    private readonly GeneralSettings _generalSettings;
     private readonly HttpClient _httpClient;
     private readonly ILogger<AltinnEventBus> _logger;
-    private readonly IResourceRightsService _altinnResourceRightsService;
     private readonly IAltinnRegisterService _altinnRegisterService;
 
-    public AltinnEventBus(HttpClient httpClient, IAltinnRegisterService altinnRegisterService, IResourceRightsService altinnResourceRightsService, IOptions<AltinnOptions> altinnOptions, ILogger<AltinnEventBus> logger)
+    public AltinnEventBus(HttpClient httpClient, IAltinnRegisterService altinnRegisterService, IOptions<GeneralSettings> generalSettings, ILogger<AltinnEventBus> logger)
     {
         _httpClient = httpClient;
-        _altinnOptions = altinnOptions.Value;
-        _altinnResourceRightsService = altinnResourceRightsService;
+        _generalSettings = generalSettings.Value;
         _altinnRegisterService = altinnRegisterService;
         _logger = logger;
     }
@@ -66,7 +61,7 @@ public class AltinnEventBus : IEventBus
             Resource = "urn:altinn:resource:" + resourceId,
             ResourceInstance = itemId,
             Type = "no.altinn.correspondence." + type.ToString().ToLowerInvariant(),
-            Source = _altinnOptions.PlatformGatewayUrl + "correspondence/api/v1/" + eventSource,
+            Source = _generalSettings.CorrespondenceBaseUrl.TrimEnd('/') + "/correspondence/api/v1/" + eventSource,
             Subject = !string.IsNullOrWhiteSpace(partyId) ? "/party/" + partyId : null,
             AlternativeSubject = alternativeSubjectFormated
         };

--- a/src/Altinn.Correspondence.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Integrations/DependencyInjection.cs
@@ -11,7 +11,6 @@ using Altinn.Correspondence.Integrations.Altinn.Notifications;
 using Altinn.Correspondence.Integrations.Altinn.Register;
 using Altinn.Correspondence.Integrations.Altinn.ResourceRegistry;
 using Altinn.Correspondence.Integrations.Dialogporten;
-using Altinn.Correspondence.Integrations.Settings;
 using Altinn.Correspondence.Integrations.Slack;
 using Altinn.Correspondence.Repositories;
 using Microsoft.Extensions.Configuration;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -10,7 +10,7 @@ using System.Net.Http.Json;
 
 namespace Altinn.Correspondence.Integrations.Dialogporten;
 
-public class DialogportenService(HttpClient _httpClient, ICorrespondenceRepository _correspondenceRepository, IOptions<DialogportenSettings> dialogportenSettings, ILogger<DialogportenService> _logger) : IDialogportenService
+public class DialogportenService(HttpClient _httpClient, ICorrespondenceRepository _correspondenceRepository, IOptions<GeneralSettings> generalSettings, ILogger<DialogportenService> _logger) : IDialogportenService
 {
     public async Task<string> CreateCorrespondenceDialog(Guid correspondenceId)
     {
@@ -23,7 +23,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
         }
 
-        var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, dialogportenSettings.Value.CorrespondenceBaseUrl);
+        var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, generalSettings.Value.CorrespondenceBaseUrl);
         var response = await _httpClient.PostAsJsonAsync("dialogporten/api/v1/serviceowner/dialogs", createDialogRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {

--- a/src/Altinn.Correspondence.Integrations/GeneralSettings.cs
+++ b/src/Altinn.Correspondence.Integrations/GeneralSettings.cs
@@ -1,6 +1,0 @@
-namespace Altinn.Correspondence.Integrations.Settings;
-
-public class GeneralSettings
-{
-    public string SlackUrl { get; set; } = "";
-}


### PR DESCRIPTION
## Description
CorrespondenceBaseUrl is better to use than PlatformGatewayUrl when p…ointing at ourselves since PlatformGatewayUrl is set to staging platform in both test and staging. This because other Altinn services are more available in staging.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
