### PR TITLE
Fix: Create reusable deploy-to-environment action, and reuse image published during deployment

### DIFF
--- a/.github/actions/deploy-to-environment/action.yml
+++ b/.github/actions/deploy-to-environment/action.yml
@@ -1,0 +1,66 @@
+# File: .github/actions/deploy-to-environment/action.yml
+name: "Deploy to Environment"
+description: "Deploy application to a specified environment"
+
+inputs:
+  environment:
+    description: "Environment to deploy to (e.g., test, staging, production)"
+    required: true
+  imageTag:
+    description: "Docker image tag to deploy"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Update infrastructure
+      uses: ./.github/actions/update-infrastructure
+      with:
+        region: "norwayeast"
+        environment: ${{ inputs.environment }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
+        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+        MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
+        MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
+        PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
+        ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
+        SLACK_URL: ${{ secrets.SLACK_URL }}
+        IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
+        IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
+
+    - name: Migrate database
+      uses: ./.github/actions/migrate-database
+      with:
+        region: "norwayeast"
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        environment: ${{ inputs.environment }}
+        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+
+    - name: Release version
+      uses: ./.github/actions/release-version
+      with:
+        region: "norwayeast"
+        environment: ${{ inputs.environment }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
+        CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
+        STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+        imageTag: ${{ inputs.imageTag }}
+        DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
+        IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}

--- a/.github/actions/deploy-to-environment/action.yml
+++ b/.github/actions/deploy-to-environment/action.yml
@@ -9,6 +9,63 @@ inputs:
   imageTag:
     description: "Docker image tag to deploy"
     required: true
+  ACCESS_MANAGEMENT_SUBSCRIPTION_KEY:
+    description: "Access Management Subscription Key"
+    required: true
+  AZURE_CLIENT_ID:
+    description: "Azure Client ID"
+    required: true
+  AZURE_ENVIRONMENT_KEY_VAULT_NAME:
+    description: "Azure Environment Key Vault Name"
+    required: true
+  AZURE_NAME_PREFIX:
+    description: "Azure Name Prefix"
+    required: true
+  AZURE_STORAGE_ACCOUNT_NAME:
+    description: "Azure Storage Account Name"
+    required: true
+  AZURE_SUBSCRIPTION_ID:
+    description: "Azure Subscription ID"
+    required: true
+  AZURE_TENANT_ID:
+    description: "Azure Tenant ID"
+    required: true
+  AZURE_TEST_ACCESS_CLIENT_ID:
+    description: "Azure Test Access Client ID"
+    required: true
+  CORRESPONDENCE_BASE_URL:
+    description: "Correspondence Base URL"
+    required: true
+  DIALOGPORTEN_ISSUER:
+    description: "Dialogporten Issuer"
+    required: true
+  IDPORTEN_CLIENT_ID:
+    description: "IDPorten Client ID"
+    required: true
+  IDPORTEN_CLIENT_SECRET:
+    description: "IDPorten Client Secret"
+    required: true
+  IDPORTEN_ISSUER:
+    description: "IDPorten Issuer"
+    required: true
+  MASKINPORTEN_CLIENT_ID:
+    description: "Maskinporten Client ID"
+    required: true
+  MASKINPORTEN_JWK:
+    description: "Maskinporten JWK"
+    required: true
+  PLATFORM_BASE_URL:
+    description: "Platform Base URL"
+    required: true
+  PLATFORM_SUBSCRIPTION_KEY:
+    description: "Platform Subscription Key"
+    required: true
+  SLACK_URL:
+    description: "Slack URL"
+    required: true
+  STORAGE_ACCOUNT_NAME:
+    description: "Storage Account Name"
+    required: true
 
 runs:
   using: "composite"
@@ -21,46 +78,46 @@ runs:
       with:
         region: "norwayeast"
         environment: ${{ inputs.environment }}
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-        AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
-        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-        MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
-        MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
-        PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
-        ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
-        SLACK_URL: ${{ secrets.SLACK_URL }}
-        IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
-        IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
+        ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ inputs.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
+        AZURE_CLIENT_ID: ${{ inputs.AZURE_CLIENT_ID }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ inputs.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_NAME_PREFIX: ${{ inputs.AZURE_NAME_PREFIX }}
+        AZURE_STORAGE_ACCOUNT_NAME: ${{ inputs.AZURE_STORAGE_ACCOUNT_NAME }}
+        AZURE_SUBSCRIPTION_ID: ${{ inputs.AZURE_SUBSCRIPTION_ID }}
+        AZURE_TENANT_ID: ${{ inputs.AZURE_TENANT_ID }}
+        AZURE_TEST_ACCESS_CLIENT_ID: ${{ inputs.AZURE_TEST_ACCESS_CLIENT_ID }}
+        IDPORTEN_CLIENT_ID: ${{ inputs.IDPORTEN_CLIENT_ID }}
+        IDPORTEN_CLIENT_SECRET: ${{ inputs.IDPORTEN_CLIENT_SECRET }}
+        MASKINPORTEN_CLIENT_ID: ${{ inputs.MASKINPORTEN_CLIENT_ID }}
+        MASKINPORTEN_JWK: ${{ inputs.MASKINPORTEN_JWK }}
+        PLATFORM_SUBSCRIPTION_KEY: ${{ inputs.PLATFORM_SUBSCRIPTION_KEY }}
+        SLACK_URL: ${{ inputs.SLACK_URL }}
 
     - name: Migrate database
       uses: ./.github/actions/migrate-database
       with:
         region: "norwayeast"
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         environment: ${{ inputs.environment }}
-        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+        AZURE_CLIENT_ID: ${{ inputs.AZURE_CLIENT_ID }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ inputs.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_NAME_PREFIX: ${{ inputs.AZURE_NAME_PREFIX }}
+        AZURE_STORAGE_ACCOUNT_NAME: ${{ inputs.AZURE_STORAGE_ACCOUNT_NAME }}
+        AZURE_SUBSCRIPTION_ID: ${{ inputs.AZURE_SUBSCRIPTION_ID }}
+        AZURE_TENANT_ID: ${{ inputs.AZURE_TENANT_ID }}
 
     - name: Release version
       uses: ./.github/actions/release-version
       with:
         region: "norwayeast"
         environment: ${{ inputs.environment }}
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
-        CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
-        STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
         imageTag: ${{ inputs.imageTag }}
-        DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
-        IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
+        AZURE_CLIENT_ID: ${{ inputs.AZURE_CLIENT_ID }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ inputs.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_NAME_PREFIX: ${{ inputs.AZURE_NAME_PREFIX }}
+        AZURE_SUBSCRIPTION_ID: ${{ inputs.AZURE_SUBSCRIPTION_ID }}
+        AZURE_TENANT_ID: ${{ inputs.AZURE_TENANT_ID }}
+        CORRESPONDENCE_BASE_URL: ${{ inputs.CORRESPONDENCE_BASE_URL }}
+        DIALOGPORTEN_ISSUER: ${{ inputs.DIALOGPORTEN_ISSUER }}
+        IDPORTEN_ISSUER: ${{ inputs.IDPORTEN_ISSUER }}
+        PLATFORM_BASE_URL: ${{ inputs.PLATFORM_BASE_URL }}
+        STORAGE_ACCOUNT_NAME: ${{ inputs.AZURE_STORAGE_ACCOUNT_NAME }}

--- a/.github/actions/deploy-to-environment/action.yml
+++ b/.github/actions/deploy-to-environment/action.yml
@@ -63,9 +63,6 @@ inputs:
   SLACK_URL:
     description: "Slack URL"
     required: true
-  STORAGE_ACCOUNT_NAME:
-    description: "Storage Account Name"
-    required: true
 
 runs:
   using: "composite"

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -12,25 +12,38 @@ jobs:
     name: QA	
     uses: ./.github/workflows/test-application.yml	
 
-  build:
-    name: Build and Publish Artifact
+  get-version: 
+    name: Get version
     runs-on: ubuntu-latest
+    outputs:
+      imageTag: ${{ steps.get-version.outputs.imageTag }}
+    permissions: 
+      contents: read
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - name: "Get current version"
+        uses: ./.github/actions/get-current-version
+        id: get-version
 
-      - name: Build Application
-        run: dotnet build
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: [get-version]
+    permissions: 
+      packages: write
+      contents: read
+    steps:        
+      - uses: actions/checkout@v4
+      - name: "Publish image"
+        uses: ./.github/actions/publish-image
         with:
-          name: correspondence-artifact
-          path: ./build
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dockerImageBaseName: ghcr.io/altinn/altinn-correspondence
+          imageTag: ${{ needs.get-version.outputs.imageTag }}
 
   deploy-test:
     name: Internal test
-    needs: build
+    needs: [get-version, publish]
     uses: ./.github/workflows/deploy-to-environment.yml
     if: always() && !failure() && !cancelled() 
     permissions: 
@@ -40,12 +53,14 @@ jobs:
     secrets: inherit
     with:
       environment: test
+      imageTag: ${{ needs.get-version.outputs.imageTag }}
 
   deploy-staging:
     name: Internal staging
     uses: ./.github/workflows/deploy-to-environment.yml
     if: always() && !failure() && !cancelled() 
     needs: [ 
+      get-version,
       deploy-test
     ]
     permissions: 
@@ -55,12 +70,14 @@ jobs:
     secrets: inherit
     with:
       environment: staging
+      imageTag: ${{ needs.get-version.outputs.imageTag }}
 
   deploy-production:
     name: Production
     needs: [
+      get-version,
       deploy-staging,
-    ]
+      ]
     uses: ./.github/workflows/deploy-to-environment.yml
     if: (!failure() && !cancelled())
     permissions: 
@@ -70,6 +87,7 @@ jobs:
     secrets: inherit
     with:
       environment: production
+      imageTag: ${{ needs.get-version.outputs.imageTag }}
 
   release-to-git:  
     name: Release to git
@@ -82,7 +100,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Release
         if: (!failure() && !cancelled())
         uses: ./.github/actions/release-to-git

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -7,7 +7,6 @@ on:
     - "Test/**" # ignore changes to tests
 
 jobs:
-
   test:	
     name: QA	
     uses: ./.github/workflows/test-application.yml	
@@ -43,21 +42,23 @@ jobs:
 
   deploy-test:
     name: Internal test
+    runs-on: ubuntu-latest
     needs: [get-version, publish]
-    uses: ./.github/workflows/deploy-to-environment.yml
     if: always() && !failure() && !cancelled() 
     permissions: 
       id-token: write
       contents: read
       packages: write
-    secrets: inherit
-    with:
-      environment: test
-      imageTag: ${{ needs.get-version.outputs.imageTag }}
+    steps:
+      - name: Deploy to environment
+        uses: ./.github/actions/deploy-to-environment
+        with:
+          environment: test
+          imageTag: ${{ needs.get-version.outputs.imageTag }}
 
   deploy-staging:
     name: Internal staging
-    uses: ./.github/workflows/deploy-to-environment.yml
+    runs-on: ubuntu-latest
     if: always() && !failure() && !cancelled() 
     needs: [ 
       get-version,
@@ -67,27 +68,31 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    secrets: inherit
-    with:
-      environment: staging
-      imageTag: ${{ needs.get-version.outputs.imageTag }}
+    steps:       
+      - name: Deploy to environment
+        uses: ./.github/actions/deploy-to-environment
+        with:
+          environment: staging
+          imageTag: ${{ needs.get-version.outputs.imageTag }}
 
   deploy-production:
     name: Production
+    runs-on: ubuntu-latest
     needs: [
       get-version,
       deploy-staging,
     ]
-    uses: ./.github/workflows/deploy-to-environment.yml
     if: (!failure() && !cancelled())
     permissions: 
       id-token: write
       contents: read
       packages: write
-    secrets: inherit
-    with:
-      environment: production
-      imageTag: ${{ needs.get-version.outputs.imageTag }}
+    steps:       
+      - name: Deploy to environment
+        uses: ./.github/actions/deploy-to-environment
+        with:
+          environment: production
+          imageTag: ${{ needs.get-version.outputs.imageTag }}
 
   release-to-git:  
     name: Release to git

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -77,7 +77,7 @@ jobs:
     needs: [
       get-version,
       deploy-staging,
-      ]
+    ]
     uses: ./.github/workflows/deploy-to-environment.yml
     if: (!failure() && !cancelled())
     permissions: 

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -12,8 +12,25 @@ jobs:
     name: QA	
     uses: ./.github/workflows/test-application.yml	
 
+  build:
+    name: Build and Publish Artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Build Application
+        run: dotnet build
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: correspondence-artifact
+          path: ./build
+
   deploy-test:
     name: Internal test
+    needs: build
     uses: ./.github/workflows/deploy-to-environment.yml
     if: always() && !failure() && !cancelled() 
     permissions: 
@@ -66,7 +83,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: release
+      - name: Release
         if: (!failure() && !cancelled())
         uses: ./.github/actions/release-to-git
         with:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -55,6 +55,25 @@ jobs:
         with:
           environment: test
           imageTag: ${{ needs.get-version.outputs.imageTag }}
+          ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
+          CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
+          DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
+          IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
+          IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
+          IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
+          MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
+          MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
+          PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
+          PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
+          SLACK_URL: ${{ secrets.SLACK_URL }}
+          STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}
 
   deploy-staging:
     name: Internal staging
@@ -74,6 +93,25 @@ jobs:
         with:
           environment: staging
           imageTag: ${{ needs.get-version.outputs.imageTag }}
+          ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
+          CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
+          DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
+          IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
+          IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
+          IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
+          MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
+          MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
+          PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
+          PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
+          SLACK_URL: ${{ secrets.SLACK_URL }}
+          STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}
 
   deploy-production:
     name: Production
@@ -93,6 +131,25 @@ jobs:
         with:
           environment: production
           imageTag: ${{ needs.get-version.outputs.imageTag }}
+          ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
+          CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
+          DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
+          IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
+          IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
+          IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
+          MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
+          MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
+          PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
+          PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
+          SLACK_URL: ${{ secrets.SLACK_URL }}
+          STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}
 
   release-to-git:  
     name: Release to git

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -73,7 +73,6 @@ jobs:
           PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
           PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
           SLACK_URL: ${{ secrets.SLACK_URL }}
