### PR TITLE
Setup yt01, at21, at22, at23 and at24 as possible environments

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -80,46 +80,6 @@ jobs:
           SLACK_URL: ${{ secrets.SLACK_URL }}
           MASKINPORTEN_TOKEN_EXCHANGE_ENVIRONMENT: ${{ secrets.MASKINPORTEN_TOKEN_EXCHANGE_ENVIRONMENT }}
 
-  deploy-at22:
-    name: deploy at22
-    runs-on: ubuntu-latest
-    environment: test
-    if: always() && !failure() && !cancelled() 
-    needs: [get-version, publish, test]
-    permissions: 
-      id-token: write
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Deploy to environment
-        uses: ./.github/actions/deploy-to-environment
-        with:
-          environment: at22
-          imageTag: ${{ needs.get-version.outputs.imageTag }}
-          ACCESS_MANAGEMENT_SUBSCRIPTION_KEY: ${{ secrets.ACCESS_MANAGEMENT_SUBSCRIPTION_KEY }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
-          CORRESPONDENCE_BASE_URL: ${{ secrets.CORRESPONDENCE_BASE_URL }}
-          CONTACT_RESERVATION_REGISTRY_BASE_URL: ${{ secrets.CONTACT_RESERVATION_REGISTRY_BASE_URL }}
-          DIALOGPORTEN_ISSUER: ${{ secrets.DIALOGPORTEN_ISSUER }}
-          IDPORTEN_CLIENT_ID: ${{ secrets.IDPORTEN_CLIENT_ID }}
-          IDPORTEN_CLIENT_SECRET: ${{ secrets.IDPORTEN_CLIENT_SECRET }}
-          IDPORTEN_ISSUER: ${{ secrets.IDPORTEN_ISSUER }}
-          MASKINPORTEN_CLIENT_ID: ${{ secrets.MASKINPORTEN_CLIENT_ID }}
-          MASKINPORTEN_JWK: ${{ secrets.MASKINPORTEN_JWK }}
-          PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
-          PLATFORM_SUBSCRIPTION_KEY: ${{ secrets.PLATFORM_SUBSCRIPTION_KEY }}
-          SLACK_URL: ${{ secrets.SLACK_URL }}
-          MASKINPORTEN_TOKEN_EXCHANGE_ENVIRONMENT: ${{ secrets.MASKINPORTEN_TOKEN_EXCHANGE_ENVIRONMENT }}
-
   deploy-staging:
     name: Internal staging
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -14,7 +14,11 @@ on:
           - test
           - staging
           - production
+          - yt01
+          - at21
           - at22
+          - at23
+          - at24
 
 jobs:
   get-version: 


### PR DESCRIPTION
## Description
Setup yt01, at21, at22, at23 and at24 as possible environments

Yt01 for performance testing and at-environments for SblBridge/A2 tests

## Related Issue(s)
- #573

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Updates**
	- Removed `deploy-at22` job from CI/CD workflow
	- Updated deployment environment options to include `yt01`, `at23`, and `at24`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->