### PR TITLE
Remove RestrictionName from AttachmentEntity

### DIFF
--- a/Test/Altinn.Correspondence.LoadTests/test_initialize_and_upload_correspondence.js
+++ b/Test/Altinn.Correspondence.LoadTests/test_initialize_and_upload_correspondence.js
@@ -37,7 +37,6 @@ formData.append('Correspondence.content.messageBody', "Test");
 formData.append('Correspondence.content.attachments[0].DataLocationType', "ExisitingExternalStorage");
 formData.append('Correspondence.content.attachments[0].DataType', "1");
 formData.append('Correspondence.content.attachments[0].Name', "testfile.txt");
-formData.append('Correspondence.content.attachments[0].RestrictionName', "testfile.txt");
 formData.append('Correspondence.content.attachments[0].Sender', sender);
 formData.append('Correspondence.content.attachments[0].SendersReference', "1234");
 formData.append('Correspondence.content.attachments[0].FileName', "testfile.txt");

--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -1727,7 +1727,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             new { Key = $"correspondence.content.Attachments[{index}].DataType", Value = attachment.DataType },
             new { Key = $"correspondence.content.Attachments[{index}].Name", Value = attachment.Name },
             new { Key = $"correspondence.content.Attachments[{index}].FileName", Value = attachment.FileName ?? "" },
-            new { Key = $"correspondence.content.Attachments[{index}].RestrictionName", Value = attachment.RestrictionName },
             new { Key = $"correspondence.content.Attachments[{index}].SendersReference", Value = attachment.SendersReference },
             new { Key = $"correspondence.content.Attachments[{index}].IsEncrypted", Value = attachment.IsEncrypted.ToString() }
         }).SelectMany(x => x).ToList()

--- a/Test/Altinn.Correspondence.Tests/Factories/AttachmentBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/AttachmentBuilder.cs
@@ -18,7 +18,6 @@ namespace Altinn.Correspondence.Tests.Factories
                 ResourceId = "1",
                 DataType = "html",
                 Name = "Test file logical name",
-                RestrictionName = "Test file restriction name",
                 Sender = "0192:986252932",
                 SendersReference = "1234",
                 FileName = "test-file",

--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
@@ -81,7 +81,6 @@ namespace Altinn.Correspondence.Tests.Factories
                 {
                     DataType = "html",
                     Name = "2",
-                    RestrictionName = "testFile2",
                     SendersReference = "1234",
                     FileName = "test-fil2e",
                     IsEncrypted = false,

--- a/Test/Altinn.Correspondence.Tests/Helpers/AttachmentHelper.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/AttachmentHelper.cs
@@ -16,7 +16,6 @@ namespace Altinn.Correspondence.Tests.Helpers
             {
                 DataType = existingAttachmentData?.DataType ?? "txt",
                 Name = existingAttachmentData?.Name ?? fileName,
-                RestrictionName = existingAttachmentData?.RestrictionName ?? "testFile3",
                 SendersReference = existingAttachmentData?.SendersReference ?? "1234",
                 FileName = existingAttachmentData?.FileName ?? fileName,
                 IsEncrypted = existingAttachmentData?.IsEncrypted ?? false,

--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -1510,7 +1510,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"dataType\": \"html\",\n  \"expirationTime\": \"2024-12-12\",\n  \"resourceId\": \"{{resource_id}}\",\n  \"name\": \"testFile\",\n  \"restrictionName\": \"testFile\",\n  \"sender\": \"0192:{{senderOrgNo}}\",\n  \"sendersReference\": \"1234\",\n  \"fileName\": \"test-file\",\n  \"isEncrypted\": false\n}",
+							"raw": "{\n  \"dataType\": \"html\",\n  \"expirationTime\": \"2024-12-12\",\n  \"resourceId\": \"{{resource_id}}\",\n  \"name\": \"testFile\",\n  \"sender\": \"0192:{{senderOrgNo}}\",\n  \"sendersReference\": \"1234\",\n  \"fileName\": \"test-file\",\n  \"isEncrypted\": false\n}",
 							"options": {
 								"raw": {
 									"headerFamily": "json",
@@ -1548,7 +1548,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"HumanReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\"\n}",
+									"raw": "{\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"HumanReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\"\n}",
 									"options": {
 										"raw": {
 											"headerFamily": "json",
@@ -1579,7 +1579,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
 						}
 					]
 				},
@@ -1670,7 +1670,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
 						}
 					]
 				},
