### PR TITLE
fix: use matchFileName and not fileMatch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,9 +12,7 @@
   ],
   "packageRules": [
     {
-      "fileMatch": [
-        "\\.bicep$"
-      ],
+      "matchFileNames": ["\\.bicep$"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
## Description
Wrong param used for renovate bot. Luckily it created an issue. I have not been able to verify the match for bicep files are correct, but it should be based on the regex pattern. 

## Related Issue(s)
- #378 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
