### PR TITLE
Use highest status instead of latest status in logic

### DIFF
--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
@@ -53,7 +53,7 @@ public class DownloadCorrespondenceAttachmentHandler(
         {
             return Errors.CorrespondenceNotFound;
         }
-        var latestStatus = correspondence.GetLatestStatus();
+        var latestStatus = correspondence.GetHighestStatus();
         if (!latestStatus.Status.IsAvailableForRecipient())
         {
             return Errors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
@@ -40,7 +40,7 @@ public class LegacyDownloadCorrespondenceAttachmentHandler(
         {
             return Errors.AttachmentNotFound;
         }
-        var latestStatus = correspondence.GetLatestStatus();
+        var latestStatus = correspondence.GetHighestStatus();
         if (!latestStatus.Status.IsAvailableForRecipient())
         {
             return Errors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -53,7 +53,7 @@ public class GetCorrespondenceDetailsHandler(
         {
             return Errors.CorrespondenceNotFound;
         }
-        var latestStatus = correspondence.GetLatestStatus();
+        var latestStatus = correspondence.GetHighestStatus();
         if (latestStatus == null)
         {
             return Errors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -51,7 +51,7 @@ public class GetCorrespondenceOverviewHandler(
             logger.LogWarning("Caller not affiliated with correspondence");
             return Errors.CorrespondenceNotFound;
         }
-        var latestStatus = correspondence.GetLatestStatus();
+        var latestStatus = correspondence.GetHighestStatus();
         if (latestStatus == null)
         {
             logger.LogWarning("Latest status not found for correspondence");

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -3,20 +3,6 @@ using Altinn.Correspondence.Core.Models.Enums;
 namespace Altinn.Correspondence.Application.Helpers;
 public static class CorrespondenceStatusExtensions
 {
-    public static CorrespondenceStatusEntity? GetLatestStatus(this CorrespondenceEntity correspondence)
-    {
-        var statusEntity = correspondence.Statuses
-            .Where(s => s.Status != CorrespondenceStatus.Fetched)
-            .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
-        return statusEntity;
-    }
-    public static CorrespondenceStatusEntity? GetLatestStatusWithoutPurged(this CorrespondenceEntity correspondence)
-    {
-        var statusEntity = correspondence.Statuses
-            .Where(s => !s.Status.IsPurged() && s.Status != CorrespondenceStatus.Fetched)
-            .OrderByDescending(s => s.StatusChanged).FirstOrDefault();
-        return statusEntity;
-    }
     public static CorrespondenceStatusEntity? GetHighestStatus(this CorrespondenceEntity correspondence)
     {
         var statusEntity = correspondence.Statuses

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -190,7 +190,8 @@ public class InitializeCorrespondencesHandler(
         foreach (var correspondence in correspondences)
         {
             var dialogJob = backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
-            if (correspondence.GetLatestStatus()?.Status != CorrespondenceStatus.Published)
+            if (correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Initialized || 
+                correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.ReadyForPublish) //TODO: Remove ReadyForPublish check if/when ReadyForPublish is removed
             {
                 var publishTime = correspondence.RequestedPublishTime;
 
@@ -248,7 +249,7 @@ public class InitializeCorrespondencesHandler(
             initializedCorrespondences.Add(new InitializedCorrespondences()
             {
                 CorrespondenceId = correspondence.Id,
-                Status = correspondence.GetLatestStatus().Status,
+                Status = correspondence.GetHighestStatus().Status,
                 Recipient = correspondence.Recipient,
                 Notifications = notificationDetails
             });

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
@@ -37,10 +37,6 @@ public class PublishCorrespondenceHandler(
         else if (correspondence.GetLatestStatus()?.Status != CorrespondenceStatus.ReadyForPublish)
         {
             errorMessage = $"Correspondence {correspondenceId} not ready for publish";
-        }
-        else if (correspondence.Content == null || correspondence.Content.Attachments.Any(a => a.Attachment?.GetLatestStatus()?.Status != AttachmentStatus.Published))
-        {
-            errorMessage = $"Correspondence {correspondenceId} has attachments not published";
         }
         else if (correspondence.RequestedPublishTime > DateTimeOffset.UtcNow)
         {

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondence.Application.Helpers;
+﻿using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
@@ -30,11 +30,11 @@ public class PublishCorrespondenceHandler(
         {
             errorMessage = "Correspondence " + correspondenceId + " not found when publishing";
         }
-        else if (hostEnvironment.IsDevelopment() && correspondence.GetLatestStatus()?.Status == CorrespondenceStatus.Published)
+        else if (hostEnvironment.IsDevelopment() && correspondence.StatusHasBeen(CorrespondenceStatus.Published))
         {
             return Task.CompletedTask;
         }
-        else if (correspondence.GetLatestStatus()?.Status != CorrespondenceStatus.ReadyForPublish)
+        else if (correspondence.GetHighestStatus()?.Status != CorrespondenceStatus.ReadyForPublish) // TODO: Change to check if equal to initialized if/when ReadyForPublish is removed
         {
             errorMessage = $"Correspondence {correspondenceId} not ready for publish";
         }

--- a/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
@@ -45,7 +45,7 @@ public class PurgeAttachmentHandler(
         bool allCorrespondencesArePurged = correspondences
             .All(correspondence =>
             {
-                var latestStatus = correspondence.GetLatestStatus();
+                var latestStatus = correspondence.GetHighestStatus();
                 if (latestStatus is null) return false;
                 return latestStatus.Status.IsPurged();
             });

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
@@ -31,7 +31,7 @@ public class PurgeCorrespondenceHelper
     }
     public Error? ValidatePurgeRequestSender(CorrespondenceEntity correspondence)
     {
-        var latestStatus = correspondence.GetLatestStatus();
+        var latestStatus = correspondence.GetHighestStatus();
         if (latestStatus == null)
         {
             return Errors.CorrespondenceNotFound;
@@ -44,7 +44,7 @@ public class PurgeCorrespondenceHelper
     }
     public Error? ValidatePurgeRequestRecipient(CorrespondenceEntity correspondence)
     {
-        var latestStatus = correspondence.GetLatestStatus();
+        var latestStatus = correspondence.GetHighestStatus();
         if (latestStatus == null)
         {
             return Errors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
@@ -23,7 +23,7 @@ public class UpdateCorrespondenceStatusHelper
     /// <returns></returns>
     public Error? ValidateCurrentStatus(CorrespondenceEntity correspondence)
     {
-        var currentStatus = correspondence.GetLatestStatus();
+        var currentStatus = correspondence.GetHighestStatus();
         if (currentStatus is null)
         {
             return Errors.LatestStatusIsNull;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use the highest valued status in the application logic, and in api responses. 
Furthermore, some logic in the publish correspondence handler have been removed, as they were related to the issue of attachments not being uploaded before creating a correspondence (issue #318)

## Related Issue(s)
- #510 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced correspondence status evaluation by updating method names from `GetLatestStatus()` to `GetHighestStatus()`, improving clarity in status retrieval.

- **Bug Fixes**
  - Maintained error handling for correspondence and attachment checks across various handlers, ensuring consistent user access verification.

- **Chores**
  - Streamlined logic for correspondence initialization and publishing processes, refining how statuses are assessed and reported.

These updates will improve the overall user experience by ensuring more accurate status handling and clearer communication of correspondence states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->