### PR TITLE
Fix: Ensure correspondence is fetched before updating to Read or Confirmed

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -1055,7 +1055,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
     }
     
     [Fact]
-    public async Task UpdateCorrespondenceStatus_ToRead_WithoutFetched_ReturnsBadRequest()
+    public async Task UpdateCorrespondenceStatus_MarkAsRead_WithoutFetched_ReturnsBadRequest()
     {
         //  Arrange
         var payload = new CorrespondenceBuilder()

--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -869,7 +869,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
 
         // Assert
         var response = await getCorrespondenceOverviewResponse.Content.ReadFromJsonAsync<CorrespondenceOverviewExt>(_responseSerializerOptions);
-        Assert.Equal(response.Status, CorrespondenceStatusExt.Published); // Status is not changed to fetched
+        Assert.Equal(CorrespondenceStatusExt.Published, response.Status); // Status is not changed to fetched
         var actual = await (await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{correspondence?.Correspondences.FirstOrDefault().CorrespondenceId}/details")).Content.ReadFromJsonAsync<CorrespondenceDetailsExt>(_responseSerializerOptions);
 
         var expectedFetchedStatuses = 1;
@@ -894,7 +894,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var getCorrespondenceDetailsResponse = await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{correspondence?.Correspondences.FirstOrDefault().CorrespondenceId}/details");
         var detailsResponse = await getCorrespondenceDetailsResponse.Content.ReadFromJsonAsync<CorrespondenceDetailsExt>(_responseSerializerOptions);
         Assert.DoesNotContain(detailsResponse.StatusHistory, item => item.Status == CorrespondenceStatusExt.Fetched); // Fetched is not added to the list
-        Assert.Equal(response.Status, CorrespondenceStatusExt.Published);
+        Assert.Equal(CorrespondenceStatusExt.Published, response.Status);
     }
 
     [Fact]
@@ -969,7 +969,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var expectedFetchedStatuses = 1;
         Assert.Equal(response.StatusHistory.Where(s => s.Status == CorrespondenceStatusExt.Fetched).Count(), expectedFetchedStatuses);
         Assert.Contains(response.StatusHistory, item => item.Status == CorrespondenceStatusExt.Published);
-        Assert.Equal(response.Status, CorrespondenceStatusExt.Published);
+        Assert.Equal(CorrespondenceStatusExt.Published, response.Status);
     }
 
     [Fact]
@@ -988,11 +988,11 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         // Assert
         var response = await getCorrespondenceDetailsResponse.Content.ReadFromJsonAsync<CorrespondenceDetailsExt>(_responseSerializerOptions);
         Assert.DoesNotContain(response.StatusHistory, item => item.Status == CorrespondenceStatusExt.Fetched);
-        Assert.Equal(response.Status, CorrespondenceStatusExt.Published);
+        Assert.Equal(CorrespondenceStatusExt.Published, response.Status);
     }
 
     [Fact]
-    public async Task MarkActions_CorrespondenceNotExists_ReturnNotFound()
+    public async Task UpdateCorrespondenceStatus_CorrespondenceNotExists_Return404()
     {
         var readResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/00000000-0100-0000-0000-000000000000/markasread", null);
         Assert.Equal(HttpStatusCode.NotFound, readResponse.StatusCode);
@@ -1005,8 +1005,9 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
     }
 
     [Fact]
-    public async Task ReceiverMarkActions_CorrespondenceNotPublished_Return404()
+    public async Task UpdateCorrespondenceStatus_CorrespondenceNotPublished_Return404()
     {
+        // Arrange
         var payload = new CorrespondenceBuilder()
             .CreateCorrespondence()
             .WithRequestedPublishTime(DateTimeOffset.UtcNow.AddDays(1))
@@ -1014,39 +1015,102 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
         var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
         Assert.NotNull(correspondenceResponse);
-        var readResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceResponse?.Correspondences.FirstOrDefault().CorrespondenceId}/markasread", null);
+        var correspondenceId = correspondenceResponse?.Correspondences.FirstOrDefault()?.CorrespondenceId;
+
+        // Act and Assert
+        var readResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/markasread", null);
         Assert.Equal(HttpStatusCode.NotFound, readResponse.StatusCode);
 
