### PR TITLE
Return Ext models in API instead of application models, rename models to avoid confusion

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -619,7 +619,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var initializeCorrespondenceResponse2 = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payloadResourceB);
         Assert.True(initializeCorrespondenceResponse2.IsSuccessStatusCode, await initializeCorrespondenceResponse2.Content.ReadAsStringAsync());
 
-        int status = (int)CorrespondenceStatus.Published;
+        int status = (int)CorrespondenceStatusExt.Published;
         var correspondenceList = await _senderClient.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resourceA}&offset={0}&limit={10}&status={status}&role={"recipientandsender"}");
         Assert.Equal(correspondenceList?.Pagination.TotalItems, payloadResourceA.Recipients.Count);
     }
@@ -1036,7 +1036,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
         var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
         initializeCorrespondenceResponse.EnsureSuccessStatusCode();
-        Assert.Equal(CorrespondenceStatus.Published, response?.Correspondences.FirstOrDefault()?.Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, response?.Correspondences.FirstOrDefault()?.Status);
         var correspondenceId = response?.Correspondences.FirstOrDefault()?.CorrespondenceId;
 
         // Act
@@ -1063,7 +1063,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             .Build();
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
         var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
-        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
         var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
 
         //  Act
@@ -1082,7 +1082,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             .Build();
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
         var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
-        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
         var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
 
         //  Act
@@ -1101,7 +1101,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             .Build();
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
         var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
-        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
         var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
 
         //  Act
@@ -1124,7 +1124,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             .Build();
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
         var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
-        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
         var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
 
         //  Act
@@ -1145,7 +1145,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             .Build();
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
         var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
-        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
         var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
 
         //  Act
@@ -1308,7 +1308,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             .Build();
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
         var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
-        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
         var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
 
         //  Act
@@ -1329,7 +1329,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
             .Build();
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
         var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
-        Assert.Equal(CorrespondenceStatus.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
         var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
 
         //  Act
@@ -1650,8 +1650,8 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
-        Assert.Equal(CorrespondenceStatus.Published, content?.Correspondences.First().Status);
-        Assert.Equal(Application.InitializeCorrespondences.NotificationStatus.MissingContact, content?.Correspondences?.First()?.Notifications?.First().Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, content?.Correspondences.First().Status);
+        Assert.Equal(InitializedNotificationStatusExt.MissingContact, content?.Correspondences?.First()?.Notifications?.First().Status);
         Assert.Equal(orderId, content?.Correspondences?.First()?.Notifications?.First().OrderId);
     }
     [Fact]
@@ -1681,8 +1681,8 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
-        Assert.Equal(CorrespondenceStatus.Published, content?.Correspondences.First().Status);
-        Assert.Equal(Application.InitializeCorrespondences.NotificationStatus.Failure, content?.Correspondences?.First()?.Notifications?.First().Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, content?.Correspondences.First().Status);
+        Assert.Equal(InitializedNotificationStatusExt.Failure, content?.Correspondences?.First()?.Notifications?.First().Status);
         Assert.Equal(Guid.Empty, content?.Correspondences?.First()?.Notifications?.First().OrderId);
     }
     [Fact]
@@ -1722,8 +1722,8 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
-        Assert.Equal(CorrespondenceStatus.Published, content?.Correspondences.First().Status);
-        Assert.Equal(Application.InitializeCorrespondences.NotificationStatus.Success, content?.Correspondences?.First()?.Notifications?.First().Status);
+        Assert.Equal(CorrespondenceStatusExt.Published, content?.Correspondences.First().Status);
+        Assert.Equal(InitializedNotificationStatusExt.Success, content?.Correspondences?.First()?.Notifications?.First().Status);
         Assert.Equal(orderId, content?.Correspondences?.First()?.Notifications?.First().OrderId);
     }
 

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -49,20 +49,16 @@ namespace Altinn.Correspondence.API.Controllers
             [FromServices] InitializeCorrespondencesHandler handler,
             CancellationToken cancellationToken)
         {
-                LogContextHelpers.EnrichLogsWithInsertCorrespondence(request.Correspondence);
-                _logger.LogInformation("Initialize correspondences");
+            LogContextHelpers.EnrichLogsWithInsertCorrespondence(request.Correspondence);
+            _logger.LogInformation("Initialize correspondences");
 
-                var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, null, request.ExistingAttachments, false);
-                var commandResult = await handler.Process(commandRequest, cancellationToken);
+            var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, null, request.ExistingAttachments, false);
+            var commandResult = await handler.Process(commandRequest, cancellationToken);
 
