### PR TITLE
Do not use condition endpoint when running locally

### DIFF
--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -327,7 +327,7 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
                 },
                 ResourceId = correspondence.ResourceId,
                 RequestedSendTime = _hostEnvironment.IsProduction() ? notificationOrder.RequestedSendTime.Value.AddDays(7) : notificationOrder.RequestedSendTime.Value.AddHours(1),                
-                ConditionEndpoint = CreateConditonEndpoint(correspondence.Id.ToString()),
+                ConditionEndpoint = CreateConditionEndpoint(correspondence.Id.ToString()),
                 SendersReference = correspondence.SendersReference,
                 NotificationChannel = notification.ReminderNotificationChannel ?? notification.NotificationChannel,
                 EmailTemplate = new EmailTemplate
@@ -363,7 +363,7 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
         return content;
     }
 
-    private Uri? CreateConditonEndpoint(string correspondenceId)
+    private Uri? CreateConditionEndpoint(string correspondenceId)
     {
         var conditionEndpoint = new Uri($"{_generalSettings.CorrespondenceBaseUrl.TrimEnd('/')}/correspondence/api/v1/correspondence/{correspondenceId}/notification/check");
         if (conditionEndpoint.Host == "localhost")

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -362,10 +362,17 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
         }
         return content;
     }
-    private Uri CreateConditonEndpoint(string correspondenceId)
+
+    private Uri? CreateConditonEndpoint(string correspondenceId)
     {
-        return new Uri($"{_generalSettings.CorrespondenceBaseUrl.TrimEnd('/')}/correspondence/api/v1/correspondence/{correspondenceId}/notification/check");
+        var conditionEndpoint = new Uri($"{_generalSettings.CorrespondenceBaseUrl.TrimEnd('/')}/correspondence/api/v1/correspondence/{correspondenceId}/notification/check");
+        if (conditionEndpoint.Host == "localhost")
+        {
+            return null;
+        }
+        return conditionEndpoint;    
     }
+
     private string CreateMessageFromToken(string message, string? token = "")
     {
         return message.Replace("{textToken}", token + " ").Trim();


### PR DESCRIPTION
## Description
Altinn Notifications condition endpoint does not and cannot work with localhost

## Related Issue(s)
- #377 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in handling environment-specific conditions with nullable `Uri` return type for the condition endpoint.

- **Bug Fixes**
	- Improved handling of localhost scenarios by returning `null` for condition endpoints when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->