### PR TITLE
Use highest status instead of newest for legacy

### DIFF
--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -132,7 +132,7 @@ public class LegacyGetCorrespondencesHandler : IHandler<LegacyGetCorrespondences
                     ServiceOwnerName = String.IsNullOrWhiteSpace(correspondence.MessageSender) ? owner!.Name : correspondence.MessageSender,
                     InstanceOwnerPartyId = recipient?.PartyId ?? 0,
                     MessageTitle = correspondence.Content.MessageTitle,
-                    Status = correspondence.GetLatestStatusWithoutPurged().Status,
+                    Status = correspondence.GetHighestStatusWithoutPurged().Status,
                     CorrespondenceId = correspondence.Id,
                     MinimumAuthenticationLevel = (int)minAuthLevel,
                     Published = correspondence.Published,

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -56,7 +56,7 @@ public class LegacyGetCorrespondenceOverviewHandler : IHandler<Guid, LegacyGetCo
         {
             return Errors.LegacyNoAccessToCorrespondence;
         }
-        var latestStatus = correspondence.GetLatestStatus();
+        var latestStatus = correspondence.GetHighestStatus();
         if (latestStatus == null)
         {
             _logger.LogWarning("Latest status not found for correspondence");

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -17,6 +17,20 @@ public static class CorrespondenceStatusExtensions
             .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
         return statusEntity;
     }
+    public static CorrespondenceStatusEntity? GetHighestStatus(this CorrespondenceEntity correspondence)
+    {
+        var statusEntity = correspondence.Statuses
+            .Where(s => s.Status != CorrespondenceStatus.Fetched)
+            .OrderByDescending(s => s.Status).FirstOrDefault();
+        return statusEntity;
+    }
+    public static CorrespondenceStatusEntity? GetHighestStatusWithoutPurged(this CorrespondenceEntity correspondence)
+    {
+        var statusEntity = correspondence.Statuses
+            .Where(s => !s.Status.IsPurged() && s.Status != CorrespondenceStatus.Fetched)
+            .OrderByDescending(s => s.Status).FirstOrDefault();
+        return statusEntity;
+    }
     public static bool IsPurged(this CorrespondenceStatus correspondenceStatus)
     {
         return correspondenceStatus == CorrespondenceStatus.PurgedByRecipient || correspondenceStatus == CorrespondenceStatus.PurgedByAltinn;

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -7,28 +7,28 @@ public static class CorrespondenceStatusExtensions
     {
         var statusEntity = correspondence.Statuses
             .Where(s => s.Status != CorrespondenceStatus.Fetched)
-            .MaxBy(s => s.StatusChanged);
+            .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
         return statusEntity;
     }
     public static CorrespondenceStatusEntity? GetLatestStatusWithoutPurged(this CorrespondenceEntity correspondence)
     {
         var statusEntity = correspondence.Statuses
             .Where(s => !s.Status.IsPurged() && s.Status != CorrespondenceStatus.Fetched)
-            .MaxBy(s => s.StatusChanged);
+            .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
         return statusEntity;
     }
     public static CorrespondenceStatusEntity? GetHighestStatus(this CorrespondenceEntity correspondence)
     {
         var statusEntity = correspondence.Statuses
             .Where(s => s.Status != CorrespondenceStatus.Fetched)
-            .MaxBy(s => s.Status);
+            .OrderByDescending(s => s.Status).FirstOrDefault();
         return statusEntity;
     }
     public static CorrespondenceStatusEntity? GetHighestStatusWithoutPurged(this CorrespondenceEntity correspondence)
     {
         var statusEntity = correspondence.Statuses
             .Where(s => !s.Status.IsPurged() && s.Status != CorrespondenceStatus.Fetched)
-            .MaxBy(s => s.Status);
+            .OrderByDescending(s => s.Status).FirstOrDefault();
         return statusEntity;
     }
     public static bool IsPurged(this CorrespondenceStatus correspondenceStatus)

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -7,28 +7,28 @@ public static class CorrespondenceStatusExtensions
     {
         var statusEntity = correspondence.Statuses
             .Where(s => s.Status != CorrespondenceStatus.Fetched)
-            .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+            .MaxBy(s => s.StatusChanged);
         return statusEntity;
     }
     public static CorrespondenceStatusEntity? GetLatestStatusWithoutPurged(this CorrespondenceEntity correspondence)
     {
         var statusEntity = correspondence.Statuses
             .Where(s => !s.Status.IsPurged() && s.Status != CorrespondenceStatus.Fetched)
-            .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
+            .MaxBy(s => s.StatusChanged);
         return statusEntity;
     }
     public static CorrespondenceStatusEntity? GetHighestStatus(this CorrespondenceEntity correspondence)
     {
         var statusEntity = correspondence.Statuses
             .Where(s => s.Status != CorrespondenceStatus.Fetched)
-            .OrderByDescending(s => s.Status).FirstOrDefault();
+            .MaxBy(s => s.Status);
         return statusEntity;
     }
     public static CorrespondenceStatusEntity? GetHighestStatusWithoutPurged(this CorrespondenceEntity correspondence)
     {
         var statusEntity = correspondence.Statuses
             .Where(s => !s.Status.IsPurged() && s.Status != CorrespondenceStatus.Fetched)
-            .OrderByDescending(s => s.Status).FirstOrDefault();
+            .MaxBy(s => s.Status);
         return statusEntity;
     }
     public static bool IsPurged(this CorrespondenceStatus correspondenceStatus)

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -92,7 +92,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
             }
 
             return query
-                .Where(cs => statusesToFilter.Contains(cs.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status));
+                .Where(cs => statusesToFilter.Contains(cs.Statuses.OrderBy(cs => cs.Status).Last().Status));
         }
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -92,7 +92,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
             }
 
             return query
-                .Where(cs => statusesToFilter.Contains(cs.Statuses.OrderBy(cs => cs.Status).Last().Status));
+                .Where(cs => statusesToFilter.Contains(cs.Statuses.MaxBy(cs => cs.Status).Status));
         }
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -92,7 +92,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
             }
 
             return query
-                .Where(cs => statusesToFilter.Contains(cs.Statuses.MaxBy(cs => cs.Status).Status));
+                .Where(cs => statusesToFilter.Contains(cs.Statuses.OrderBy(cs => cs.Status).Last().Status));
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Use highest status instead of newest status for legacy requests 

## Related Issue(s)
- #508 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new methods for retrieving the highest status of correspondences, enhancing status evaluation capabilities.

- **Bug Fixes**
	- Updated logic for fetching the latest status of correspondences to improve accuracy in status retrieval.

- **Documentation**
	- Adjusted method signatures and descriptions to reflect changes in status retrieval logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->