### PR TITLE
LegacyController: Add UpdateCorrespondenceStatusHandler for Confirm and Archive

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
@@ -6,6 +6,8 @@ using Altinn.Correspondence.Application.DownloadCorrespondenceAttachment;
 using Altinn.Correspondence.Application.GetCorrespondenceHistory;
 using Altinn.Correspondence.Application.GetCorrespondenceOverview;
 using Altinn.Correspondence.Application.GetCorrespondences;
+using Altinn.Correspondence.Application.UpdateCorrespondenceStatus;
+using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Mappers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -120,6 +122,60 @@ namespace Altinn.Correspondence.API.Controllers
             );
         }
 
+        /// Mark Correspondence found by ID as confirmed
+        /// </summary>
+        /// <remarks>
+        /// Meant for Receivers
+        /// </remarks>
+        /// <returns>StatusId</returns>
+        [HttpPost]
+        [Route("{correspondenceId}/confirm")]
+        public async Task<ActionResult> Confirm(
+            Guid correspondenceId,
+            [FromServices] LegacyUpdateCorrespondenceStatusHandler handler,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Marking Correspondence as confirmed for {correspondenceId}", correspondenceId.ToString());
+
+            var commandResult = await handler.Process(new UpdateCorrespondenceStatusRequest
+            {
+                CorrespondenceId = correspondenceId,
+                Status = CorrespondenceStatus.Confirmed
+            }, cancellationToken);
+
+            return commandResult.Match(
+                data => Ok(data),
+                Problem
+            );
+        }
+
+        /// <summary>
+        /// Mark Correspondence found by ID as archived
+        /// </summary>
+        /// <remarks>
+        /// Meant for Receivers
+        /// </remarks>
+        /// <returns>StatusId</returns>
+        [HttpPost]
+        [Route("{correspondenceId}/archive")]
+        public async Task<ActionResult> Archive(
+            Guid correspondenceId,
+            [FromServices] LegacyUpdateCorrespondenceStatusHandler handler,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Archiving Correspondence with id: {correspondenceId}", correspondenceId.ToString());
+
+            var commandResult = await handler.Process(new UpdateCorrespondenceStatusRequest
+            {
+                CorrespondenceId = correspondenceId,
+                Status = CorrespondenceStatus.Archived
+            }, cancellationToken);
+
+            return commandResult.Match(
+                data => Ok(data),
+                Problem
+            );
+        }
         private ActionResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
     }
 }

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -59,6 +59,7 @@ public static class DependencyInjection
         services.AddScoped<LegacyGetCorrespondenceOverviewHandler>();
         services.AddScoped<LegacyGetCorrespondenceHistoryHandler>();
         services.AddScoped<LegacyDownloadCorrespondenceAttachmentHandler>();
