### PR TITLE
Feat: Add PartyUuid to all status events for Attachment and Correspondence

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -84,7 +84,8 @@ public class DialogportenTests : IClassFixture<CustomWebApplicationFactory>
         var config = _factory.Services.GetService<IConfiguration>();
         var dialogportenSettings = new DialogportenSettings();
         config.GetSection(nameof(DialogportenSettings)).Bind(dialogportenSettings);
-        var dialogTokenClient = _factory.CreateClientWithDialogportenClaims(dialogportenSettings.Issuer, ("p", DialogportenCorrespondenceMapper.GetRecipientUrn(correspondence)));
+        var dialogTokenClient = _factory.CreateClientWithDialogportenClaims(dialogportenSettings.Issuer, ("p", DialogportenCorrespondenceMapper.GetRecipientUrn(correspondence)),
+            ("ID", correspondence.Recipient));
 
         // Act
         var contentResponse = await dialogTokenClient.GetAsync("correspondence/api/v1/correspondence/" + initializedCorrespondence.Correspondences[0].CorrespondenceId + "/content");

--- a/src/Altinn.Correspondence.API/Mappers/AttachmentStatusMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentStatusMapper.cs
@@ -13,7 +13,8 @@ internal static class AttachmentStatusMapper
         {
             Status = (AttachmentStatusExt)AttachmentStatus.Status,
             StatusText = AttachmentStatus.StatusText,
-            StatusChanged = AttachmentStatus.StatusChanged
+            StatusChanged = AttachmentStatus.StatusChanged,
+            PartyUuid = AttachmentStatus.PartyUuid,
         };
         return attachment;
     }

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceStatusMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceStatusMapper.cs
@@ -14,7 +14,8 @@ internal static class CorrespondenceStatusMapper
 
             Status = (CorrespondenceStatusExt)correspondenceStatus.Status,
             StatusText = correspondenceStatus.StatusText,
-            StatusChanged = correspondenceStatus.StatusChanged
+            StatusChanged = correspondenceStatus.StatusChanged,
+            PartyUuid = correspondenceStatus.PartyUuid
         };
         return Correspondence;
     }

--- a/src/Altinn.Correspondence.API/Models/AtachmentStatusEvent.cs
+++ b/src/Altinn.Correspondence.API/Models/AtachmentStatusEvent.cs
@@ -27,7 +27,7 @@ namespace Altinn.Correspondence.API.Models
         public DateTimeOffset StatusChanged { get; set; }
 
         /// <summary>
-        /// The UUID for the party that triggered this Correspondence Status Event
+        /// The UUID for the party that triggered this Attachment Status Event
         /// </summary>
         [JsonPropertyName("partyUuid")]
         public Guid PartyUuid { get; set; }

--- a/src/Altinn.Correspondence.API/Models/AtachmentStatusEvent.cs
+++ b/src/Altinn.Correspondence.API/Models/AtachmentStatusEvent.cs
@@ -25,5 +25,11 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("statusChanged")]
         public DateTimeOffset StatusChanged { get; set; }
+
+        /// <summary>
+        /// The UUID for the party that triggered this Correspondence Status Event
+        /// </summary>
+        [JsonPropertyName("partyUuid")]
+        public Guid PartyUuid { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.API/Models/CorrespondenceStatusEventExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceStatusEventExt.cs
@@ -25,5 +25,11 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("statusChanged")]
         public DateTimeOffset StatusChanged { get; set; }
