### PR TITLE
Legacy - authorize multiple recipients

### DIFF
--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -45,4 +45,5 @@ public static class Errors
     public static Error MissingPrefferedNotificationContent = new Error(37, "Email body, subject and SMS body must be provided when sending preferred notifications", HttpStatusCode.BadRequest);
     public static Error MissingPrefferedReminderNotificationContent = new Error(38, $"Reminder email body, subject and SMS body must be provided when sending reminder preferred notifications", HttpStatusCode.BadRequest);
     public static Error AttachmentNotPublished = new Error(39, "Attachment is not published", HttpStatusCode.BadRequest);
+    public static Error LegacyNotAccessToOwner(int partyId) { return new Error(40, $"User does not have access to party with partyId {partyId}", HttpStatusCode.Unauthorized); }
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
@@ -100,6 +100,6 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
         public bool onlyHierarchyElementWithNoAccess { get; set; }
         public List<string> authorizedResources { get; set; }
         public List<string> authorizedRoles { get; set; }
-        public List<string> subunits { get; set; }
+        public List<AuthroizedPartiesResponse> subunits { get; set; }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Uses accessmanagement to get all authroized parties for a user. Then validates that the user has access to all parties in InstanceOwnerPartyIdList

## Related Issue(s)
- #307 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a specific error for users lacking access to designated parties.
	- Enhanced authorization checks for retrieving correspondences, improving access management.

- **Bug Fixes**
	- Improved error handling for invalid `OnbehalfOfPartyId` scenarios.

- **Refactor**
	- Streamlined logic for recipient mapping in the correspondence handling process.
	- Updated data structure for authorized parties to enhance data representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->