### PR TITLE
PurgedCorrespondences should be available to recipient

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceStatusTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceStatusTests.cs
@@ -197,6 +197,9 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 
             var fetchResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}");
             Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
+            // Verify the correspondence status after purge
+            var purgedCorrespondence = await fetchResponse.Content.ReadFromJsonAsync<CorrespondenceOverviewExt>(_responseSerializerOptions);
+            Assert.Equal(CorrespondenceStatusExt.PurgedByRecipient, purgedCorrespondence?.Status);
         }
 
     }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceStatusTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceStatusTests.cs
@@ -177,30 +177,5 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Assert
             Assert.Equal(HttpStatusCode.OK, archiveResponse.StatusCode);
         }
-
-        [Fact]
-        public async Task Can_Get_Overview_When_Purged()
-        {
-            //  Arrange
-            var payload = new CorrespondenceBuilder()
-                .CreateCorrespondence()
-                .WithDueDateTime(DateTimeOffset.UtcNow.AddDays(1))
-                .WithConfirmationNeeded(true)
-                .Build();
-            var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
-            var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
-            Assert.Equal(CorrespondenceStatusExt.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
-            var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
-
-            var purgeRequest = await _recipientClient.DeleteAsync($"correspondence/api/v1/correspondence/{correspondenceId}/purge");
-            purgeRequest.EnsureSuccessStatusCode();
-
-            var fetchResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}");
-            Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
-            // Verify the correspondence status after purge
-            var purgedCorrespondence = await fetchResponse.Content.ReadFromJsonAsync<CorrespondenceOverviewExt>(_responseSerializerOptions);
-            Assert.Equal(CorrespondenceStatusExt.PurgedByRecipient, purgedCorrespondence?.Status);
-        }
-
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceStatusTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceStatusTests.cs
@@ -178,5 +178,26 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             Assert.Equal(HttpStatusCode.OK, archiveResponse.StatusCode);
         }
 
+        [Fact]
+        public async Task Can_Get_Overview_When_Purged()
+        {
+            //  Arrange
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithDueDateTime(DateTimeOffset.UtcNow.AddDays(1))
+                .WithConfirmationNeeded(true)
+                .Build();
+            var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+            var correspondenceResponse = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+            Assert.Equal(CorrespondenceStatusExt.Published, correspondenceResponse?.Correspondences?.FirstOrDefault()?.Status);
+            var correspondenceId = correspondenceResponse?.Correspondences?.FirstOrDefault()?.CorrespondenceId;
+
+            var purgeRequest = await _recipientClient.DeleteAsync($"correspondence/api/v1/correspondence/{correspondenceId}/purge");
+            purgeRequest.EnsureSuccessStatusCode();
+
+            var fetchResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}");
+            Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
+        }
+
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/Base/LegacyTestBase.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/Base/LegacyTestBase.cs
@@ -11,7 +11,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy.Base
         public readonly HttpClient _legacyClient;
         public readonly HttpClient _senderClient;
         public readonly string _partyIdClaim = "urn:altinn:partyid";
-        public readonly int _validPartyId = 50952483;
+        public readonly int _digdirPartyId = 50952483;
 
         public LegacyTestBase(CustomWebApplicationFactory factory)
         {
@@ -25,7 +25,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy.Base
             _senderClient = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.SenderScope));
             _legacyClient = _factory.CreateClientWithAddedClaims(
                 ("scope", AuthorizationConstants.LegacyScope),
-                (_partyIdClaim, _validPartyId.ToString()));
+                (_partyIdClaim, _digdirPartyId.ToString()));
         }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/Base/LegacyTestBase.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/Base/LegacyTestBase.cs
@@ -11,7 +11,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy.Base
         public readonly HttpClient _legacyClient;
         public readonly HttpClient _senderClient;
         public readonly string _partyIdClaim = "urn:altinn:partyid";
-        public readonly int _digdirPartyId = 50167512;
+        public readonly int _validPartyId = 50952483;
 
         public LegacyTestBase(CustomWebApplicationFactory factory)
         {
@@ -25,7 +25,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy.Base
             _senderClient = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.SenderScope));
             _legacyClient = _factory.CreateClientWithAddedClaims(
                 ("scope", AuthorizationConstants.LegacyScope),
-                (_partyIdClaim, _digdirPartyId.ToString()));
+                (_partyIdClaim, _validPartyId.ToString()));
         }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyRetrievalTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyRetrievalTests.cs
