### PR TITLE
Missing reference to Github environment in CI/CD

### DIFF
--- a/.github/actions/deploy-to-environment/action.yml
+++ b/.github/actions/deploy-to-environment/action.yml
@@ -1,9 +1,6 @@
 # File: .github/actions/deploy-to-environment/action.yml
 name: "Deploy to Environment"
 description: "Deploy application to a specified environment"
-permissions:
-  id-token: write
-  contents: read
 
 inputs:
   environment:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -43,8 +43,9 @@ jobs:
   deploy-test:
     name: Internal test
     runs-on: ubuntu-latest
-    needs: [get-version, publish]
+    environment: test
     if: always() && !failure() && !cancelled() 
+    needs: [get-version, publish]
     permissions: 
       id-token: write
       contents: read
@@ -80,6 +81,7 @@ jobs:
   deploy-staging:
     name: Internal staging
     runs-on: ubuntu-latest
+    environment: staging
     if: always() && !failure() && !cancelled() 
     needs: [ 
       get-version,
@@ -120,11 +122,12 @@ jobs:
   deploy-production:
     name: Production
     runs-on: ubuntu-latest
+    environment: production
+    if: (!failure() && !cancelled())
     needs: [
       get-version,
       deploy-staging,
     ]
-    if: (!failure() && !cancelled())
     permissions: 
       id-token: write
       contents: read


### PR DESCRIPTION
## Description
Missing reference to Github environment in CI/CD. The only repository secrets that were used were the ones outside a Github environment.

Also removed a previous "fix" that did not fix issue.

## Related Issue(s)
- #374 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