@@ -1762,7 +1762,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
 						}
 					]
 				},
@@ -1840,7 +1840,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
 						}
 					]
 				},
@@ -1920,7 +1920,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"Deleted\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Failed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Deleted\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"Deleted\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\",\n  \"statusHistory\": [\n    {\n      \"status\": \"Failed\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    },\n    {\n      \"status\": \"Deleted\",\n      \"statusText\": \"<string>\",\n      \"statusChanged\": \"<dateTime>\"\n    }\n  ]\n}"
 						}
 					]
 				},
@@ -1998,7 +1998,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"restrictionName\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
+							"body": "{\n  \"dataLocationUrl\": \"ExternalStorage\",\n  \"dataType\": \"<string>\",\n  \"expirationTime\": \"<dateTime>\",\n  \"name\": \"<string>\",\n  \"sendersReference\": \"<string>\",\n  \"usageType\": \"MachineReadable\",\n  \"fileName\": \"<string>\",\n  \"isEncrypted\": \"<boolean>\",\n  \"checksum\": \"<string>\",\n  \"attachmentId\": \"<uuid>\",\n  \"status\": \"UploadProcessing\",\n  \"statusText\": \"<string>\",\n  \"statusChanged\": \"<dateTime>\"\n}"
 						}
 					]
 				}

--- a/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
@@ -18,7 +18,6 @@ internal static class AttachmentDetailsMapper
             FileName = AttachmentDetails.FileName,
             Name = AttachmentDetails.Name,
             Sender = AttachmentDetails.Sender,
-            RestrictionName = AttachmentDetails.RestrictionName,
             StatusText = AttachmentDetails.StatusText,
             StatusChanged = AttachmentDetails.StatusChanged,
             DataType = AttachmentDetails.DataType,

--- a/src/Altinn.Correspondence.API/Mappers/AttachmentOverviewMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentOverviewMapper.cs
@@ -15,7 +15,6 @@ internal static class AttachmentOverviewMapper
             Sender = attachmentOverview.Sender,
             Name = attachmentOverview.Name,
             FileName = attachmentOverview.FileName,
-            RestrictionName = attachmentOverview.RestrictionName,
             Status = (AttachmentStatusExt)attachmentOverview.Status,
             StatusText = attachmentOverview.StatusText,
             Checksum = attachmentOverview.Checksum,

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
@@ -19,7 +19,6 @@ internal static class CorrespondenceAttachmentMapper
             SendersReference = attachment.Attachment.SendersReference,
             Checksum = attachment.Attachment.Checksum,
             DataLocationType = (AttachmentDataLocationTypeExt)attachment.Attachment.DataLocationType,
-            RestrictionName = attachment.Attachment.RestrictionName,
             Status = (AttachmentStatusExt)attachment.Attachment.GetLatestStatus()!.Status,
             StatusText = attachment.Attachment.GetLatestStatus()!.StatusText,
             StatusChanged = attachment.Attachment.GetLatestStatus()!.StatusChanged,

--- a/src/Altinn.Correspondence.API/Mappers/InitializeAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeAttachmentMapper.cs
@@ -14,7 +14,6 @@ internal static class InitializeAttachmentMapper
             ResourceId = initializeAttachmentExt.ResourceId,
             FileName = initializeAttachmentExt.FileName,
             Name = initializeAttachmentExt.Name,
-            RestrictionName = initializeAttachmentExt.RestrictionName,
             Sender = initializeAttachmentExt.Sender,
             SendersReference = initializeAttachmentExt.SendersReference,
             DataType = initializeAttachmentExt.DataType,

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceAttachmentMapper.cs
@@ -17,7 +17,6 @@ internal static class InitializeCorrespondenceAttachmentMapper
                 Created = DateTimeOffset.UtcNow,
                 FileName = initializeAttachmentExt.FileName,
                 Name = initializeAttachmentExt.Name,
