### PR TITLE
Fix deploy permission

### DIFF
--- a/.github/actions/deploy-to-environment/action.yml
+++ b/.github/actions/deploy-to-environment/action.yml
@@ -75,8 +75,6 @@ runs:
 
     - name: Update infrastructure
       uses: ./.github/actions/update-infrastructure
-      permissions:
-        id-token: write
       with:
         region: "norwayeast"
         environment: ${{ inputs.environment }}

--- a/.github/actions/deploy-to-environment/action.yml
+++ b/.github/actions/deploy-to-environment/action.yml
@@ -1,6 +1,9 @@
 # File: .github/actions/deploy-to-environment/action.yml
 name: "Deploy to Environment"
 description: "Deploy application to a specified environment"
+permissions:
+  id-token: write
+  contents: read
 
 inputs:
   environment:
@@ -72,6 +75,8 @@ runs:
 
     - name: Update infrastructure
       uses: ./.github/actions/update-infrastructure
+      permissions:
+        id-token: write
       with:
         region: "norwayeast"
         environment: ${{ inputs.environment }}

--- a/.github/actions/update-infrastructure/action.yml
+++ b/.github/actions/update-infrastructure/action.yml
@@ -1,7 +1,4 @@
 name: Update infrastructure
-permissions:
-  id-token: write
-  contents: read
 description: "Update the infrastructure to the version given by git ref"
 
 inputs:

--- a/.github/actions/update-infrastructure/action.yml
+++ b/.github/actions/update-infrastructure/action.yml
@@ -72,9 +72,6 @@ runs:
 
     - name: OIDC Login to Azure Public Cloud
       uses: azure/login@v2
-      permissions:
-        id-token: write
-        contents: read
       with:
         client-id: ${{ inputs.AZURE_CLIENT_ID }}
         tenant-id: ${{ inputs.AZURE_TENANT_ID }}

--- a/.github/actions/update-infrastructure/action.yml
+++ b/.github/actions/update-infrastructure/action.yml
@@ -1,5 +1,7 @@
 name: Update infrastructure
-
+permissions:
+  id-token: write
+  contents: read
 description: "Update the infrastructure to the version given by git ref"
 
 inputs:
@@ -70,10 +72,14 @@ runs:
 
     - name: OIDC Login to Azure Public Cloud
       uses: azure/login@v2
+      permissions:
+        id-token: write
+        contents: read
       with:
         client-id: ${{ inputs.AZURE_CLIENT_ID }}
         tenant-id: ${{ inputs.AZURE_TENANT_ID }}
         subscription-id: ${{ inputs.AZURE_SUBSCRIPTION_ID }}
+        auth-type: OIDC
 
     - name: Generate postgresql password
       id: pwd-generator

--- a/.github/actions/update-infrastructure/action.yml
+++ b/.github/actions/update-infrastructure/action.yml
@@ -76,7 +76,6 @@ runs:
         client-id: ${{ inputs.AZURE_CLIENT_ID }}
         tenant-id: ${{ inputs.AZURE_TENANT_ID }}
         subscription-id: ${{ inputs.AZURE_SUBSCRIPTION_ID }}
-        auth-type: OIDC
 
     - name: Generate postgresql password
       id: pwd-generator


### PR DESCRIPTION
## Description
Seems that composite actions needs to have its permissions explicitly defined in its own file even tho it is passed in from calling workflow.
Github Actions is weird.

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced GitHub Actions with new permissions for improved authentication and resource interaction.
		- Added `id-token: write` and `contents: read` permissions to deployment and infrastructure update actions.
- **Bug Fixes**
	- No bug fixes were included in this release. 
- **Documentation**
	- No changes to existing input descriptions or requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->