### PR TITLE
remove isRecipient check in Legacy because user can have delegated permissions

### DIFF
--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
@@ -38,7 +38,7 @@ public class LegacyDownloadCorrespondenceAttachmentHandler : IHandler<DownloadCo
         {
             return Errors.CouldNotFindOrgNo;
         }
-
+        // TODO: Authorize party
         var correspondence = await _correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, cancellationToken);
         if (correspondence is null)
         {
@@ -48,11 +48,6 @@ public class LegacyDownloadCorrespondenceAttachmentHandler : IHandler<DownloadCo
         if (attachment is null)
         {
             return Errors.AttachmentNotFound;
-        }
-        bool isRecipient = correspondence.Recipient == ("0192:"+party.OrgNumber) || correspondence.Recipient == party.SSN;
-        if (!isRecipient)
-        {
-            return Errors.CorrespondenceNotFound;
         }
         var latestStatus = correspondence.GetLatestStatus();
         if (!latestStatus.Status.IsAvailableForRecipient())

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -33,6 +33,7 @@ public class LegacyGetCorrespondenceHistoryHandler : IHandler<Guid, LegacyGetCor
         {
             return Errors.CouldNotFindOrgNo;
         }
+        // TODO: Authorize party
         var correspondence = await _correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, cancellationToken);
         if (correspondence is null)
         {
@@ -46,7 +47,7 @@ public class LegacyGetCorrespondenceHistoryHandler : IHandler<Guid, LegacyGetCor
         var minimumAuthLevel = await _altinnAuthorizationService.CheckUserAccessAndGetMinimumAuthLevel(correspondence.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Read }, cancellationToken);
         if (minimumAuthLevel is not int authenticationLevel)
         {
-            authenticationLevel = 2;
+            authenticationLevel = 2; // TODO: Remove when authorization is implemented
             // return Errors.LegacyNoAccessToCorrespondence;
         }
 

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
@@ -39,13 +39,9 @@ public class LegacyUpdateCorrespondenceStatusHandler : IHandler<UpdateCorrespond
         {
             return Errors.CouldNotFindOrgNo;
         }
+        // TODO: Authorize party
         var correspondence = await _correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, cancellationToken);
         if (correspondence == null)
-        {
-            return Errors.CorrespondenceNotFound;
-        }
-        bool isRecipient = correspondence.Recipient == ("0192:" + party.OrgNumber) || correspondence.Recipient == party.SSN;
-        if (!isRecipient)
         {
             return Errors.CorrespondenceNotFound;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Because the user might have delegated permissions, the endpoints cannot decide if the user can access the correspondences based on the recipients list. This will be handled instead based on the partyId and its authorized parties. 

## Related Issue(s)
- #455
- #408
- #420 
- #428 
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined recipient validation process for downloading and updating correspondence status.
	- Placeholder for future party authorization implementation added.

- **Bug Fixes**
	- Maintained error handling for invalid party IDs and missing correspondence.

- **Documentation**
	- Added comments to indicate future enhancements and clarify temporary logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->