### PR TITLE
Functionality for recipientName token in message

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -209,6 +209,25 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
             Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
         }
+        [Fact]
+        public async Task InitializeCorrespondence_With_RecipientToken_succeeds()
+        {
+            var payload = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .WithMessageSummary("<h1>test for {{recipientName}}</h1>")
+            .Build();
+
+            var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+            Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+
+            payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithMessageSummary("<h1>test for {{recipientName}}</h1>")
+                .Build();
+
+            initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+            Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+        }
 
         [Fact]
         public async Task InitializeCorrespondence_No_Message_Body_fails()
@@ -417,7 +436,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
             var initializeContent = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
             Assert.NotNull(initializeContent);
-            var recipients = initializeContent.Correspondences.Select(c => c.Recipient).ToList(); 
+            var recipients = initializeContent.Correspondences.Select(c => c.Recipient).ToList();
             var overview = await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{initializeContent.Correspondences.First().CorrespondenceId}");
             var overviewContent = await overview.Content.ReadFromJsonAsync<GetCorrespondenceOverviewResponse>(_responseSerializerOptions);
             Assert.NotNull(overviewContent);

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -214,19 +214,19 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         {
             var payload = new CorrespondenceBuilder()
             .CreateCorrespondence()
-            .WithMessageSummary("<h1>test for {{recipientName}}</h1>")
+            .WithMessageSummary("test for {{recipientName}}")
             .Build();
 
             var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
-            Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
 
             payload = new CorrespondenceBuilder()
                 .CreateCorrespondence()
-                .WithMessageSummary("<h1>test for {{recipientName}}</h1>")
+                .WithMessageSummary("test for {{recipientName}}")
                 .Build();
 
             initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
-            Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
         }
 
         [Fact]

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -33,6 +33,7 @@ public static class CorrespondenceErrors
     public static Error ArchiveBeforeConfirmed = new Error(1026, "Cannot archive or delete a correspondence which has not been confirmed when confirmation is required", HttpStatusCode.BadRequest);
     public static Error InvalidDateRange = new Error(1027, "From date cannot be after to date", HttpStatusCode.BadRequest);
     public static Error OffsetAndLimitIsNegative = new Error(1028, "Limit and offset must be greater than or equal to 0", HttpStatusCode.BadRequest);
+    public static Error RecipientLookupFailed(List<string> recipients) { return new Error(1029, $"Could not find partyId for the following recipients: {string.Join(", ", recipients)}", HttpStatusCode.NotFound); }
 }
 public static class AttachmentErrors
 {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -326,14 +326,10 @@ namespace Altinn.Correspondence.Application.Helpers
             };
         }
 
