### PR TITLE
convert markdown to html for Legacy API

### DIFF
--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -3,6 +3,7 @@ using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
+using Markdig;
 using Microsoft.Extensions.Logging;
 using OneOf;
 
@@ -111,8 +112,8 @@ public class LegacyGetCorrespondenceOverviewHandler : IHandler<Guid, LegacyGetCo
             Attachments = correspondence.Content!.Attachments ?? new List<CorrespondenceAttachmentEntity>(),
             Language = correspondence.Content!.Language,
             MessageTitle = correspondence.Content!.MessageTitle,
-            MessageSummary = correspondence.Content!.MessageSummary,
-            MessageBody = correspondence.Content!.MessageBody,
+            MessageSummary = ConvertToHtml(correspondence.Content!.MessageSummary),
+            MessageBody = ConvertToHtml(correspondence.Content!.MessageBody),
             Status = latestStatus.Status,
             StatusText = latestStatus.StatusText,
             StatusChanged = latestStatus.StatusChanged,
@@ -142,5 +143,12 @@ public class LegacyGetCorrespondenceOverviewHandler : IHandler<Guid, LegacyGetCo
             InstanceOwnerPartyId = resourceOwnerParty.PartyId
         };
         return response;
+    }
+
+    public string ConvertToHtml(string markdown)
+    {
+        var pipleline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseYamlFrontMatter().Build();
+        var html = Markdown.ToHtml(markdown, pipleline).Replace("\n", "");
+        return html;
     }
 }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -3,7 +3,6 @@ using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
-using Markdig;
 using Microsoft.Extensions.Logging;
 using OneOf;
 

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -112,8 +112,8 @@ public class LegacyGetCorrespondenceOverviewHandler : IHandler<Guid, LegacyGetCo
             Attachments = correspondence.Content!.Attachments ?? new List<CorrespondenceAttachmentEntity>(),
             Language = correspondence.Content!.Language,
             MessageTitle = correspondence.Content!.MessageTitle,
-            MessageSummary = ConvertToHtml(correspondence.Content!.MessageSummary),
-            MessageBody = ConvertToHtml(correspondence.Content!.MessageBody),
+            MessageSummary = TextValidation.ConvertToHtml(correspondence.Content!.MessageSummary),
+            MessageBody = TextValidation.ConvertToHtml(correspondence.Content!.MessageBody),
             Status = latestStatus.Status,
             StatusText = latestStatus.StatusText,
             StatusChanged = latestStatus.StatusChanged,
@@ -143,12 +143,5 @@ public class LegacyGetCorrespondenceOverviewHandler : IHandler<Guid, LegacyGetCo
             InstanceOwnerPartyId = resourceOwnerParty.PartyId
         };
         return response;
-    }
-
-    public string ConvertToHtml(string markdown)
-    {
-        var pipleline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseYamlFrontMatter().Build();
-        var html = Markdown.ToHtml(markdown, pipleline).Replace("\n", "");
-        return html;
     }
 }

--- a/src/Altinn.Correspondence.Application/Helpers/TextValidation.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/TextValidation.cs
@@ -7,6 +7,13 @@ namespace Altinn.Correspondence.Application.Helpers;
 
 public class TextValidation
 {
+    public static string ConvertToHtml(string markdown)
+    {
+        var pipleline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseYamlFrontMatter().Build();
+        var html = Markdown.ToHtml(markdown, pipleline).Replace("\n", "");
+        return html;
+    }
+
     public static bool ValidatePlainText(string text)
     {
         var converter = new ReverseMarkdown.Converter();


### PR DESCRIPTION
## Description
Converts markdown to HTML for legacy API. 


As messageBody is already stored and sanetized, it should not be needed to repeat that action. 
It should never be null aswell as correspondences will always have a message

## Related Issue(s)
- #443 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced HTML formatting for message summaries and bodies in correspondence details.
	- Added a new method to convert Markdown content to HTML.

- **Bug Fixes**
	- Simplified authorization logic for accessing correspondence, ensuring consistent error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->