### PR TITLE
fix: use correct lookupParty function, change onbehalfofpartyId to int

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
@@ -67,7 +67,7 @@ namespace Altinn.Correspondence.API.Controllers
         [ApiExplorerSettings(IgnoreApi = true)]
         public async Task<ActionResult<LegacyGetCorrespondenceHistoryResponse>> GetCorrespondenceHistory( // TODO: Should this be LegacyCorrespondenceHistoryExt? 
             Guid correspondenceId,
-            [FromQuery] string onBehalfOfPartyId,
+            [FromQuery] int onBehalfOfPartyId,
             [FromServices] LegacyGetCorrespondenceHistoryHandler handler,
             CancellationToken cancellationToken)
         {

--- a/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
@@ -67,17 +67,12 @@ namespace Altinn.Correspondence.API.Controllers
         [ApiExplorerSettings(IgnoreApi = true)]
         public async Task<ActionResult<LegacyGetCorrespondenceHistoryResponse>> GetCorrespondenceHistory( // TODO: Should this be LegacyCorrespondenceHistoryExt? 
             Guid correspondenceId,
-            [FromQuery] int onBehalfOfPartyId,
             [FromServices] LegacyGetCorrespondenceHistoryHandler handler,
             CancellationToken cancellationToken)
         {
             _logger.LogInformation("Getting Correspondence history for {correspondenceId}", correspondenceId.ToString());
 
-            var commandResult = await handler.Process(new LegacyGetCorrespondenceHistoryRequest
-            {
-                CorrespondenceId = correspondenceId,
-                OnBehalfOfPartyId = onBehalfOfPartyId
-            }, cancellationToken);
+            var commandResult = await handler.Process(correspondenceId, cancellationToken);
 
             return commandResult.Match(
                 data => Ok(data),

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -29,7 +29,7 @@ public class LegacyGetCorrespondenceHistoryHandler : IHandler<LegacyGetCorrespon
             return Errors.CorrespondenceNotFound;
         }
 
-        var recipientParty = await _altinnRegisterService.LookUpPartyById(request.OnBehalfOfPartyId, cancellationToken);
+        var recipientParty = await _altinnRegisterService.LookUpPartyByPartyId(request.OnBehalfOfPartyId, cancellationToken);
         if (recipientParty == null || (string.IsNullOrEmpty(recipientParty.SSN) && string.IsNullOrEmpty(recipientParty.OrgNumber)))
         {
             return Errors.CouldNotFindOrgNo; // TODO: Update to better error message

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -12,7 +12,7 @@ public class LegacyGetCorrespondenceHistoryHandler : IHandler<Guid, LegacyGetCor
     private readonly IAltinnNotificationService _altinnNotificationService;
     private readonly IAltinnRegisterService _altinnRegisterService;
     private readonly IAltinnAuthorizationService _altinnAuthorizationService;
-    private UserClaimsHelper _userClaimsHelper;
+    private readonly UserClaimsHelper _userClaimsHelper;
 
     public LegacyGetCorrespondenceHistoryHandler(ICorrespondenceRepository correspondenceRepository, IAltinnNotificationService altinnNotificationService, IAltinnRegisterService altinnRegisterService, IAltinnAuthorizationService altinnAuthorizationService, UserClaimsHelper userClaimsHelper)
     {
@@ -24,12 +24,11 @@ public class LegacyGetCorrespondenceHistoryHandler : IHandler<Guid, LegacyGetCor
     }
     public async Task<OneOf<LegacyGetCorrespondenceHistoryResponse, Error>> Process(Guid correspondenceId, CancellationToken cancellationToken)
     {
-        var partyId = _userClaimsHelper.GetPartyId();
-        if (partyId is null)
+        if (_userClaimsHelper.GetPartyId() is not int partyId)
         {
             return Errors.InvalidPartyId;
         }
-        var recipientParty = await _altinnRegisterService.LookUpPartyByPartyId(partyId.Value, cancellationToken);
+        var recipientParty = await _altinnRegisterService.LookUpPartyByPartyId(partyId, cancellationToken);
         if (recipientParty == null || (string.IsNullOrEmpty(recipientParty.SSN) && string.IsNullOrEmpty(recipientParty.OrgNumber)))
         {
             return Errors.CouldNotFindOrgNo;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryRequest.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryRequest.cs
@@ -1,7 +1,0 @@
-namespace Altinn.Correspondence.Application.GetCorrespondenceHistory;
-
-public class LegacyGetCorrespondenceHistoryRequest
-{
-    public required int OnBehalfOfPartyId { get; set; }
-    public required Guid CorrespondenceId { get; set; }
-}

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryRequest.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryRequest.cs
@@ -2,6 +2,6 @@ namespace Altinn.Correspondence.Application.GetCorrespondenceHistory;
 
 public class LegacyGetCorrespondenceHistoryRequest
 {
-    public required string OnBehalfOfPartyId { get; set; }
+    public required int OnBehalfOfPartyId { get; set; }
     public required Guid CorrespondenceId { get; set; }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I had accidentally used orgnumber instead of partyId when implementing the eventhistory endpoint for the legacy controller. This is now fixed, and tests have been done by passing in partyId instead of orgNumber in the call.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `GetCorrespondenceHistory` method to accept an integer for the `onBehalfOfPartyId` parameter, enhancing data type consistency.
  
- **Bug Fixes**
	- Improved the `Process` method by renaming the lookup function for better clarity and accuracy in retrieving party information.

- **Documentation**
	- Updated property type for `OnBehalfOfPartyId` in request handling to reflect the change from string to integer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->