### PR TITLE
Make DueDateTime nullable

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
@@ -28,8 +28,6 @@ namespace Altinn.Correspondence.Tests.Factories
                         MessageBody = "# test body /n __test__ /n **test**/n [test](www.test.no) /n ![test](www.test.no) /n ```test``` /n > test /n - test /n 1. test /n 1. test /n [x] test /n [ ] test /n ## test /n ### test /n #### test /n ##### test /n ###### test /n + test list /n - test list /n * list element",
                     },
                     RequestedPublishTime = DateTimeOffset.UtcNow,
-                    DueDateTime = DateTimeOffset.UtcNow.AddDays(2),
-                    AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddDays(3),
                     PropertyList = new Dictionary<string, string>(){
                         {"deserunt_12", "1"},
                         {"culpa_852", "2"},
@@ -203,5 +201,3 @@ namespace Altinn.Correspondence.Tests.Factories
         }
     }
 }
-
-

--- a/src/Altinn.Correspondence.API/Models/BaseCorrespondenceExt.cs
+++ b/src/Altinn.Correspondence.API/Models/BaseCorrespondenceExt.cs
@@ -64,7 +64,7 @@ namespace Altinn.Correspondence.API.Models
         /// Gets or sets a date and time for when the recipient must reply.
         /// </summary>
         [JsonPropertyName("dueDateTime")]
-        public DateTimeOffset DueDateTime { get; set; }
+        public DateTimeOffset? DueDateTime { get; set; }
 
         /// <summary>
         /// Gets or sets an list of references Senders can use this field to tell the recipient that the correspondence is related to the referenced item(s)

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
@@ -44,7 +44,7 @@ public class GetCorrespondenceDetailsResponse
 
     public DateTimeOffset? AllowSystemDeleteAfter { get; set; }
 
-    public DateTimeOffset DueDateTime { get; set; }
+    public DateTimeOffset? DueDateTime { get; set; }
 
     public Dictionary<string, string> PropertyList { get; set; } = new Dictionary<string, string>();
     

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
@@ -43,7 +43,7 @@ public class GetCorrespondenceOverviewResponse
 
     public DateTimeOffset? AllowSystemDeleteAfter { get; set; }
 
-    public DateTimeOffset DueDateTime { get; set; }
+    public DateTimeOffset? DueDateTime { get; set; }
 
     public Dictionary<string, string> PropertyList { get; set; } = new Dictionary<string, string>();
     

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -18,25 +18,31 @@ namespace Altinn.Correspondence.Application.Helpers
         public Error? ValidateDateConstraints(CorrespondenceEntity correspondence)
         {
             var RequestedPublishTime = correspondence.RequestedPublishTime;
-            if (correspondence.DueDateTime < DateTimeOffset.UtcNow)
+            if (correspondence.DueDateTime is not null)
             {
-                return Errors.DueDatePriorToday;
+                if (correspondence.DueDateTime < DateTimeOffset.UtcNow)
+                {
+                    return Errors.DueDatePriorToday;
+                }
+                if (correspondence.DueDateTime < RequestedPublishTime)
+                {
+                    return Errors.DueDatePriorRequestedPublishTime;
+                }
             }
-            if (correspondence.DueDateTime < RequestedPublishTime)
+            if (correspondence.AllowSystemDeleteAfter is not null)
             {
-                return Errors.DueDatePriorRequestedPublishTime;
-            }
-            if (correspondence.AllowSystemDeleteAfter < DateTimeOffset.UtcNow)
-            {
-                return Errors.AllowSystemDeletePriorToday;
-            }
-            if (correspondence.AllowSystemDeleteAfter < RequestedPublishTime)
-            {
-                return Errors.AllowSystemDeletePriorRequestedPublishTime;
-            }
-            if (correspondence.AllowSystemDeleteAfter < correspondence.DueDateTime)
-            {
-                return Errors.AllowSystemDeletePriorDueDate;
+                if (correspondence.AllowSystemDeleteAfter < DateTimeOffset.UtcNow)
+                {
+                    return Errors.AllowSystemDeletePriorToday;
+                }
+                if (correspondence.AllowSystemDeleteAfter < RequestedPublishTime)
+                {
+                    return Errors.AllowSystemDeletePriorRequestedPublishTime;
+                }
+                if (correspondence.DueDateTime is not null && correspondence.AllowSystemDeleteAfter < correspondence.DueDateTime)
+                {
+                    return Errors.AllowSystemDeletePriorDueDate;
+                }
             }
             return null;
         }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -207,7 +207,10 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
                 _backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, cancellationToken), publishTime);
 
             }
-            _backgroundJobClient.Schedule<CorrespondenceDueDateHandler>((handler) => handler.Process(correspondence.Id, cancellationToken), correspondence.DueDateTime);
+            if (correspondence.DueDateTime is not null)
+            {
+                _backgroundJobClient.Schedule<CorrespondenceDueDateHandler>((handler) => handler.Process(correspondence.Id, cancellationToken), correspondence.DueDateTime.Value);
+            }
             await _eventBus.Publish(AltinnEventType.CorrespondenceInitialized, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, cancellationToken);
 
             var notificationDetails = new List<NotificationDetails>();

--- a/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceEntity.cs
@@ -31,7 +31,7 @@ namespace Altinn.Correspondence.Core.Models.Entities
 
         public DateTimeOffset? AllowSystemDeleteAfter { get; set; }
 
-        public DateTimeOffset DueDateTime { get; set; }
+        public DateTimeOffset? DueDateTime { get; set; }
 
         public List<ExternalReferenceEntity> ExternalReferences { get; set; } = new List<ExternalReferenceEntity>();
 

--- a/src/Altinn.Correspondence.Persistence/Migrations/20241024133220_Nullable_DueDateTime.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20241024133220_Nullable_DueDateTime.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241024133220_Nullable_DueDateTime")]
+    partial class Nullable_DueDateTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20241024133220_Nullable_DueDateTime.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20241024133220_Nullable_DueDateTime.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Nullable_DueDateTime : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "DueDateTime",
+                schema: "correspondence",
+                table: "Correspondences",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "DueDateTime",
+                schema: "correspondence",
+                table: "Correspondences",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Allow DueDateTime to be nullable, since it is not required. 
This makes the output more intuitive when the user ommits to set this value when creating a correspondence. 

## Related Issue(s)
- #390 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in handling due dates by allowing the `DueDateTime` property to be nullable across various correspondence-related components.
  
- **Bug Fixes**
	- Improved validation logic to prevent errors when checking due dates and system deletion settings, ensuring null values are handled appropriately.

- **Migrations**
	- Introduced a migration to update the database schema, allowing the `DueDateTime` column in the `Correspondences` table to accept null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->