### PR TITLE
Added markdown line break to messageBody

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -162,7 +162,7 @@ namespace Altinn.Correspondence.API.Controllers
         [HttpGet]
         [Route("{correspondenceId}/content")]
         [Produces("application/vnd.dialogporten.frontchannelembed+json;type=markdown")]
-        [Authorize(AuthenticationSchemes = AuthorizationConstants.DialogportenScheme)]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient, AuthenticationSchemes = AuthorizationConstants.AltinnTokenOrDialogportenScheme)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
         public async Task<ActionResult> GetCorrespondenceContent(
             Guid correspondenceId,
@@ -176,7 +176,11 @@ namespace Altinn.Correspondence.API.Controllers
                 CorrespondenceId = correspondenceId
             }, HttpContext.User, cancellationToken);
             return commandResult.Match(
-                data => Ok(data.Content.MessageBody),
+                data =>
+                {
+                    var messageBody = data.Content.MessageBody?.Replace("\n", "<br />");
+                    return Ok(messageBody);
+                },
                 Problem
             );
         }

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -162,7 +162,7 @@ namespace Altinn.Correspondence.API.Controllers
         [HttpGet]
         [Route("{correspondenceId}/content")]
         [Produces("application/vnd.dialogporten.frontchannelembed+json;type=markdown")]
-        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient, AuthenticationSchemes = AuthorizationConstants.AltinnTokenOrDialogportenScheme)]
+        [Authorize(AuthenticationSchemes = AuthorizationConstants.DialogportenScheme)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
         public async Task<ActionResult> GetCorrespondenceContent(
             Guid correspondenceId,

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogTokenXacmlMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogTokenXacmlMapper.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 using static Altinn.Authorization.ABAC.Constants.XacmlConstants;
 
 namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
-{
+{ 
     public static class DialogTokenXacmlMapper
     {
         internal const string DefaultIssuer = "Dialogporten";
@@ -124,12 +124,13 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
         public static bool ValidateDialogportenResult(XacmlJsonResponse response, ClaimsPrincipal user)
         {
+            return true;
             foreach (var result in response.Response)
             {
                 if (!result.Decision.Equals(XacmlContextDecision.Permit.ToString()))
                 {
                     return false;
-                }
+                }                
                 if (result.Obligations != null)
                 {
                     List<XacmlJsonObligationOrAdvice> obligations = result.Obligations;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogTokenXacmlMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogTokenXacmlMapper.cs
@@ -124,7 +124,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
         public static bool ValidateDialogportenResult(XacmlJsonResponse response, ClaimsPrincipal user)
         {
-            return true;
             foreach (var result in response.Response)
             {
                 if (!result.Decision.Equals(XacmlContextDecision.Permit.ToString()))

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogTokenXacmlMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogTokenXacmlMapper.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 using static Altinn.Authorization.ABAC.Constants.XacmlConstants;
 
 namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
-{ 
+{
     public static class DialogTokenXacmlMapper
     {
         internal const string DefaultIssuer = "Dialogporten";
@@ -129,7 +129,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 if (!result.Decision.Equals(XacmlContextDecision.Permit.ToString()))
                 {
                     return false;
-                }                
+                }
                 if (result.Obligations != null)
                 {
                     List<XacmlJsonObligationOrAdvice> obligations = result.Obligations;


### PR DESCRIPTION
## Description
Line breaks in messageBody are shown as "\n", changed it to markdown format "<br />".

## Related Issue(s)
- #463 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated authorization for accessing correspondence content based on the `DialogportenScheme`.
	- Enhanced message body formatting by converting newline characters to HTML line breaks in responses.

- **Bug Fixes**
	- Improved consistency in response formatting across the correspondence API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->