### PR TITLE
Allow correspondence without attachment in form-data endpoint

### DIFF
--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -492,9 +492,6 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
     public async Task UploadCorrespondenceWithoutAttachments_Gives_Ok()
     {
         // Arrange
-        using var stream = File.OpenRead("./Data/Markdown.text");
-        var file = new FormFile(stream, 0, stream.Length, null, Path.GetFileName(stream.Name));
-        var attachmentData = AttachmentHelper.GetAttachmentMetaData(file.FileName);
         var payload = new CorrespondenceBuilder()
             .CreateCorrespondence()
             .Build();
@@ -503,6 +500,7 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
 
         // Act
         var uploadCorrespondenceResponse = await _senderClient.PostAsync("correspondence/api/v1/correspondence/upload", formData);
+
         // Assert
         Assert.True(uploadCorrespondenceResponse.IsSuccessStatusCode, await uploadCorrespondenceResponse.Content.ReadAsStringAsync());
     }

--- a/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/CorrespondenceControllerTests.cs
@@ -489,6 +489,25 @@ public class CorrespondenceControllerTests : IClassFixture<CustomWebApplicationF
     }
 
     [Fact]
+    public async Task UploadCorrespondenceWithoutAttachments_Gives_Ok()
+    {
+        // Arrange
+        using var stream = File.OpenRead("./Data/Markdown.text");
+        var file = new FormFile(stream, 0, stream.Length, null, Path.GetFileName(stream.Name));
+        var attachmentData = AttachmentHelper.GetAttachmentMetaData(file.FileName);
+        var payload = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .Build();
+        var formData = CorrespondenceToFormData(payload.Correspondence);
+        formData.Add(new StringContent("0192:986252932"), "recipients[0]");
+
+        // Act
+        var uploadCorrespondenceResponse = await _senderClient.PostAsync("correspondence/api/v1/correspondence/upload", formData);
+        // Assert
+        Assert.True(uploadCorrespondenceResponse.IsSuccessStatusCode, await uploadCorrespondenceResponse.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
     public async Task UploadCorrespondence_WithoutAttachments_ReturnsUnsupportedMediaType()
     {
         // Arrange

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -52,7 +52,7 @@ namespace Altinn.Correspondence.API.Controllers
                 LogContextHelpers.EnrichLogsWithInsertCorrespondence(request.Correspondence);
                 _logger.LogInformation("Initialize correspondences");
 
-                var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, null, request.ExistingAttachments, false);
+                var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, null, request.ExistingAttachments);
                 var commandResult = await handler.Process(commandRequest, cancellationToken);
 
                 return commandResult.Match(
@@ -86,7 +86,7 @@ namespace Altinn.Correspondence.API.Controllers
 
             Request.EnableBuffering();
 
-            var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, attachments, request.ExistingAttachments, true);
+            var commandRequest = InitializeCorrespondencesMapper.MapToRequest(request.Correspondence, request.Recipients, attachments, request.ExistingAttachments);
             var commandResult = await handler.Process(commandRequest, cancellationToken);
 
             return commandResult.Match(

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
@@ -6,7 +6,7 @@ namespace Altinn.Correspondence.Mappers;
 
 internal static class InitializeCorrespondencesMapper
 {
-    internal static InitializeCorrespondencesRequest MapToRequest(BaseCorrespondenceExt initializeCorrespondenceExt, List<string> Recipients, List<IFormFile>? attachments, List<Guid>? existingAttachments, bool isUploadRequest)
+    internal static InitializeCorrespondencesRequest MapToRequest(BaseCorrespondenceExt initializeCorrespondenceExt, List<string> Recipients, List<IFormFile>? attachments, List<Guid>? existingAttachments)
     {
         var correspondence = new CorrespondenceEntity
         {
@@ -40,7 +40,6 @@ internal static class InitializeCorrespondencesMapper
         {
             Correspondence = correspondence,
             Attachments = attachments ?? new List<IFormFile>(),
-            IsUploadRequest = isUploadRequest,
             ExistingAttachments = existingAttachments ?? new List<Guid>(),
             Recipients = Recipients,
             Notification = initializeCorrespondenceExt.Notification != null ? InitializeCorrespondenceNotificationMapper.MapToRequest(initializeCorrespondenceExt.Notification) : null

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -77,15 +77,10 @@ public class InitializeCorrespondencesHandler : IHandler<InitializeCorrespondenc
         {
             return contentError;
         }
-        bool isUploadRequest = request.IsUploadRequest;
         var existingAttachmentIds = request.ExistingAttachments;
         var uploadAttachments = request.Attachments;
         var uploadAttachmentMetadata = request.Correspondence.Content.Attachments;
 
-        if (isUploadRequest && uploadAttachments.Count == 0)
-        {
-            return Errors.NoAttachments;
-        }
         // Validate that existing attachments are correct
         var existingAttachments = await _initializeCorrespondenceHelper.GetExistingAttachments(existingAttachmentIds);
         if (existingAttachments.Count != existingAttachmentIds.Count)

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesRequest.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesRequest.cs
@@ -11,8 +11,6 @@ public class InitializeCorrespondencesRequest
 
     public NotificationRequest? Notification { get; set; }
 
-    public bool IsUploadRequest { get; set; }
-
     public List<Guid> ExistingAttachments { get; set; }
 
     public List<string> Recipients { get; set; }


### PR DESCRIPTION
## Description
The /correspondence/upload is intended to be an all-in-one endpoint, and we should permit correspondences without attachments in the endpoint.

## Related Issue(s)
- #461 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new test for uploading correspondence without attachments, ensuring successful operation.
  
- **Bug Fixes**
	- Improved handling of upload requests by streamlining attachment validation logic, allowing uploads without attachments under certain conditions.

- **Refactor**
	- Simplified method signatures across various components by removing unnecessary parameters related to upload requests, enhancing code clarity. 

- **Tests**
	- Updated and retained existing tests to ensure consistent functionality in the correspondence upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->