+
+        /// <summary>
+        /// The UUID for the party that triggered this Correspondence Status Event
+        /// </summary>
+        [JsonPropertyName("partyUuid")]
+        public Guid PartyUuid { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -60,5 +60,5 @@ public static class Errors
     public static Error InvalidDateRange = new Error(52, "From date cannot be after to date", HttpStatusCode.BadRequest);
     public static Error InvalidSenderForAttachment = new Error(53, "The sender of the correspondence must be equal the sender of existing attachments", HttpStatusCode.BadRequest);
     public static Error CouldNotDetermineCaller = new Error(54, "Could not determine caller", HttpStatusCode.Unauthorized);
-    public static Error CouldNotFindPartyUuid = new Error(55, "Could retrieve party uuid from lookup in Altinn Register", HttpStatusCode.BadRequest);
+    public static Error CouldNotFindPartyUuid = new Error(55, "Could not retrieve party uuid from lookup in Altinn Register", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -60,4 +60,5 @@ public static class Errors
     public static Error InvalidDateRange = new Error(52, "From date cannot be after to date", HttpStatusCode.BadRequest);
     public static Error InvalidSenderForAttachment = new Error(53, "The sender of the correspondence must be equal the sender of existing attachments", HttpStatusCode.BadRequest);
     public static Error CouldNotDetermineCaller = new Error(54, "Could not determine caller", HttpStatusCode.Unauthorized);
+    public static Error CouldNotFindPartyUuid = new Error(55, "Could retrieve party uuid from register", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -60,5 +60,5 @@ public static class Errors
     public static Error InvalidDateRange = new Error(52, "From date cannot be after to date", HttpStatusCode.BadRequest);
     public static Error InvalidSenderForAttachment = new Error(53, "The sender of the correspondence must be equal the sender of existing attachments", HttpStatusCode.BadRequest);
     public static Error CouldNotDetermineCaller = new Error(54, "Could not determine caller", HttpStatusCode.Unauthorized);
-    public static Error CouldNotFindPartyUuid = new Error(55, "Could retrieve party uuid from register", HttpStatusCode.BadRequest);
+    public static Error CouldNotFindPartyUuid = new Error(55, "Could retrieve party uuid from lookup in Altinn Register", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -70,6 +70,10 @@ public class LegacyGetCorrespondenceOverviewHandler(
         {
             return Errors.CouldNotFindOrgNo;
         }
+        if (userParty.PartyUuid is not Guid partyUuid)
+        {
+            return Errors.CouldNotFindPartyUuid;
+        }
 
         return await TransactionWithRetriesPolicy.Execute<LegacyGetCorrespondenceOverviewResponse>(async (cancellationToken) =>
         {
@@ -80,7 +84,8 @@ public class LegacyGetCorrespondenceOverviewHandler(
                     CorrespondenceId = correspondence.Id,
                     Status = CorrespondenceStatus.Fetched,
                     StatusText = CorrespondenceStatus.Fetched.ToString(),
-                    StatusChanged = DateTimeOffset.UtcNow
+                    StatusChanged = DateTimeOffset.UtcNow,
+                    PartyUuid = partyUuid
                 }, cancellationToken);
             }
             catch (Exception e)
@@ -96,6 +101,7 @@ public class LegacyGetCorrespondenceOverviewHandler(
                     Status = CorrespondenceStatus.Read,
                     StatusChanged = DateTimeOffset.UtcNow,
                     StatusText = CorrespondenceStatus.Read.ToString(),
+                    PartyUuid = partyUuid
                 }, cancellationToken);
                 await updateCorrespondenceStatusHelper.PublishEvent(eventBus, correspondence, CorrespondenceStatus.Read, cancellationToken);
             }

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -171,7 +171,7 @@ namespace Altinn.Correspondence.Application.Helpers
             return status;
         }
 
-        public async Task<Error?> UploadAttachments(List<AttachmentEntity> correspondenceAttachments, List<IFormFile> files, CancellationToken cancellationToken)
+        public async Task<Error?> UploadAttachments(List<AttachmentEntity> correspondenceAttachments, List<IFormFile> files, Guid partyUuid, CancellationToken cancellationToken)
         {
             foreach (var file in files)
             {
@@ -184,7 +184,7 @@ namespace Altinn.Correspondence.Application.Helpers
                 OneOf<UploadAttachmentResponse, Error> uploadResponse;
                 await using (var f = file.OpenReadStream())
                 {
-                    uploadResponse = await uploadHelper.UploadAttachment(f, attachment.Id, cancellationToken);
+                    uploadResponse = await uploadHelper.UploadAttachment(f, attachment.Id, partyUuid, cancellationToken);
                 }
                 var error = uploadResponse.Match(
                     _ => { return null; },
@@ -195,14 +195,15 @@ namespace Altinn.Correspondence.Application.Helpers
             return null;
         }
 
-        public async Task<AttachmentEntity> ProcessNewAttachment(CorrespondenceAttachmentEntity correspondenceAttachment, CancellationToken cancellationToken)
+        public async Task<AttachmentEntity> ProcessNewAttachment(CorrespondenceAttachmentEntity correspondenceAttachment, Guid partyUuid, CancellationToken cancellationToken)
         {
             var status = new List<AttachmentStatusEntity>(){
                 new AttachmentStatusEntity
                 {
                     Status = AttachmentStatus.Initialized,
                     StatusChanged = DateTimeOffset.UtcNow,
-                    StatusText = AttachmentStatus.Initialized.ToString()
+                    StatusText = AttachmentStatus.Initialized.ToString(),
+                    PartyUuid = partyUuid
                 }
             };
             var attachment = correspondenceAttachment.Attachment!;

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -50,7 +50,8 @@ public class MalwareScanResultHandler(
                 AttachmentId = attachmentId,
                 Status = AttachmentStatus.Published,
                 StatusChanged = DateTimeOffset.UtcNow,
-                StatusText = AttachmentStatus.Published.ToString()
+                StatusText = AttachmentStatus.Published.ToString(),
+                PartyUuid = partyUuid
             }, cancellationToken);
             await eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.Sender, cancellationToken);
             logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
@@ -65,7 +66,8 @@ public class MalwareScanResultHandler(
                 AttachmentId = attachmentId,
                 Status = AttachmentStatus.Failed,
                 StatusChanged = DateTimeOffset.UtcNow,
-                StatusText = $"Malware scan failed: {data.ScanResultType}: {data.ScanResultDetails}"
+                StatusText = $"Malware scan failed: {data.ScanResultType}: {data.ScanResultDetails}",
+                PartyUuid = partyUuid
             }, cancellationToken);
             await eventBus.Publish(AltinnEventType.AttachmentUploadFailed, attachment.ResourceId, attachmentIdFromBlobUri, "Malware scan", attachment.Sender, cancellationToken);
             logger.LogWarning("Malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -36,7 +36,7 @@ public class MalwareScanResultHandler(
             logger.LogError("Could not parse Guid from {attachmentIdFromBlobUri}", attachmentIdFromBlobUri);
             return Errors.AttachmentNotFound;
         }
-        var party = await altinnRegisterService.LookUpPartyById(userClaimsHelper.GetUserID(), cancellationToken);
+        var party = await altinnRegisterService.LookUpPartyById(attachment.Sender, cancellationToken);
         if (party?.PartyUuid is not Guid partyUuid)
         {
             return Errors.CouldNotFindPartyUuid;

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Correspondence.Application.MalwareScanResult.Models;
+﻿using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Application.MalwareScanResult.Models;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
@@ -11,11 +12,13 @@ using System.Security.Claims;
 namespace Altinn.Correspondence.Application;
 
 public class MalwareScanResultHandler(
+    IAltinnRegisterService altinnRegisterService,
     IAttachmentRepository attachmentRepository,
     IAttachmentStatusRepository attachmentStatusRepository,
     IEventBus eventBus,
     ICorrespondenceRepository correspondenceRepository,
     ICorrespondenceStatusRepository correspondenceStatusRepository,
+    UserClaimsHelper userClaimsHelper,
     ILogger<MalwareScanResultHandler> logger) : IHandler<ScanResultData, Task>
 {
     public async Task<OneOf<Task, Error>> Process(ScanResultData data, ClaimsPrincipal? user, CancellationToken cancellationToken)
@@ -33,6 +36,11 @@ public class MalwareScanResultHandler(
             logger.LogError("Could not parse Guid from {attachmentIdFromBlobUri}", attachmentIdFromBlobUri);
             return Errors.AttachmentNotFound;
         }
+        var party = await altinnRegisterService.LookUpPartyById(userClaimsHelper.GetUserID(), cancellationToken);
+        if (party?.PartyUuid is not Guid partyUuid)
+        {
+            return Errors.CouldNotFindPartyUuid;
+        }
 
         if (data.ScanResultType.Equals("No threats found", StringComparison.InvariantCultureIgnoreCase))
         {
@@ -46,7 +54,7 @@ public class MalwareScanResultHandler(
             }, cancellationToken);
             await eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.Sender, cancellationToken);
             logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
-            await CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, cancellationToken);
+            await CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, partyUuid, cancellationToken);
             return Task.CompletedTask;
         }
         else
