### PR TITLE
Legacy overview autosets read status

### DIFF
--- a/Test/Altinn.Correspondence.Tests/LegacyControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/LegacyControllerTests.cs
@@ -270,6 +270,26 @@ public class LegacyControllerTests : IClassFixture<CustomWebApplicationFactory>
         Assert.Equal(HttpStatusCode.BadRequest, readResponse.StatusCode);
     }
 
+    public async Task Overview_Sets_Read_Status()
+    {
+        // Arrange
+        var payload = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .Build();
+        var correspondence = await CorrespondenceHelper.GetInitializedCorrespondence(_senderClient, _serializerOptions, payload);
+        var correspondenceId = correspondence.CorrespondenceId;
+
+        // Act
+        var response = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{correspondenceId}/overview");
+        var firstOverview = await response.Content.ReadFromJsonAsync<LegacyCorrespondenceOverviewExt>(_serializerOptions);
+        response = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{correspondenceId}/overview");
+        var secondOverview = await response.Content.ReadFromJsonAsync<LegacyCorrespondenceOverviewExt>(_serializerOptions);
+
+        // Assert
+        Assert.Equal(CorrespondenceStatusExt.Published, firstOverview?.Status);
+        Assert.Equal(CorrespondenceStatusExt.Read, secondOverview?.Status);
+    }
+
     [Fact]
     public async Task UpdateCorrespondenceStatus_ToConfirmed_WithoutFetched_ReturnsBadRequest()
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When calling overview for legacy, the correspondence is marked as read


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
