### PR TITLE
fix: Validate Content is not null in InitializeCorrespondence

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -55,22 +55,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         // Assert
         Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
     }
-    
-    [Fact]
-    public async Task InitializeCorrespondence_WithoutContent_ReturnsBadRequest()
-    {
-        // Arrange
-        var correspondence = new CorrespondenceBuilder()
-            .CreateCorrespondence()
-            .WithCorrespondenceContent(null)
-            .Build();
-
-        // Act
-        var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
-    }
 
     [Fact]
     public async Task InitializeCorrespondence_WithExistingAttachmentsPublished_ReturnsOK()
@@ -133,6 +117,53 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+    }
+    
+    [Fact]
+    public async Task InitializeCorrespondence_WithoutContent_ReturnsBadRequest()
+    {
+        // Arrange
+        var correspondence = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .WithCorrespondenceContent(null)
+            .Build();
+
+        // Act
+        var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+    }
+    
+    [Fact]
+    public async Task InitializeCorrespondence_WithEmptyMessageFields_ReturnsBadRequest()
+    {
+        // Arrange
+        var payload1 = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .WithMessageTitle("")
+            .Build();
+
+        var payload2 = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .WithMessageSummary("")
+            .Build();
+        
+        var payload3 = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .WithMessageBody("")
+            .Build();
+
+        // Act
+        var response1 = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload1);
+        var response2 = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload2);
+        var response3 = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload3);
+
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response1.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response2.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response3.StatusCode);
     }
 
     [Fact]

--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -55,6 +55,22 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         // Assert
         Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
     }
+    
+    [Fact]
+    public async Task InitializeCorrespondence_WithoutContent_ReturnsBadRequest()
+    {
+        // Arrange
+        var correspondence = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .WithCorrespondenceContent(null)
+            .Build();
+
+        // Act
+        var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+    }
 
     [Fact]
     public async Task InitializeCorrespondence_WithExistingAttachmentsPublished_ReturnsOK()

--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
@@ -49,6 +49,11 @@ namespace Altinn.Correspondence.Tests.Factories
             _correspondence.Correspondence.ResourceId = resourceId;
             return this;
         }
+        public CorrespondenceBuilder WithCorrespondenceContent(InitializeCorrespondenceContentExt? content)
+        {
+            _correspondence.Correspondence.Content = content;
+            return this;
+        }
         public CorrespondenceBuilder WithMessageTitle(string title)
         {
             _correspondence.Correspondence.Content!.MessageTitle = title;

--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
@@ -56,17 +56,17 @@ namespace Altinn.Correspondence.Tests.Factories
         }
         public CorrespondenceBuilder WithMessageTitle(string title)
         {
-            _correspondence.Correspondence.Content!.MessageTitle = title;
+            _correspondence.Correspondence.Content.MessageTitle = title;
             return this;
         }
         public CorrespondenceBuilder WithMessageBody(string? messageBody)
         {
-            _correspondence.Correspondence.Content!.MessageBody = messageBody;
+            _correspondence.Correspondence.Content.MessageBody = messageBody;
             return this;
         }
         public CorrespondenceBuilder WithMessageSummary(string? messageBody)
         {
-            _correspondence.Correspondence.Content!.MessageSummary = messageBody;
+            _correspondence.Correspondence.Content.MessageSummary = messageBody;
             return this;
         }
         public CorrespondenceBuilder WithAttachments()

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -48,5 +48,5 @@ public static class Errors
     public static Error LegacyNotAccessToOwner(int partyId) { return new Error(40, $"User does not have access to party with partyId {partyId}", HttpStatusCode.Unauthorized); }
     public static Error CorrespondenceNotConfirmed = new Error(41, "Cannot archive or delete a correspondence which has not been confirmed when confirmation is required", HttpStatusCode.BadRequest);
     public static Error DueDateRequired = new Error(42, "DueDateTime is required when confirmation is needed", HttpStatusCode.BadRequest);