-                return commandResult.Match(
-                    data => Ok(new InitializeCorrespondencesResponseExt()
-                    {
-                        Correspondences = data.Correspondences,
-                        AttachmentIds = data.AttachmentIds
-                    }),
-                    Problem
-                );
+            return commandResult.Match(
+                data => Ok(InitializeCorrespondencesMapper.MapToExternal(data)),
+                Problem
+            );
         }
 
         /// <summary>
@@ -90,11 +86,7 @@ namespace Altinn.Correspondence.API.Controllers
             var commandResult = await handler.Process(commandRequest, cancellationToken);
 
             return commandResult.Match(
-                data => Ok(new InitializeCorrespondencesResponseExt()
-                {
-                    Correspondences = data.Correspondences,
-                    AttachmentIds = data.AttachmentIds
-                }),
+                data => Ok(InitializeCorrespondencesMapper.MapToExternal(data)),
                 Problem
             );
         }

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.API.Models;
+using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application.InitializeCorrespondences;
 using Altinn.Correspondence.Core.Models.Entities;
 
@@ -44,6 +45,25 @@ internal static class InitializeCorrespondencesMapper
             ExistingAttachments = existingAttachments ?? new List<Guid>(),
             Recipients = Recipients,
             Notification = initializeCorrespondenceExt.Notification != null ? InitializeCorrespondenceNotificationMapper.MapToRequest(initializeCorrespondenceExt.Notification) : null
+        };
+    }
+    internal static InitializeCorrespondencesResponseExt MapToExternal(InitializeCorrespondencesResponse response)
+    {
+        return new InitializeCorrespondencesResponseExt
+        {
+            Correspondences = response.Correspondences.Select(correspondence => new InitializedCorrespondencesExt
+            {
+                CorrespondenceId = correspondence.CorrespondenceId,
+                Status = (CorrespondenceStatusExt)correspondence.Status,
+                Recipient = correspondence.Recipient,
+                Notifications = correspondence.Notifications?.Select(notification => new InitializedCorrespondencesNotificationsExt
+                {
+                    OrderId = notification.OrderId,
+                    IsReminder = notification.IsReminder,
+                    Status = (InitializedNotificationStatusExt)notification.Status
+                }).ToList()
+            }).ToList(),
+            AttachmentIds = response.AttachmentIds
         };
     }
 }

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondencesResponseExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondencesResponseExt.cs
@@ -1,9 +1,30 @@
-using Altinn.Correspondence.Application.InitializeCorrespondences;
+using Altinn.Correspondence.API.Models.Enums;
 
 namespace Altinn.Correspondence.API.Models;
 
 public class InitializeCorrespondencesResponseExt
 {
-    public List<CorrespondenceDetails> Correspondences { get; set; }
+    public List<InitializedCorrespondencesExt> Correspondences { get; set; }
     public List<Guid> AttachmentIds { get; set; }
+}
+
+
+public class InitializedCorrespondencesExt
+{
+    public Guid CorrespondenceId { get; set; }
+    public CorrespondenceStatusExt Status { get; set; }
+    public required string Recipient { get; set; }
+    public List<InitializedCorrespondencesNotificationsExt>? Notifications { get; set; }
+}
+public class InitializedCorrespondencesNotificationsExt
+{
+    public Guid? OrderId { get; set; }
+    public bool? IsReminder { get; set; }
+    public InitializedNotificationStatusExt Status { get; set; }
+}
+public enum InitializedNotificationStatusExt
+{
+    Success,
+    MissingContact,
+    Failure,
 }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceResponse.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceResponse.cs
