### PR TITLE
Cpu bicep parameter as json

### DIFF
--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -34,6 +34,7 @@ param containerAppResources object = prodLikeEnvironment ? {
   cpu: 2
   memory: '4.0Gi'
 } : {
+  // Using json() as a workaround for Bicep float type limitations in Container Apps
   cpu: json('0.5')
   memory: '1.0Gi'
 }

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -25,16 +25,12 @@ param userIdentityClientId string
 @secure()
 param containerAppEnvId string
 
-type ContainerAppResources = {
-    cpu: int
-    memory: string
-}
 type ContainerAppScale = {
     minReplicas: int
     maxReplicas: int
 }
 param prodLikeEnvironment bool = environment == 'production' || maskinporten_token_exchange_environment == 'yt01'
-param containerAppResources ContainerAppResources = prodLikeEnvironment ? {
+param containerAppResources object = prodLikeEnvironment ? {
   cpu: 2
   memory: '4.0Gi'
 } : {


### PR DESCRIPTION
## Description
Cannot use typed object because the bicep float work-around required for containerapp cpu parameter does not work with the bicep typing system.

## Related Issue(s)
- #573

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated Azure Container App resource configuration for more flexible resource allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->