-          STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}
 
   deploy-staging:
     name: Internal staging
@@ -111,7 +110,6 @@ jobs:
           PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
           PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
           SLACK_URL: ${{ secrets.SLACK_URL }}
-          STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}
 
   deploy-production:
     name: Production
@@ -149,7 +147,6 @@ jobs:
           PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
           PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
           SLACK_URL: ${{ secrets.SLACK_URL }}
-          STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}
 
   release-to-git:  
     name: Release to git

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -11,10 +11,15 @@ on:
     inputs:
       environment:
         type: choice
+        description: "Environment to deploy to"
         options:
           - test
           - staging
           - production
+      imageTag:
+        type: string
+        description: "Docker image tag to deploy"
+        required: true
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -1,8 +1,6 @@
 name: Deploy to environment
 
 on:
-  push:
-    branches: [ fix/upload-and-download-artifact-for-publishing ]  # Trigger only on this branch
   workflow_call:
     inputs:
       environment:

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -52,56 +52,59 @@ jobs:
       contents: read
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: correspondence-artifact
 
-    - name: Update infrastructure
-      uses: ./.github/actions/update-infrastructure
-      with:
-        region: norwayeast
-        environment: ${{ inputs.environment }}
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-        AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
-        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-        MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
-        MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
-        PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
-        ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
-        SLACK_URL: ${{ secrets.SLACK_URL }}
-        IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
-        IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Migrate database
-      uses: ./.github/actions/migrate-database
-      with:
-        region: norwayeast
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        environment: ${{ inputs.environment }}
-        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+      - name: Update infrastructure
+        uses: ./.github/actions/update-infrastructure
+        with:
+          region: norwayeast
+          environment: ${{ inputs.environment }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+          AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
+          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
+          MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
+          PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
+          ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
+          SLACK_URL: ${{ secrets.SLACK_URL }}
+          IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
+          IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
 
-    - name: Release version
-      uses: ./.github/actions/release-version
-      with:
-        region: norwayeast
-        environment: ${{ inputs.environment }}
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
-        CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
-        STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-        imageTag: ${{ needs.get-version.outputs.imageTag }}
-        DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
-        IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
+      - name: Migrate database
+        uses: ./.github/actions/migrate-database
+        with:
+          region: norwayeast
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          environment: ${{ inputs.environment }}
+          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
 
-    
+      - name: Release version
+        uses: ./.github/actions/release-version
+        with:
+          region: norwayeast
+          environment: ${{ inputs.environment }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
+          CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
+          STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          imageTag: ${{ needs.get-version.outputs.imageTag }}
+          DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
+          IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -63,3 +63,22 @@ jobs:
       with:
         environment: ${{ inputs.environment }}
         imageTag: ${{ needs.get-version.outputs.imageTag }}
+        ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
+        CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
+        DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
+        IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
+        IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
+        IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
+        MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
+        MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
+        PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
+        PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
+        SLACK_URL: ${{ secrets.SLACK_URL }}
+        STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -55,6 +55,9 @@ jobs:
       contents: read
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Deploy to environment
       uses: ./.github/actions/deploy-to-environment
       with:

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -79,4 +79,3 @@ jobs:
         PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
         PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
         SLACK_URL: ${{ secrets.SLACK_URL }}
-        STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -1,6 +1,8 @@
 name: Deploy to environment
 
 on:
+  push:
+    branches: [ fix/upload-and-download-artifact-for-publishing ]  # Trigger only on this branch
   workflow_call:
     inputs:
       environment:

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -5,6 +5,8 @@ on:
     inputs:
       environment:
         type: string
+      imageTag:
+        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -15,96 +17,65 @@ on:
           - production
 
 jobs:
-  get-version: 
-    name: Get version
-    runs-on: ubuntu-latest
-    outputs:
-      imageTag: ${{ steps.get-version.outputs.imageTag }}
-    permissions: 
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: "Get current version"
-        uses: ./.github/actions/get-current-version
-        id: get-version
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    needs: [get-version]
-    permissions: 
-      packages: write
-      contents: read
-    steps:        
-      - uses: actions/checkout@v4
-      - name: "Publish image"
-        uses: ./.github/actions/publish-image
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          dockerImageBaseName: ghcr.io/altinn/altinn-correspondence
-          imageTag: ${{ needs.get-version.outputs.imageTag }}
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    needs: [get-version]
     permissions: 
       id-token: write
       contents: read
 
     steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: correspondence-artifact
+    - name: Checkout
+      uses: actions/checkout@v4
 
-      - name: Checkout
-        uses: actions/checkout@v4
+    - name: Update infrastructure
+      uses: ./.github/actions/update-infrastructure
+      with:
+        region: norwayeast
+        environment: ${{ inputs.environment }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
+        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+        MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
+        MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
+        PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
+        ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
+        SLACK_URL: ${{ secrets.SLACK_URL }}
+        IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
+        IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
 
-      - name: Update infrastructure
-        uses: ./.github/actions/update-infrastructure
-        with:
-          region: norwayeast
-          environment: ${{ inputs.environment }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-          AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
-          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-          MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
-          MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
-          PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
-          ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
-          SLACK_URL: ${{ secrets.SLACK_URL }}
-          IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
-          IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
+    - name: Migrate database
+      uses: ./.github/actions/migrate-database
+      with:
+        region: norwayeast
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        environment: ${{ inputs.environment }}
+        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
 
-      - name: Migrate database
-        uses: ./.github/actions/migrate-database
-        with:
-          region: norwayeast
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          environment: ${{ inputs.environment }}
-          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+    - name: Release version
+      uses: ./.github/actions/release-version
+      with:
+        region: norwayeast
+        environment: ${{ inputs.environment }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
+        CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
+        STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+        imageTag: ${{ inputs.imageTag }}
+        DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
+        IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
 
-      - name: Release version
-        uses: ./.github/actions/release-version
-        with:
-          region: norwayeast
-          environment: ${{ inputs.environment }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
-          CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
-          STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-          imageTag: ${{ needs.get-version.outputs.imageTag }}
-          DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
-          IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
+    

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -7,8 +7,6 @@ on:
     inputs:
       environment:
         type: string
-      imageTag:
-        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -18,71 +16,47 @@ on:
           - test
           - staging
           - production
-      imageTag:
-        type: string
-        description: "Docker image tag to deploy"
-        required: true
 
 jobs:
+  get-version: 
+    name: Get version
+    runs-on: ubuntu-latest
+    outputs:
+      imageTag: ${{ steps.get-version.outputs.imageTag }}
+    permissions: 
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Get current version"
+        uses: ./.github/actions/get-current-version
+        id: get-version
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: [get-version]
+    permissions: 
+      packages: write
+      contents: read
+    steps:        
+      - uses: actions/checkout@v4
+      - name: "Publish image"
+        uses: ./.github/actions/publish-image
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dockerImageBaseName: ghcr.io/altinn/altinn-correspondence
+          imageTag: ${{ needs.get-version.outputs.imageTag }}
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    needs: [get-version]
     environment: ${{ inputs.environment }}
     permissions: 
       id-token: write
       contents: read
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Update infrastructure
-      uses: ./.github/actions/update-infrastructure
+    - name: Deploy to environment
+      uses: ./.github/actions/deploy-to-environment
       with:
-        region: norwayeast
         environment: ${{ inputs.environment }}
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-        AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
-        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-        MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
-        MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
-        PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
-        ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
-        SLACK_URL: ${{ secrets.SLACK_URL }}
-        IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
-        IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
-
-    - name: Migrate database
-      uses: ./.github/actions/migrate-database
-      with:
-        region: norwayeast
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        environment: ${{ inputs.environment }}
-        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-
-    - name: Release version
-      uses: ./.github/actions/release-version
-      with:
-        region: norwayeast
-        environment: ${{ inputs.environment }}
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-        AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
-        CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
-        STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-        imageTag: ${{ inputs.imageTag }}
-        DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
-        IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
-
-    
+        imageTag: ${{ needs.get-version.outputs.imageTag }}

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -1,9 +1,6 @@
 name: Publish test branch
 
 on:
-  push:
-    branches: [ fix/upload-and-download-artifact-for-publishing ]  # Trigger only on this branch
-
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -1,6 +1,9 @@
 name: Publish test branch
 
 on:
+  push:
+    branches: [ fix/upload-and-download-artifact-for-publishing ]  # Trigger only on this branch
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `deploy-to-environment.yml` workflow logic has been moved into an action which is used in the CI-CD workflow as well as the Deploy to Environment workflow.

## Related Issue(s)
- #374 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new deployment action for specified environments, allowing for streamlined application deployment with input parameters for environment and image tagging.
	- Added an input parameter for selecting deployment environments (test, staging, production) in the deployment workflow.

- **Bug Fixes**
	- Removed dependencies on outdated jobs, ensuring smoother deployment processes.

- **Chores**
	- Updated CI/CD workflows to enhance version retrieval and image publishing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->