@@ -4,11 +4,11 @@ namespace Altinn.Correspondence.Application.InitializeCorrespondences;
 
 public class InitializeCorrespondencesResponse
 {
-    public List<InializedCorrespondences> Correspondences { get; set; }
+    public List<InitializedCorrespondences> Correspondences { get; set; }
     public List<Guid> AttachmentIds { get; set; }
 }
 
-public class InializedCorrespondences
+public class InitializedCorrespondences
 {
     public Guid CorrespondenceId { get; set; }
     public CorrespondenceStatus Status { get; set; }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceResponse.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceResponse.cs
@@ -4,24 +4,24 @@ namespace Altinn.Correspondence.Application.InitializeCorrespondences;
 
 public class InitializeCorrespondencesResponse
 {
-    public List<CorrespondenceDetails> Correspondences { get; set; }
+    public List<InializedCorrespondences> Correspondences { get; set; }
     public List<Guid> AttachmentIds { get; set; }
 }
 
-public class CorrespondenceDetails
+public class InializedCorrespondences
 {
     public Guid CorrespondenceId { get; set; }
     public CorrespondenceStatus Status { get; set; }
     public required string Recipient { get; set; }
-    public List<NotificationDetails>? Notifications { get; set; }
+    public List<InitializedCorrespondencesNotifications>? Notifications { get; set; }
 }
-public class NotificationDetails
+public class InitializedCorrespondencesNotifications
 {
     public Guid? OrderId { get; set; }
     public bool? IsReminder { get; set; }
-    public NotificationStatus Status { get; set; }
+    public InitializedNotificationStatus Status { get; set; }
 }
-public enum NotificationStatus 
+public enum InitializedNotificationStatus 
 {
     Success,
     MissingContact,

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -195,7 +195,7 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
         }
         await _correspondenceRepository.CreateCorrespondences(correspondences, cancellationToken);
 
-        var correspondenceDetails = new List<InializedCorrespondences>();
+        var initializedCorrespondences = new List<InitializedCorrespondences>();
         foreach (var correspondence in correspondences)
         {
             var dialogJob = _backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
@@ -254,7 +254,7 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
                     _backgroundJobClient.ContinueJobWith<IDialogportenService>(dialogJob, (dialogportenService) => dialogportenService.CreateInformationActivity(correspondence.Id, DialogportenActorType.ServiceOwner, DialogportenTextType.NotificationOrderCreated, notification.RequestedSendTime!.Value.ToString("yyyy-MM-dd HH:mm")));
                 }
             }
-            correspondenceDetails.Add(new InializedCorrespondences()
+            initializedCorrespondences.Add(new InitializedCorrespondences()
             {
                 CorrespondenceId = correspondence.Id,
                 Status = correspondence.GetLatestStatus().Status,
@@ -265,7 +265,7 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
 
         return new InitializeCorrespondencesResponse()
         {
-            Correspondences = correspondenceDetails,
+            Correspondences = initializedCorrespondences,
             AttachmentIds = correspondences.SelectMany(c => c.Content?.Attachments.Select(a => a.AttachmentId)).ToList()
         };
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The InitializeCorrespondence endpoint was not using Ext models, but rather returning the application models. However, these two models should be seperated as they may serve different purposes and we want to have better control over what the API is returning for its consumers. 

The `CorrespondenceDetails` model has also been renamed. I found it too confusing and easy to mistake for the return model of the `GetCorrespondenceDetails` endpoint. My mistake, as I was the one who chose that name. 

## Related Issue(s)
- #458 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced correspondence response model with detailed status and notification handling.
	- Introduced new classes and enumerations for improved data representation.

- **Bug Fixes**
	- Improved error handling for notification creation failures.

- **Refactor**
	- Updated response handling methods to utilize centralized mapping for better maintainability.
	- Renamed and restructured classes to align with new correspondence and notification models.

- **Tests**
	- Updated tests to reflect changes in correspondence status and notification handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->