-        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceResponse?.Correspondences.FirstOrDefault().CorrespondenceId}/confirm", null);
+        // Act and Assert
+        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/confirm", null);
         Assert.Equal(HttpStatusCode.NotFound, confirmResponse.StatusCode);
     }
 
     [Fact]
-    public async Task ReceiverMarkActions_CorrespondencePublished_ReturnOk()
+    public async Task UpdateCorrespondenceStatus_CorrespondencePublished_ReturnOk()
     {
-        var attachmentId = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions);
+        // Arrange
         var payload = new CorrespondenceBuilder()
             .CreateCorrespondence()
-            .WithExistingAttachments([attachmentId])
             .Build();
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
         var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
         initializeCorrespondenceResponse.EnsureSuccessStatusCode();
-        Assert.NotNull(response);
+        Assert.Equal(CorrespondenceStatus.Published, response?.Correspondences.FirstOrDefault()?.Status);
+        var correspondenceId = response?.Correspondences.FirstOrDefault()?.CorrespondenceId;
 
-        var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{response.Correspondences.FirstOrDefault().CorrespondenceId}", _responseSerializerOptions);
-        Assert.True(overview?.Status == CorrespondenceStatusExt.Published);
-        Assert.NotNull(payload);
-        var readResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{response.Correspondences.FirstOrDefault().CorrespondenceId}/markasread", null);
+        // Act
+        var fetchResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}"); // Fetch in order to be able to Read
+        Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
+
+        var readResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/markasread", null);
         readResponse.EnsureSuccessStatusCode();
 
-        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{response.Correspondences.FirstOrDefault().CorrespondenceId}/confirm", null);
-        confirmResponse.EnsureSuccessStatusCode();
-
-        var markAsUnreadResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{response.Correspondences.FirstOrDefault().CorrespondenceId}/markasunread", null);
+        var markAsUnreadResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/markasunread", null);
         markAsUnreadResponse.EnsureSuccessStatusCode();
-        overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{response.Correspondences.FirstOrDefault().CorrespondenceId}", _responseSerializerOptions);
-        Assert.True(overview?.MarkedUnread == true);
+
+        // Assert
+        var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{correspondenceId}", _responseSerializerOptions);
+        Assert.True(overview?.MarkedUnread);
+    }
+    
+    [Fact]
+    public async Task UpdateCorrespondenceStatus_ToRead_WithoutFetched_ReturnsBadRequest()
+    {
+        //  Arrange
+        var payload = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .Build();
+        var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+        var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
+
+        //  Act
+        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/markasread", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, confirmResponse.StatusCode);
+    }
+    
+    [Fact]
+    public async Task UpdateCorrespondenceStatus_ToConfirmed_WithoutFetched_ReturnsBadRequest()
+    {
+        //  Arrange
+        var payload = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .Build();
+        var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+        var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
+
+        //  Act
+        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/confirm", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, confirmResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateCorrespondenceStatus_ToConfirmed_WhenCorrespondenceIsFetched_GivesOk()
+    {
+        //  Arrange
+        var payload = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .Build();
+        var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+        var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
+
+        //  Act
+        var fetchResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}");
+        Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
+        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/confirm", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, confirmResponse.StatusCode);
     }
 
     [Fact]
@@ -1085,7 +1149,9 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
 
         //  Act
-        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/confirm", null);
+        var fetchResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}"); // Fetch in order to be able to Confirm
+        Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
+        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/confirm", null); // Update to Confirmed in order to be able to Archive
         Assert.Equal(HttpStatusCode.OK, confirmResponse.StatusCode);
         var archiveResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/archive", null);
 
@@ -1267,7 +1333,9 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
 
         //  Act
-        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/confirm", null);
+        var fetchResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}"); // Fetch in order to be able to confirm
+        Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
+        var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/confirm", null); // Confirm in order to be able to delete
         Assert.Equal(HttpStatusCode.OK, confirmResponse.StatusCode);
         var deleteResponse = await _recipientClient.DeleteAsync($"correspondence/api/v1/correspondence/{correspondenceId}/purge");
 

