### PR TITLE
Fix CICD failing because it cannot find the deploy-to-environment action

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -50,6 +50,9 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Deploy to environment
         uses: ./.github/actions/deploy-to-environment
         with:
@@ -87,6 +90,9 @@ jobs:
       contents: read
       packages: write
     steps:       
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Deploy to environment
         uses: ./.github/actions/deploy-to-environment
         with:
@@ -124,6 +130,9 @@ jobs:
       contents: read
       packages: write
     steps:       
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Deploy to environment
         uses: ./.github/actions/deploy-to-environment
         with:


### PR DESCRIPTION
## Description
CI-CD was failing because it could not find the action specified in the deploy jobs.

I remember the same error happened with the `deploy-to-environment.yml` workflow, but I forgot to fix it here also.

## Related Issue(s)
- #374 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI/CD workflow to include additional checkout steps for deployment jobs, ensuring the latest code is available for testing and production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->