### PR TITLE
Add `markasread` functionality to LegacyController

### DIFF
--- a/Test/Altinn.Correspondence.Tests/LegacyControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/LegacyControllerTests.cs
@@ -213,9 +213,9 @@ public class LegacyControllerTests : IClassFixture<CustomWebApplicationFactory>
         var archiveResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{randomCorrespondenceId}/archive", null);
         Assert.Equal(HttpStatusCode.NotFound, archiveResponse.StatusCode);
 
-        // TODO: Missing markasread implementation
-        // var readResponse = await _client.PostAsync($"correspondence/api/v1/legacy/correspondence/{randomCorrespondenceId}/markasread", null);
-        // Assert.Equal(HttpStatusCode.NotFound, readResponse.StatusCode);
+        // Act and Assert
+        var readResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{randomCorrespondenceId}/markasread", null);
+        Assert.Equal(HttpStatusCode.NotFound, readResponse.StatusCode);
     }
 
     [Fact]
@@ -254,7 +254,6 @@ public class LegacyControllerTests : IClassFixture<CustomWebApplicationFactory>
         Assert.Equal(HttpStatusCode.OK, archiveResponse.StatusCode);
     }
     
-    /* TODO: Implement markasread
     [Fact]
     public async Task UpdateCorrespondenceStatus_MarkAsRead_WithoutFetched_ReturnsBadRequest()
     {
@@ -271,7 +270,6 @@ public class LegacyControllerTests : IClassFixture<CustomWebApplicationFactory>
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, readResponse.StatusCode);
     }
-    */
     
     [Fact]
     public async Task UpdateCorrespondenceStatus_ToConfirmed_WithoutFetched_ReturnsBadRequest()

--- a/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
@@ -118,6 +118,34 @@ namespace Altinn.Correspondence.API.Controllers
             );
         }
 
+        /// <summary>
+        /// Mark Correspondence found by ID as read
+        /// </summary>
+        /// <remarks>
+        /// Meant for Receivers
+        /// </remarks>
+        /// <returns>StatusId</returns>
+        [HttpPost]
+        [Route("{correspondenceId}/markasread")]
+        public async Task<ActionResult> MarkAsRead(
+            Guid correspondenceId,
+            [FromServices] LegacyUpdateCorrespondenceStatusHandler handler,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Marking Correspondence as read for {correspondenceId}", correspondenceId.ToString());
+
+            var commandResult = await handler.Process(new UpdateCorrespondenceStatusRequest
+            {
+                CorrespondenceId = correspondenceId,
+                Status = CorrespondenceStatus.Read
+            }, cancellationToken);
+
+            return commandResult.Match(
+                data => Ok(data),
+                Problem
+            );
+        }
+
         /// Mark Correspondence found by ID as confirmed
         /// </summary>
         /// <remarks>

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
@@ -53,16 +53,11 @@ public class LegacyUpdateCorrespondenceStatusHandler : IHandler<UpdateCorrespond
         {
             return Errors.LegacyNoAccessToCorrespondence;
         }
-        var currentStatus = correspondence.GetLatestStatus();
-        if (currentStatus is null)
+        var currentStatusError = _updateCorrespondenceStatusHelper.ValidateCurrentStatus(correspondence);
+        if (currentStatusError is not null)
         {
-            return Errors.LatestStatusIsNull;
+            return currentStatusError;
         }
-        if (!currentStatus.Status.IsAvailableForRecipient())
-        {
-            return Errors.CorrespondenceNotFound;
-        }
-        // TODO: Implement logic for markasread and markasunread
         var updateError = _updateCorrespondenceStatusHelper.ValidateUpdateRequest(request, correspondence);
         if (updateError is not null)
         {

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
@@ -7,6 +7,29 @@ using Altinn.Correspondence.Core.Services.Enums;
 namespace Altinn.Correspondence.Application.UpdateCorrespondenceStatus;
 public class UpdateCorrespondenceStatusHelper
 {
+
+    /// <summary>
+    /// Validates if the current status of the correspondence allows for status updates.
+    /// </summary>
+    /// <param name="correspondence">The correspondence entity to validate</param>
+    /// <returns></returns>
+    public Error? ValidateCurrentStatus(CorrespondenceEntity correspondence)
+    {
+        var currentStatus = correspondence.GetLatestStatus();
+        if (currentStatus is null)
+        {
+            return Errors.LatestStatusIsNull;
+        }
+        if (!currentStatus.Status.IsAvailableForRecipient())
+        {
+            return Errors.CorrespondenceNotFound;
+        }
+        if (currentStatus!.Status.IsPurged())
+        {
+            return Errors.CorrespondencePurged;
+        }
+        return null;
+    }
     /// <summary>
     /// Validates if the requested status update is allowed based on the current correspondence state.
     /// </summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `markasread` functionality to LegacyController. This follows the same logic as the CorrespondenceController for A3. As such, more of the common methods have been moved to a helper file.

## Related Issue(s)
- #472
- #428

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to mark correspondence as read, enhancing user interaction with the correspondence API.
	- Added validation for current correspondence status to improve error handling during updates.

- **Bug Fixes**
	- Enhanced test coverage for marking correspondence as read, ensuring proper responses for non-existent correspondence.

- **Documentation**
	- Updated test cases to reflect new functionality and improved error handling in the correspondence status update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->