-                RestrictionName = initializeAttachmentExt.RestrictionName,
                 ResourceId = resourceId,
                 Sender = sender,
                 SendersReference = initializeAttachmentExt.SendersReference,

--- a/src/Altinn.Correspondence.API/Models/BaseAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/BaseAttachmentExt.cs
@@ -21,16 +21,6 @@ namespace Altinn.Correspondence.API.Models
         public required string Name { get; set; }
 
         /// <summary>
-        /// The name of the Restriction Policy restricting access to this element
-        /// </summary>
-        /// <remarks>
-        /// An empty value indicates no restriction above the ones governing the correspondence referencing this attachment
-        /// </remarks>
-        [JsonPropertyName("restrictionName")]
-        [Required]
-        public string RestrictionName { get; set; } = string.Empty;
-
-        /// <summary>
         /// A value indicating whether the attachment is encrypted or not.
         /// </summary>
         [JsonPropertyName("isEncrypted")]

--- a/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsHandler.cs
@@ -48,7 +48,6 @@ public class GetAttachmentDetailsHandler : IHandler<Guid, GetAttachmentDetailsRe
             CorrespondenceIds = correspondenceIds,
             FileName = attachment.FileName,
             Sender = attachment.Sender,
-            RestrictionName = attachment.RestrictionName,
             IsEncrypted = attachment.IsEncrypted,
             Checksum = attachment.Checksum,
         };

--- a/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentDetails/GetAttachmentDetailsResponse.cs
@@ -27,8 +27,6 @@ public class GetAttachmentDetailsResponse
 
     public string DataType { get; set; } = string.Empty;
 
-    public string RestrictionName { get; set; } = string.Empty;
-
     public bool IsEncrypted { get; set; }
 
     public string Checksum { get; set; } = string.Empty;

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewHandler.cs
@@ -50,7 +50,6 @@ public class GetAttachmentOverviewHandler : IHandler<Guid, GetAttachmentOverview
             CorrespondenceIds = correspondenceIds,
             FileName = attachment.FileName,
             Sender = attachment.Sender,
-            RestrictionName = attachment.RestrictionName,
         };
         return response;
     }

--- a/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetAttachmentOverview/GetAttachmentOverviewResponse.cs
@@ -27,7 +27,5 @@ public class GetAttachmentOverviewResponse
 
     public string DataType { get; set; } = string.Empty;
 
-    public string RestrictionName { get; set; } = string.Empty;
-
     public List<Guid> CorrespondenceIds { get; set; } = new List<Guid>();
 }

--- a/src/Altinn.Correspondence.Core/Models/Entities/AttachmentEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/AttachmentEntity.cs
@@ -18,8 +18,6 @@ namespace Altinn.Correspondence.Core.Models.Entities
         [MaxLength(255)]
         public string Name { get; set; }
 
-        public string? RestrictionName { get; set; }
-
         public bool IsEncrypted { get; set; }
 
         public string? Checksum { get; set; } = string.Empty;

--- a/src/Altinn.Correspondence.Persistence/Migrations/20241029141456_Remove_RestrictionNameFromAttachmentEntity.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20241029141456_Remove_RestrictionNameFromAttachmentEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241029141456_Remove_RestrictionNameFromAttachmentEntity")]
+    partial class Remove_RestrictionNameFromAttachmentEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20241029141456_Remove_RestrictionNameFromAttachmentEntity.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20241029141456_Remove_RestrictionNameFromAttachmentEntity.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Remove_RestrictionNameFromAttachmentEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RestrictionName",
+                schema: "correspondence",
+                table: "Attachments");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RestrictionName",
+                schema: "correspondence",
+                table: "Attachments",
+                type: "text",
+                nullable: true);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove RestrictionName from AttachmentEntity and all mappers.

## Related Issue(s)
- #410 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced test coverage for correspondence initialization scenarios, including handling of notifications and validation of different templates.
  
- **Bug Fixes**
	- Removed unnecessary `RestrictionName` property from various data structures and responses, simplifying data handling.
  
- **Chores**
	- Updated Postman collection for API endpoints to ensure proper JSON formatting and compliance.
  
- **Documentation**
	- Updated migration scripts to reflect changes in the database schema by removing the `RestrictionName` field from the `AttachmentEntity`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->