@@ -132,7 +132,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             // Assert
             var content = await response.Content.ReadFromJsonAsync<List<LegacyGetCorrespondenceHistoryResponse>>(_serializerOptions);
             Assert.NotNull(content);
-            Assert.Contains(content, status => status.User.PartyId == _digdirPartyId);
+            Assert.Contains(content, status => status.User.PartyId == _validPartyId);
             Assert.Contains(content, status => status.Status.Contains(CorrespondenceStatus.Published.ToString()));
             Assert.Contains(content, status => status.Status.Contains(CorrespondenceStatus.Fetched.ToString()));
             Assert.Contains(content, status => status.Status.Contains(CorrespondenceStatus.Confirmed.ToString()));

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyRetrievalTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyRetrievalTests.cs
@@ -132,7 +132,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             // Assert
             var content = await response.Content.ReadFromJsonAsync<List<LegacyGetCorrespondenceHistoryResponse>>(_serializerOptions);
             Assert.NotNull(content);
-            Assert.Contains(content, status => status.User.PartyId == _validPartyId);
+            Assert.Contains(content, status => status.User.PartyId == _digdirPartyId);
             Assert.Contains(content, status => status.Status.Contains(CorrespondenceStatus.Published.ToString()));
             Assert.Contains(content, status => status.Status.Contains(CorrespondenceStatus.Fetched.ToString()));
             Assert.Contains(content, status => status.Status.Contains(CorrespondenceStatus.Confirmed.ToString()));

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
@@ -162,7 +162,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             {
                 Offset = 0,
                 Limit = 10,
-                InstanceOwnerPartyIdList = new int[] { _digdirPartyId },
+                InstanceOwnerPartyIdList = new int[] { _validPartyId },
                 IncludeActive = true,
                 IncludeArchived = true,
                 IncludeDeleted = true,

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
@@ -162,7 +162,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             {
                 Offset = 0,
                 Limit = 10,
-                InstanceOwnerPartyIdList = new int[] { _validPartyId },
+                InstanceOwnerPartyIdList = new int[] { _digdirPartyId },
                 IncludeActive = true,
                 IncludeArchived = true,
                 IncludeDeleted = true,

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
@@ -162,7 +162,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             {
                 Offset = 0,
                 Limit = 10,
-                InstanceOwnerPartyIdList = new int[] { _digdirPartyId },
+                InstanceOwnerPartyIdList = new int[] { },
                 IncludeActive = true,
                 IncludeArchived = true,
                 IncludeDeleted = true,

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyStatusTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyStatusTests.cs
@@ -207,7 +207,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             var fetchResponse = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{correspondenceId}");
             Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
             // Verify the correspondence status after purge
-            var purgedCorrespondence = await fetchResponse.Content.ReadFromJsonAsync<CorrespondenceOverviewExt>(_serializerOptions);
+            var purgedCorrespondence = await fetchResponse.Content.ReadFromJsonAsync<LegacyCorrespondenceOverviewExt>(_serializerOptions);
             Assert.Equal(CorrespondenceStatusExt.PurgedByRecipient, purgedCorrespondence?.Status);
         }
 

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyStatusTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyStatusTests.cs
@@ -204,7 +204,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             var purgeRequest = await _legacyClient.DeleteAsync($"correspondence/api/v1/legacy/correspondence/{correspondenceId}/purge");
             purgeRequest.EnsureSuccessStatusCode();
 
-            var fetchResponse = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{correspondenceId}");
+            var fetchResponse = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{correspondenceId}/overview");
             Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
             // Verify the correspondence status after purge
             var purgedCorrespondence = await fetchResponse.Content.ReadFromJsonAsync<LegacyCorrespondenceOverviewExt>(_serializerOptions);

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -50,7 +50,7 @@ public class LegacyGetCorrespondenceHistoryHandler(
         var correspondenceHistory = new List<LegacyGetCorrespondenceHistoryResponse>();
         foreach (var correspondenceStatus in correspondence.Statuses)
         {
-            if (correspondenceStatus.Status.IsAvailableForRecipient())
+            if (correspondenceStatus.Status.IsAvailableForLegacyRecipient())
             {
                 correspondenceHistory.Add(await GetCorrespondenceStatus(correspondenceStatus, recipientParty, senderParty, cancellationToken));
             }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -62,7 +62,7 @@ public class LegacyGetCorrespondenceOverviewHandler : IHandler<Guid, LegacyGetCo
             _logger.LogWarning("Latest status not found for correspondence");
             return Errors.CorrespondenceNotFound;
         }
-        if (!latestStatus.Status.IsAvailableForRecipient())
+        if (!latestStatus.Status.IsAvailableForLegacyRecipient())
         {
             _logger.LogWarning("Rejected because correspondence not available for recipient in current state.");
             return Errors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -47,7 +47,7 @@ public static class CorrespondenceStatusExtensions
         List<CorrespondenceStatus> validStatuses =
         [
             CorrespondenceStatus.Published, CorrespondenceStatus.Fetched, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
-            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved
+            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved, CorrespondenceStatus.PurgedByRecipient, CorrespondenceStatus.PurgedByAltinn
         ];
         return validStatuses.Contains(correspondenceStatus);
     }

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -47,7 +47,16 @@ public static class CorrespondenceStatusExtensions
         List<CorrespondenceStatus> validStatuses =
         [
             CorrespondenceStatus.Published, CorrespondenceStatus.Fetched, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
-            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved, CorrespondenceStatus.PurgedByRecipient, CorrespondenceStatus.PurgedByAltinn
+            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved
+        ];
+        return validStatuses.Contains(correspondenceStatus);
+    }
+    public static bool IsAvailableForLegacyRecipient(this CorrespondenceStatus correspondenceStatus)
+    {
+        List<CorrespondenceStatus> validStatuses =
+        [
+            CorrespondenceStatus.Published, CorrespondenceStatus.Fetched, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
+            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved, CorrespondenceStatus.PurgedByAltinn, CorrespondenceStatus.PurgedByRecipient
         ];
         return validStatuses.Contains(correspondenceStatus);
     }

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementDevService.cs
@@ -7,11 +7,12 @@ namespace Altinn.Correspondence.Integrations.Altinn.AccessManagement;
 
 public class AltinnAccessManagementDevService : IAltinnAccessManagementService
 {
+    private readonly int _digdirPartyId = 50952483;
     public Task<List<Party>> GetAuthorizedParties(Party partyToRequestFor, CancellationToken cancellationToken = default)
     {
         Party party = new()
         {
-            PartyId = 50167512,
+            PartyId = _digdirPartyId,
             OrgNumber = "991825827",
             SSN = "",
             Resources = new List<string>(),

--- a/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
@@ -8,11 +8,12 @@ public class AltinnRegisterDevService : IAltinnRegisterService
 {
     private const string _identificationIDPattern = @"^(?:\d{11}|\d{9}|\d{4}:\d{9})$";
     private static readonly Regex IdentificationIDRegex = new(_identificationIDPattern);
+    private readonly int _digdirPartyId = 50952483;
     public Task<string?> LookUpPartyId(string identificationId, CancellationToken cancellationToken)
     {
         if (IdentificationIDRegex.IsMatch(identificationId))
         {
-            return Task.FromResult<string?>("50952483");
+            return Task.FromResult<string?>(_digdirPartyId.ToString());
         }
         return Task.FromResult<string?>(null);
     }
@@ -31,7 +32,7 @@ public class AltinnRegisterDevService : IAltinnRegisterService
         {
             return Task.FromResult<Party?>(new Party
             {
-                PartyId = 50167512,
+                PartyId = _digdirPartyId,
                 OrgNumber = "991825827",
                 SSN = "",
                 Resources = new List<string>(),
@@ -47,7 +48,7 @@ public class AltinnRegisterDevService : IAltinnRegisterService
     {
         var party = new Party
         {
-            PartyId = 50167512,
+            PartyId = _digdirPartyId,
             OrgNumber = "991825827",
             SSN = "",
             Resources = new List<string>(),

--- a/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
@@ -12,7 +12,7 @@ public class AltinnRegisterDevService : IAltinnRegisterService
     {
         if (IdentificationIDRegex.IsMatch(identificationId))
         {
-            return Task.FromResult<string?>("50167512");
+            return Task.FromResult<string?>("50952483");
         }
         return Task.FromResult<string?>(null);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds purged statuses to list over statuses available for recipient
- Add digdir party ID to all Dev integrations

## Related Issue(s)
- #508 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded criteria for determining available statuses for legacy recipients by including purged statuses.

- **Tests**
	- Added new tests to verify system behavior when a correspondence is purged.
	- Updated tests to reflect changes in request construction related to party IDs.

- **Chores**
	- Updated hardcoded `PartyId` values to a new variable for improved maintainability across relevant services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->