--- a/Test/Altinn.Correspondence.Tests/NotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/NotificationTests.cs
@@ -39,8 +39,7 @@ public class NotificationTests : IClassFixture<MaskinportenWebApplicationFactory
     [Fact]
     public async Task CheckNotification_For_Correspondence_With_Unread_Status_Gives_True()
     {
-        var factory = _factory;
-        var client = factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.SenderScope));
+        var client = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.SenderScope));
         var correspondence = new CorrespondenceBuilder().CreateCorrespondence().Build();
         var initializeCorrespondenceResponse = await client.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
         initializeCorrespondenceResponse.EnsureSuccessStatusCode();
@@ -57,8 +56,7 @@ public class NotificationTests : IClassFixture<MaskinportenWebApplicationFactory
     [Fact]
     public async Task CheckNotification_For_Correspondence_With_Read_Status_Gives_False()
     {
-        var factory = new CustomWebApplicationFactory();
-        var client = factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.SenderScope));
+        var client = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.SenderScope));
         var correspondence = new CorrespondenceBuilder()
             .CreateCorrespondence()
             .WithRequestedPublishTime(DateTime.UtcNow.AddHours(-1))
@@ -69,7 +67,7 @@ public class NotificationTests : IClassFixture<MaskinportenWebApplicationFactory
         var responseContent = await initializeCorrespondenceResponse.Content.ReadAsStringAsync();
         var correspondenceId = JsonSerializer.Deserialize<InitializeCorrespondencesResponseExt>(responseContent, _responseSerializerOptions).Correspondences.First().CorrespondenceId;;
 
-        var recipientClient = factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.RecipientScope));
+        var recipientClient = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.RecipientScope));
         var fetchResponse = await recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}"); // Fetch in order to read
         fetchResponse.EnsureSuccessStatusCode();
         var markasread = await recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/markasread", null);

--- a/Test/Altinn.Correspondence.Tests/NotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/NotificationTests.cs
@@ -39,7 +39,7 @@ public class NotificationTests : IClassFixture<MaskinportenWebApplicationFactory
     [Fact]
     public async Task CheckNotification_For_Correspondence_With_Unread_Status_Gives_True()
     {
-        var factory = new CustomWebApplicationFactory();
+        var factory = _factory;
         var client = factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.SenderScope));
         var correspondence = new CorrespondenceBuilder().CreateCorrespondence().Build();
         var initializeCorrespondenceResponse = await client.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
@@ -70,6 +70,8 @@ public class NotificationTests : IClassFixture<MaskinportenWebApplicationFactory
         var correspondenceId = JsonSerializer.Deserialize<InitializeCorrespondencesResponseExt>(responseContent, _responseSerializerOptions).Correspondences.First().CorrespondenceId;;
 
         var recipientClient = factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.RecipientScope));
+        var fetchResponse = await recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}"); // Fetch in order to read
+        fetchResponse.EnsureSuccessStatusCode();
         var markasread = await recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/markasread", null);
         markasread.EnsureSuccessStatusCode();
 

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -55,5 +55,5 @@ public static class Errors
     public static Error InvalidLanguage = new Error(47, "Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)", HttpStatusCode.BadRequest);
     public static Error LegacyNoAccessToCorrespondence = new Error(48, "User does not have access to the correspondence", HttpStatusCode.Unauthorized);
     public static Error ConfirmBeforeFetched = new Error(49, "Correspondence must be fetched before it can be confirmed", HttpStatusCode.BadRequest);