-        public string AddRecipientToMessage(string message, string? recipient)
+        public string AddRecipientToMessage(string message, string recipient)
         {
             if (message.Contains("{{recipientName}}"))
             {
-                if (string.IsNullOrEmpty(recipient))
-                {
-                    throw new ArgumentException("Recipient is null or empty");
-                }
                 return message.Replace("{{recipientName}}", recipient);
             }
             return message;

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -11,7 +11,6 @@ using Altinn.Notifications.Core.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Tokens;
 using OneOf;
 
 namespace Altinn.Correspondence.Application.Helpers
@@ -331,7 +330,7 @@ namespace Altinn.Correspondence.Application.Helpers
         {
             if (message.Contains("{{recipientName}}"))
             {
-                if (recipient.IsNullOrEmpty())
+                if (string.IsNullOrEmpty(recipient))
                 {
                     throw new ArgumentException("Recipient is null or empty");
                 }

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -255,7 +255,6 @@ namespace Altinn.Correspondence.Application.Helpers
 
         public CorrespondenceEntity MapToCorrespondenceEntity(InitializeCorrespondencesRequest request, string recipient, List<AttachmentEntity> attachmentsToBeUploaded, Guid partyUuid, Party? partyDetails)
         {
-            Console.WriteLine("RecipientDetails: " + partyDetails?.Name);
             List<CorrespondenceStatusEntity> statuses =
             [
                 new CorrespondenceStatusEntity
@@ -330,8 +329,6 @@ namespace Altinn.Correspondence.Application.Helpers
 
         public string AddRecipientToMessage(string message, string? recipient)
         {
-            Console.WriteLine("Adding recipient to message");
-            Console.WriteLine("recipient: " + recipient);
             if (message.Contains("{{recipientName}}"))
             {
                 if (recipient.IsNullOrEmpty())

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -156,9 +156,6 @@ public class InitializeCorrespondencesHandler(
             }
             foreach (var details in recipientDetails)
             {
-                Console.WriteLine("RecipientSSN: " + details.SSN);
-                Console.WriteLine("RecipientOrgNumber: " + details.OrgNumber);
-                Console.WriteLine("RecipientDetails: " + details.Name);
                 if (details.PartyUuid == Guid.Empty)
                 {
                     return CorrespondenceErrors.RecipientLookupFailed(new List<string> { details.SSN ?? details.OrgNumber });
@@ -169,7 +166,6 @@ public class InitializeCorrespondencesHandler(
         foreach (var recipient in request.Recipients)
         {
             var recipientParty = recipientDetails.FirstOrDefault(r => r.SSN == recipient.WithoutPrefix() || r.OrgNumber == recipient.WithoutPrefix());
-            Console.WriteLine("Recipient: " + recipient);
             var correspondence = initializeCorrespondenceHelper.MapToCorrespondenceEntity(request, recipient, attachmentsToBeUploaded, partyUuid, recipientParty);
             correspondences.Add(correspondence);
         }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -170,13 +170,9 @@ public class InitializeCorrespondencesHandler(
             correspondences.Add(correspondence);
         }
         await correspondenceRepository.CreateCorrespondences(correspondences, cancellationToken);
-
-
-
         var initializedCorrespondences = new List<InitializedCorrespondences>();
         foreach (var correspondence in correspondences)
         {
-
             var dialogJob = backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
             if (correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Initialized ||
                 correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.ReadyForPublish)

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -118,7 +118,7 @@ public class InitializeCorrespondencesHandler(
             {
                 return NotificationErrors.TemplateNotFound;
             }
-            notificationContents = await GeNotificationContent(request.Notification, templates, request.Correspondence, cancellationToken, request.Correspondence.Content?.Language);
+            notificationContents = await GetNotificationContent(request.Notification, templates, request.Correspondence, cancellationToken, request.Correspondence.Content?.Language);
             if (notificationContents.Count == 0)
             {
                 return NotificationErrors.TemplateNotFound;
@@ -330,7 +330,7 @@ public class InitializeCorrespondencesHandler(
         }
         return notifications;
     }
-    private async Task<List<NotificationContent>> GeNotificationContent(NotificationRequest request, List<NotificationTemplateEntity> templates, CorrespondenceEntity correspondence, CancellationToken cancellationToken, string? language = null)
+    private async Task<List<NotificationContent>> GetNotificationContent(NotificationRequest request, List<NotificationTemplateEntity> templates, CorrespondenceEntity correspondence, CancellationToken cancellationToken, string? language = null)
     {
         var content = new List<NotificationContent>();
         var sendersName = correspondence.MessageSender;

--- a/src/Altinn.Correspondence.Core/Services/IAltinnRegisterService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IAltinnRegisterService.cs
@@ -8,4 +8,5 @@ public interface IAltinnRegisterService
     Task<string?> LookUpName(string identificationId, CancellationToken cancellationToken);
     Task<Party?> LookUpPartyByPartyId(int partyId, CancellationToken cancellationToken);
     Task<Party?> LookUpPartyById(string identificationId, CancellationToken cancellationToken);
+    Task<List<Party>?> LookUpPartiesByIds(List<string> identificationIds, CancellationToken cancellationToken);
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
@@ -61,4 +61,26 @@ public class AltinnRegisterDevService : IAltinnRegisterService
         };
         return Task.FromResult<Party?>(party);
     }
+    public Task<List<Party>?> LookUpPartiesByIds(List<string> identificationIds, CancellationToken cancellationToken)
+    {
+        var parties = new List<Party>();
+        foreach (var id in identificationIds)
+        {
+            if (IdentificationIDRegex.IsMatch(id.WithoutPrefix()))
+            {
+                parties.Add(new Party
+                {
+                    PartyId = _digdirPartyId,
+                    OrgNumber = id,
+                    SSN = id,
+                    Resources = new List<string>(),
+                    PartyTypeName = PartyType.Organization,
+                    UnitType = "Virksomhet",
+                    Name = "Digitaliseringsdirektoratet",
+                    PartyUuid = Guid.NewGuid(),
+                });
+            }
+        }
+        return Task.FromResult<List<Party>?>(parties);
+    }
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterService.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Json;
+﻿using System.Globalization;
+using System.Net.Http.Json;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Options;
 using Altinn.Correspondence.Core.Services;
@@ -78,5 +79,33 @@ public class AltinnRegisterService : IAltinnRegisterService
             return null;
         }
         return party;
+    }
+    public async Task<List<Party>?> LookUpPartiesByIds(List<string> identificationIds, CancellationToken cancellationToken = default)
+    {
+        var organizations = identificationIds.Where(x => x.IsOrganizationNumber()).Select(x => new PartyLookup() { OrgNo = x }).ToList();
+        var socialSecurityNumbers = identificationIds.Where(x => x.IsSocialSecurityNumber()).Select(x => new PartyLookup() { Ssn = x }).ToList();
+        var partyLookup = new PartyNamesLookup()
+        {
+            Parties = organizations.Concat(socialSecurityNumbers).ToList()
+        };
+        var response = await _httpClient.PostAsJsonAsync("register/api/v1/parties/nameslookup", partyLookup, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Error when looking up party names in Altinn Register.Statuscode was: {statusCode}, error was: {error}", response.StatusCode, await response.Content.ReadAsStringAsync());
+            return null;
+        }
+        var parties = await response.Content.ReadFromJsonAsync<PartyNamesLookupResult>();
+        if (parties is null)
+        {
+            _logger.LogError("Unexpected json response when looking up party names in Altinn Register");
+            return null;
+        }
+
+        return parties.PartyNames.Select(x => new Party
+        {
+            OrgNumber = x.OrgNo,
+            SSN = x.Ssn,
+            Name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(x.Name.ToLower())
+        }).ToList();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added suport for recipientName in the message (title, summary and/or body) with syntaxt {{recipientName}}

- It is a different format than Notifications because that format is not supported for markdown. 

## Related Issue(s)
- #224 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced recipient lookup capabilities with support for dynamic message content.
	- Added ability to look up multiple parties by identification IDs.

- **Improvements**
	- Improved error handling for recipient lookup scenarios.
	- Updated notification content generation process.
	- Refined message template processing with recipient name placeholders.

- **Bug Fixes**
	- Resolved issues with message content generation and recipient details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->