### PR TITLE
Restore level auth of Dialogtoken

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
@@ -168,6 +168,10 @@ public class AltinnAuthorizationService : IAltinnAuthorizationService
         {
             return IdportenXacmlMapper.ValidateIdportenAuthorizationResponse(response, user);
         }
+        if (personIdClaim?.Issuer == _dialogportenSettings.Issuer)
+        {
+            return DialogTokenXacmlMapper.ValidateDialogportenResult(response, user);
+        }
         foreach (var decision in response.Response)
         {
             var result = DecisionHelper.ValidateDecisionResult(decision, user);


### PR DESCRIPTION
## Description
This code seems to have been inadvertently removed in a previous PR, breaking Dialogtoken auth

## Related Issue(s)
- #490 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user access validation and authorization response handling for Dialogporten integration.
	- Improved logic for determining minimum authorization levels based on organization numbers.

- **Bug Fixes**
	- Refined error handling and logging for user access checks.

- **Documentation**
	- Updated method signatures for clarity and improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->