@@ -65,7 +73,7 @@ public class MalwareScanResultHandler(
         }
     }
 
-    public async Task CheckCorrespondenceStatusesAfterDeleteAndPublish(Guid attachmentId, CancellationToken cancellationToken)
+    public async Task CheckCorrespondenceStatusesAfterDeleteAndPublish(Guid attachmentId, Guid partyUuid, CancellationToken cancellationToken)
     {
         var attachment = await attachmentRepository.GetAttachmentById(attachmentId, true, cancellationToken);
         if (attachment == null)
@@ -88,7 +96,8 @@ public class MalwareScanResultHandler(
                     CorrespondenceId = correspondenceId,
                     Status = CorrespondenceStatus.ReadyForPublish,
                     StatusChanged = DateTime.UtcNow,
-                    StatusText = CorrespondenceStatus.ReadyForPublish.ToString()
+                    StatusText = CorrespondenceStatus.ReadyForPublish.ToString(),
+                    PartyUuid = partyUuid
                 }
             );
         }

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -46,7 +46,7 @@ public class PublishCorrespondenceHandler(
         }
         CorrespondenceStatusEntity status;
         AltinnEventType eventType = AltinnEventType.CorrespondencePublished;
-        var party = await altinnRegisterService.LookUpPartyById(userClaimsHelper.GetUserID(), cancellationToken);
+        var party = await altinnRegisterService.LookUpPartyById(correspondence.Sender, cancellationToken);
         if (party?.PartyUuid is not Guid partyUuid)
         {
             return Errors.CouldNotFindPartyUuid;

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -20,8 +20,7 @@ public class PublishCorrespondenceHandler(
     ICorrespondenceStatusRepository correspondenceStatusRepository,
     IEventBus eventBus,
     IHostEnvironment hostEnvironment,
-    IBackgroundJobClient backgroundJobClient,
-    UserClaimsHelper userClaimsHelper) : IHandler<Guid, Task>
+    IBackgroundJobClient backgroundJobClient) : IHandler<Guid, Task>
 {
     public async Task<OneOf<Task, Error>> Process(Guid correspondenceId, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {

--- a/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeAttachment/PurgeAttachmentHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace Altinn.Correspondence.Application.PurgeAttachment;
 
 public class PurgeAttachmentHandler(
+    IAltinnRegisterService altinnRegisterService,
     IAltinnAuthorizationService altinnAuthorizationService,
     IAttachmentRepository attachmentRepository,
     IAttachmentStatusRepository attachmentStatusRepository,
@@ -53,6 +54,11 @@ public class PurgeAttachmentHandler(
         {
             return Errors.PurgeAttachmentWithExistingCorrespondence;
         }
+        var party = await altinnRegisterService.LookUpPartyById(userClaimsHelper.GetUserID(), cancellationToken);
+        if (party?.PartyUuid is not Guid partyUuid)
+        {
+            return Errors.CouldNotFindPartyUuid;
+        }
         return await TransactionWithRetriesPolicy.Execute<Guid>(async (cancellationToken) =>
         {
             await storageRepository.PurgeAttachment(attachmentId, cancellationToken);
@@ -61,7 +67,8 @@ public class PurgeAttachmentHandler(
                 AttachmentId = attachmentId,
                 Status = AttachmentStatus.Purged,
                 StatusChanged = DateTimeOffset.UtcNow,
-                StatusText = AttachmentStatus.Purged.ToString()
+                StatusText = AttachmentStatus.Purged.ToString(),
+                PartyUuid = partyUuid
             }, cancellationToken);
 
             await eventBus.Publish(AltinnEventType.AttachmentPurged, attachment.ResourceId, attachmentId.ToString(), "attachment", attachment.Sender, cancellationToken);

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
@@ -67,7 +67,7 @@ public class LegacyPurgeCorrespondenceHandler(
             }, cancellationToken);
 
             await eventBus.Publish(AltinnEventType.CorrespondencePurged, correspondence.ResourceId, correspondenceId.ToString(), "correspondence", correspondence.Sender, cancellationToken);
-            await purgeCorrespondenceHelper.CheckAndPurgeAttachments(correspondenceId, cancellationToken);
+            await purgeCorrespondenceHelper.CheckAndPurgeAttachments(correspondenceId, partyUuid, cancellationToken);
             purgeCorrespondenceHelper.ReportActivityToDialogporten(isSender: false, correspondenceId);
             purgeCorrespondenceHelper.CancelNotification(correspondenceId, cancellationToken);
             return correspondenceId;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
@@ -51,6 +51,10 @@ public class LegacyPurgeCorrespondenceHandler(
         {
             return recipientPurgeError;
         }
+        if (party.PartyUuid is not Guid partyUuid)
+        {
+            return Errors.CouldNotFindPartyUuid;
+        }
         return await TransactionWithRetriesPolicy.Execute<Guid>(async (cancellationToken) =>
         {
             await correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
@@ -58,7 +62,8 @@ public class LegacyPurgeCorrespondenceHandler(
                 CorrespondenceId = correspondenceId,
                 Status = CorrespondenceStatus.PurgedByRecipient,
                 StatusChanged = DateTimeOffset.UtcNow,
-                StatusText = CorrespondenceStatus.PurgedByRecipient.ToString()
+                StatusText = CorrespondenceStatus.PurgedByRecipient.ToString(),
+                PartyUuid = partyUuid,
             }, cancellationToken);
 
             await eventBus.Publish(AltinnEventType.CorrespondencePurged, correspondence.ResourceId, correspondenceId.ToString(), "correspondence", correspondence.Sender, cancellationToken);

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHandler.cs
@@ -94,7 +94,7 @@ public class PurgeCorrespondenceHandler(
             }, cancellationToken);
 
             await eventBus.Publish(AltinnEventType.CorrespondencePurged, correspondence.ResourceId, correspondenceId.ToString(), "correspondence", correspondence.Sender, cancellationToken);
-            await purgeCorrespondenceHelper.CheckAndPurgeAttachments(correspondenceId, cancellationToken);
+            await purgeCorrespondenceHelper.CheckAndPurgeAttachments(correspondenceId, partyUuid, cancellationToken);
             purgeCorrespondenceHelper.ReportActivityToDialogporten(isSender, correspondenceId);
             purgeCorrespondenceHelper.CancelNotification(correspondenceId, cancellationToken);
             return correspondenceId;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
@@ -59,7 +59,7 @@ public class PurgeCorrespondenceHelper
         }
         return null;
     }
-    public async Task CheckAndPurgeAttachments(Guid correspondenceId, CancellationToken cancellationToken)
+    public async Task CheckAndPurgeAttachments(Guid correspondenceId, Guid partyUuid, CancellationToken cancellationToken)
     {
         var attachments = await _attachmentRepository.GetAttachmentsByCorrespondence(correspondenceId, cancellationToken);
         foreach (var attachment in attachments)
@@ -76,7 +76,8 @@ public class PurgeCorrespondenceHelper
                 AttachmentId = attachment.Id,
                 Status = AttachmentStatus.Purged,
                 StatusChanged = DateTimeOffset.UtcNow,
-                StatusText = AttachmentStatus.Purged.ToString()
+                StatusText = AttachmentStatus.Purged.ToString(),
+                PartyUuid = partyUuid
             };
             await _attachmentStatusRepository.AddAttachmentStatus(attachmentStatus, cancellationToken);
         }

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
@@ -1,5 +1,4 @@
 using Altinn.Correspondence.Application.Helpers;
-using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
@@ -10,7 +9,6 @@ using System.Security.Claims;
 namespace Altinn.Correspondence.Application.UpdateCorrespondenceStatus;
 public class LegacyUpdateCorrespondenceStatusHandler(
     ICorrespondenceRepository correspondenceRepository,
-    ICorrespondenceStatusRepository correspondenceStatusRepository,
     IAltinnAuthorizationService altinnAuthorizationService,
     IAltinnRegisterService altinnRegisterService,
     IEventBus eventBus,
@@ -49,16 +47,13 @@ public class LegacyUpdateCorrespondenceStatusHandler(
         {
             return updateError;
         }
+        if (party.PartyUuid is not Guid partyUuid)
+        {
+            return Errors.CouldNotFindPartyUuid;
+        }
         return await TransactionWithRetriesPolicy.Execute<Guid>(async (cancellationToken) =>
         {
-            await correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
-            {
-                CorrespondenceId = correspondence.Id,
-                Status = request.Status,
-                StatusChanged = DateTime.UtcNow,
-                StatusText = request.Status.ToString(),
-            }, cancellationToken);
-
+            await updateCorrespondenceStatusHelper.AddCorrespondenceStatus(correspondence, request.Status, partyUuid, cancellationToken);
             updateCorrespondenceStatusHelper.ReportActivityToDialogporten(request.CorrespondenceId, request.Status);
             await updateCorrespondenceStatusHelper.PublishEvent(eventBus, correspondence, request.Status, cancellationToken);
             return request.CorrespondenceId;

--- a/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
@@ -1,6 +1,7 @@
 using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
 using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Security.Claims;
@@ -9,12 +10,14 @@ namespace Altinn.Correspondence.Application.UploadAttachment;
 
 public class UploadAttachmentHandler(
     IAltinnAuthorizationService altinnAuthorizationService,
+    IAltinnRegisterService altinnRegisterService,
     IAttachmentRepository attachmentRepository,
     ICorrespondenceRepository correspondenceRepository,
     UploadHelper uploadHelper,
     UserClaimsHelper userClaimsHelper,
     ILogger<UploadAttachmentHandler> logger) : IHandler<UploadAttachmentRequest, UploadAttachmentResponse>
 {
+
     public async Task<OneOf<UploadAttachmentResponse, Error>> Process(UploadAttachmentRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         var attachment = await attachmentRepository.GetAttachmentById(request.AttachmentId, true, cancellationToken);
@@ -47,9 +50,14 @@ public class UploadAttachmentHandler(
         {
             return Errors.CantUploadToExistingCorrespondence;
         }
+        var party = await altinnRegisterService.LookUpPartyById(userClaimsHelper.GetUserID(), cancellationToken);
+        if (party?.PartyUuid is not Guid partyUuid)
+        {
+            return Errors.CouldNotFindPartyUuid;
+        }
         return await TransactionWithRetriesPolicy.Execute(async (cancellationToken) =>
         {
-            var uploadResult = await uploadHelper.UploadAttachment(request.UploadStream, request.AttachmentId, cancellationToken);
+            var uploadResult = await uploadHelper.UploadAttachment(request.UploadStream, request.AttachmentId, partyUuid, cancellationToken);
             return uploadResult.Match<OneOf<UploadAttachmentResponse, Error>>(
                 data => { return data; },
                 error => { return error; }

--- a/src/Altinn.Correspondence.Core/Models/Entities/AttachmentStatusEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/AttachmentStatusEntity.cs
@@ -20,6 +20,7 @@ namespace Altinn.Correspondence.Core.Models.Entities
         public Guid AttachmentId { get; set; }
         [ForeignKey("AttachmentId")]
         public AttachmentEntity? Attachment { get; set; }
+        public Guid PartyUuid { get; set; }
 
     }
 }

--- a/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceStatusEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceStatusEntity.cs
@@ -20,6 +20,7 @@ namespace Altinn.Correspondence.Core.Models.Entities
         public Guid CorrespondenceId { get; set; }
         [ForeignKey("CorrespondenceId")]
         public CorrespondenceEntity? Correspondence { get; set; }
+        public Guid PartyUuid { get; set; }
 
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
@@ -38,6 +38,7 @@ public class AltinnRegisterDevService : IAltinnRegisterService
                 PartyTypeName = PartyType.Organization,
                 UnitType = "Virksomhet",
                 Name = "Digitaliseringsdirektoratet",
+                PartyUuid = Guid.NewGuid(),
             });
         }
         return Task.FromResult<Party?>(null);
@@ -54,6 +55,7 @@ public class AltinnRegisterDevService : IAltinnRegisterService
             PartyTypeName = PartyType.Organization,
             UnitType = "Virksomhet",
             Name = "Digitaliseringsdirektoratet",
+            PartyUuid = Guid.NewGuid(),
         };
         return Task.FromResult<Party?>(party);
     }

--- a/src/Altinn.Correspondence.Persistence/Migrations/20241127091140_Add_PartyUuidToCorrespondenceStatusEntity.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20241127091140_Add_PartyUuidToCorrespondenceStatusEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241127091140_Add_PartyUuidToCorrespondenceStatusEntity")]
+    partial class Add_PartyUuidToCorrespondenceStatusEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20241127091140_Add_PartyUuidToCorrespondenceStatusEntity.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20241127091140_Add_PartyUuidToCorrespondenceStatusEntity.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_PartyUuidToCorrespondenceStatusEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "PartyUuid",
+                schema: "correspondence",
+                table: "CorrespondenceStatuses",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PartyUuid",
+                schema: "correspondence",
+                table: "CorrespondenceStatuses");
+        }
+    }
+}

--- a/src/Altinn.Correspondence.Persistence/Migrations/20241127134045_Add_PartyUuidToAttachmentStatusEntity.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20241127134045_Add_PartyUuidToAttachmentStatusEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241127134045_Add_PartyUuidToAttachmentStatusEntity")]
+    partial class Add_PartyUuidToAttachmentStatusEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20241127134045_Add_PartyUuidToAttachmentStatusEntity.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20241127134045_Add_PartyUuidToAttachmentStatusEntity.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_PartyUuidToAttachmentStatusEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "PartyUuid",
+                schema: "correspondence",
+                table: "AttachmentStatuses",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PartyUuid",
+                schema: "correspondence",
+                table: "AttachmentStatuses");
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the `Guid PartyUuid` field to `CorrespondenceStatusEntity` and `AttachmentStatusEntity`.
This is retrieved from Altinn Register using the value found in the `consumer.ID` where applicable. Otherwise the ID has defaulted to the sender, i.e Malware Scan and most Hangfire jobs.


## Related Issue(s)
- #528 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `PartyUuid` property to `AttachmentStatusEntity` and `CorrespondenceStatusEntity`, enhancing tracking of statuses associated with specific parties.
	- Enhanced error handling for party UUID retrieval across various handlers, improving robustness in user identification processes.

- **Bug Fixes**
	- Added validation for party UUID in multiple handlers to ensure accurate processing and error reporting.

- **Refactor**
	- Updated several methods to include `partyUuid` in their parameters, streamlining status updates and attachment handling.

- **Chores**
	- Added migration scripts for database schema updates to accommodate the new `PartyUuid` properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->