-    public static Error ReadBeforeFetched = new Error(50, "Correspondence must be fetched before it can be confirmed", HttpStatusCode.BadRequest);
+    public static Error ReadBeforeFetched = new Error(50, "Correspondence must be fetched before it can be read", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -46,7 +46,7 @@ public static class Errors
     public static Error MissingPrefferedReminderNotificationContent = new Error(38, $"Reminder email body, subject and SMS body must be provided when sending reminder preferred notifications", HttpStatusCode.BadRequest);
     public static Error AttachmentNotPublished = new Error(39, "Attachment is not published", HttpStatusCode.BadRequest);
     public static Error LegacyNotAccessToOwner(int partyId) { return new Error(40, $"User does not have access to party with partyId {partyId}", HttpStatusCode.Unauthorized); }
-    public static Error CorrespondenceNotConfirmed = new Error(41, "Cannot archive or delete a correspondence which has not been confirmed when confirmation is required", HttpStatusCode.BadRequest);
+    public static Error ArchiveBeforeConfirmed = new Error(41, "Cannot archive or delete a correspondence which has not been confirmed when confirmation is required", HttpStatusCode.BadRequest);
     public static Error DueDateRequired = new Error(42, "DueDateTime is required when confirmation is needed", HttpStatusCode.BadRequest);
     public static Error MissingContent = new Error(43, "The Content field must be provided for the correspondence", HttpStatusCode.BadRequest);
     public static Error MessageTitleEmpty = new Error(44, "Message title cannot be empty", HttpStatusCode.BadRequest);
@@ -54,4 +54,6 @@ public static class Errors
     public static Error MessageSummaryEmpty = new Error(46, "Message summary cannot be empty", HttpStatusCode.BadRequest);
     public static Error InvalidLanguage = new Error(47, "Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)", HttpStatusCode.BadRequest);
     public static Error LegacyNoAccessToCorrespondence = new Error(48, "User does not have access to the correspondence", HttpStatusCode.Unauthorized);
+    public static Error ConfirmBeforeFetched = new Error(49, "Correspondence must be fetched before it can be confirmed", HttpStatusCode.BadRequest);
+    public static Error ReadBeforeFetched = new Error(50, "Correspondence must be fetched before it can be confirmed", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -32,7 +32,7 @@ public static class CorrespondenceStatusExtensions
     {
         List<CorrespondenceStatus> validStatuses =
         [
-            CorrespondenceStatus.Published, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
+            CorrespondenceStatus.Published, CorrespondenceStatus.Fetched, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
             CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved
         ];
         return validStatuses.Contains(correspondenceStatus);

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -89,7 +89,7 @@ public class PurgeCorrespondenceHandler : IHandler<Guid, Guid>
             }
             if (correspondence.IsConfirmationNeeded && !correspondence.StatusHasBeen(CorrespondenceStatus.Confirmed))
             {
-                return Errors.CorrespondenceNotConfirmed;
+                return Errors.ArchiveBeforeConfirmed;
             }
             newStatus = new CorrespondenceStatusEntity()
             {

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHandler.cs
@@ -92,7 +92,7 @@ public class UpdateCorrespondenceStatusHandler : IHandler<UpdateCorrespondenceSt
         {
             return Errors.ConfirmBeforeFetched;
         }
-        if (request.Status == CorrespondenceStatus.Archived && correspondence.IsConfirmationNeeded && !correspondence.StatusHasBeen(CorrespondenceStatus.Confirmed))
+        if (request.Status == CorrespondenceStatus.Archived && correspondence.IsConfirmationNeeded is true && !correspondence.StatusHasBeen(CorrespondenceStatus.Confirmed))
         {
             return Errors.ArchiveBeforeConfirmed;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds validation to make sure `UpdateCorrespondenceStatusHandler` cannot set the statuses `Read` or `Write` if the correspondence has not been fetched (i.e. `GET correspondence/{correspondenceId}`) has been executed.

## Related Issue(s)
- #416 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new error messages for correspondence handling: `ConfirmBeforeFetched` and `ReadBeforeFetched`.
	- Enhanced test coverage for correspondence functionality with new test cases.

- **Bug Fixes**
	- Improved error handling in correspondence status updates to ensure proper validation before processing.

- **Refactor**
	- Renamed test methods for clarity and consistency.
	- Streamlined test setup by reusing existing instances.
	- Centralized validation logic in the status update process.
	- Updated valid statuses to include `Fetched` in correspondence availability checks.

- **Documentation**
	- Updated error message definitions to reflect new contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->