-    public static Error MissingContent = new Error(43, "Content must be provided for the correspondence", HttpStatusCode.BadRequest);
+    public static Error MissingContent = new Error(43, "The Content field must be provided for the correspondence", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -48,4 +48,5 @@ public static class Errors
     public static Error LegacyNotAccessToOwner(int partyId) { return new Error(40, $"User does not have access to party with partyId {partyId}", HttpStatusCode.Unauthorized); }
     public static Error CorrespondenceNotConfirmed = new Error(41, "Cannot archive or delete a correspondence which has not been confirmed when confirmation is required", HttpStatusCode.BadRequest);
     public static Error DueDateRequired = new Error(42, "DueDateTime is required when confirmation is needed", HttpStatusCode.BadRequest);
+    public static Error MissingContent = new Error(43, "Content must be provided for the correspondence", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -49,4 +49,7 @@ public static class Errors
     public static Error CorrespondenceNotConfirmed = new Error(41, "Cannot archive or delete a correspondence which has not been confirmed when confirmation is required", HttpStatusCode.BadRequest);
     public static Error DueDateRequired = new Error(42, "DueDateTime is required when confirmation is needed", HttpStatusCode.BadRequest);
     public static Error MissingContent = new Error(43, "The Content field must be provided for the correspondence", HttpStatusCode.BadRequest);
+    public static Error MessageTitleEmpty = new Error(44, "Message title cannot be empty", HttpStatusCode.BadRequest);
+    public static Error MessageBodyEmpty = new Error(45, "Message body cannot be empty", HttpStatusCode.BadRequest);
+    public static Error MessageSummaryEmpty = new Error(46, "Message summary cannot be empty", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -46,17 +46,21 @@ namespace Altinn.Correspondence.Application.Helpers
             }
             return null;
         }
-        public Error? ValidateCorrespondenceContent(CorrespondenceContentEntity content)
+        public Error? ValidateCorrespondenceContent(CorrespondenceContentEntity? content)
         {
-            if (!TextValidation.ValidatePlainText(content?.MessageTitle))
+            if (content == null)
+            {
+                return Errors.MissingContent;
+            }
+            if (!TextValidation.ValidatePlainText(content.MessageTitle))
             {
                 return Errors.MessageTitleIsNotPlainText;
             }
-            if (!TextValidation.ValidateMarkdown(content?.MessageBody))
+            if (!TextValidation.ValidateMarkdown(content.MessageBody))
             {
                 return Errors.MessageBodyIsNotMarkdown;
             }
-            if (!TextValidation.ValidateMarkdown(content?.MessageSummary))
+            if (!TextValidation.ValidateMarkdown(content.MessageSummary))
             {
                 return Errors.MessageSummaryIsNotMarkdown;
             }

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -52,13 +52,25 @@ namespace Altinn.Correspondence.Application.Helpers
             {
                 return Errors.MissingContent;
             }
+            if (string.IsNullOrWhiteSpace(content.MessageTitle))
+            {
+                return Errors.MessageTitleEmpty;
+            }
             if (!TextValidation.ValidatePlainText(content.MessageTitle))
             {
                 return Errors.MessageTitleIsNotPlainText;
             }
+            if (string.IsNullOrWhiteSpace(content.MessageBody))
+            {
+                return Errors.MessageBodyEmpty;
+            }
             if (!TextValidation.ValidateMarkdown(content.MessageBody))
             {
                 return Errors.MessageBodyIsNotMarkdown;
+            }
+            if (string.IsNullOrWhiteSpace(content.MessageSummary))
+            {
+                return Errors.MessageSummaryEmpty;
             }
             if (!TextValidation.ValidateMarkdown(content.MessageSummary))
             {


### PR DESCRIPTION
## Description
Fix: validate and return error if `Correspondence.Content` is null.

## Related Issue(s)
- #398 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added tests for handling null and empty message fields in correspondence initialization.
	- Introduced a method to set correspondence content directly in the builder.
	- Added specific error messages for missing or empty fields in correspondence operations.

- **Bug Fixes**
	- Enhanced validation to handle cases where correspondence content may be absent or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->