+        services.AddScoped<LegacyUpdateCorrespondenceStatusHandler>();
 
         // Migration
         services.AddScoped<MigrateInitializeAttachmentHandler>();

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
@@ -1,0 +1,72 @@
+using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using OneOf;
+
+namespace Altinn.Correspondence.Application.UpdateCorrespondenceStatus;
+public class LegacyUpdateCorrespondenceStatusHandler : IHandler<UpdateCorrespondenceStatusRequest, Guid>
+{
+    private readonly ICorrespondenceRepository _correspondenceRepository;
+    private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
+    private readonly IAltinnRegisterService _altinnRegisterService;
+    private readonly IEventBus _eventBus;
+    private readonly UserClaimsHelper _userClaimsHelper;
+    public LegacyUpdateCorrespondenceStatusHandler(ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, IAltinnRegisterService altinnRegisterService, IEventBus eventBus, UserClaimsHelper userClaimsHelper)
+    {
+        _correspondenceRepository = correspondenceRepository;
+        _correspondenceStatusRepository = correspondenceStatusRepository;
+        _altinnRegisterService = altinnRegisterService;
+        _eventBus = eventBus;
+        _userClaimsHelper = userClaimsHelper;
+    }
+    public async Task<OneOf<Guid, Error>> Process(UpdateCorrespondenceStatusRequest request, CancellationToken cancellationToken)
+    {
+        if (_userClaimsHelper.GetPartyId() is not int partyId)
+        {
+            return Errors.InvalidPartyId;
+        }
+        var party = await _altinnRegisterService.LookUpPartyByPartyId(partyId, cancellationToken);
+        if (party is null || (string.IsNullOrEmpty(party.SSN) && string.IsNullOrEmpty(party.OrgNumber)))
+        {
+            return Errors.CouldNotFindOrgNo;
+        }
+        var correspondence = await _correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, cancellationToken);
+        if (correspondence == null)
+        {
+            return Errors.CorrespondenceNotFound;
+        }
+        bool isRecipient = correspondence.Recipient == ("0192:" + party.OrgNumber) || correspondence.Recipient == party.SSN;
+        if (!isRecipient)
+        {
+            return Errors.CorrespondenceNotFound;
+        }
+        var currentStatus = correspondence.GetLatestStatus();
+        if (currentStatus is null)
+        {
+            return Errors.LatestStatusIsNull;
+        }
+        if (!currentStatus.Status.IsAvailableForRecipient())
+        {
+            return Errors.CorrespondenceNotFound;
+        }
+        // TODO: Implement logic for markasread and markasunread
+        var updateStatusHelper = new UpdateCorrespondenceStatusHelper();
+        var updateError = updateStatusHelper.ValidateUpdateRequest(request, correspondence);
+        if (updateError is not null)
+        {
+            return updateError;
+        }
+
+        await _correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
+        {
+            CorrespondenceId = correspondence.Id,
+            Status = request.Status,
+            StatusChanged = DateTime.UtcNow,
+            StatusText = request.Status.ToString(),
+        }, cancellationToken);
+
+        await updateStatusHelper.PublishEvent(_eventBus, correspondence, request.Status, cancellationToken);
+        return request.CorrespondenceId;
+    }
+}

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
@@ -1,0 +1,37 @@
+using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Services;
+using Altinn.Correspondence.Core.Services.Enums;
+
+namespace Altinn.Correspondence.Application.UpdateCorrespondenceStatus;
+public class UpdateCorrespondenceStatusHelper
+{
+    public Error? ValidateUpdateRequest(UpdateCorrespondenceStatusRequest request, CorrespondenceEntity correspondence)
+    {
+        if (request.Status == CorrespondenceStatus.Read && !correspondence.StatusHasBeen(CorrespondenceStatus.Fetched))
+        {
+            return Errors.ReadBeforeFetched;
+        }
+        if (request.Status == CorrespondenceStatus.Confirmed && !correspondence.StatusHasBeen(CorrespondenceStatus.Fetched))
+        {
+            return Errors.ConfirmBeforeFetched;
+        }
+        if (request.Status == CorrespondenceStatus.Archived && correspondence.IsConfirmationNeeded is true && !correspondence.StatusHasBeen(CorrespondenceStatus.Confirmed))
+        {
+            return Errors.ArchiveBeforeConfirmed;
+        }
+        return null;
+    }
+    public async Task PublishEvent(IEventBus eventBus, CorrespondenceEntity correspondence, CorrespondenceStatus status, CancellationToken cancellationToken)
+    {
+        if (status == CorrespondenceStatus.Confirmed)
+        {
+            await eventBus.Publish(AltinnEventType.CorrespondenceReceiverConfirmed, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, cancellationToken);
+        }
+        else if (status == CorrespondenceStatus.Read)
+        {
+            await eventBus.Publish(AltinnEventType.CorrespondenceReceiverRead, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `LegacyUpdateCorrespondenceStatusHandler` for Legacy endpoint. This only supports "confirm" and "archive" as of now. It follows the same logic as the one in CorrespondenceController, meaning that the correspondence needs to be "fetched" via the `LegacyGetCorrespondenceOverview` or `LegacyGetCorrespondenceDetails` request.

## Related Issue(s)
- #428
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
