### PR TITLE
fix subunits for legacy search

### DIFF
--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -46,10 +46,6 @@ public class LegacyGetCorrespondencesHandler(
         if (request.InstanceOwnerPartyIdList != null && request.InstanceOwnerPartyIdList.Length > 0)
         {
             var authorizedParties = await altinnAccessManagementService.GetAuthorizedParties(userParty, cancellationToken);
-            foreach (var party in authorizedParties.Where(c => c.SubUnits != null && c.SubUnits.Count > 0))
-            {
-                authorizedParties.AddRange(party.SubUnits);
-            }
             var authorizedPartiesDict = authorizedParties.ToDictionary(p => p.PartyId, p => p);
             foreach (int instanceOwnerPartyId in request.InstanceOwnerPartyIdList)
             {

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -46,7 +46,11 @@ public class LegacyGetCorrespondencesHandler(
         if (request.InstanceOwnerPartyIdList != null && request.InstanceOwnerPartyIdList.Length > 0)
         {
             var authorizedParties = await altinnAccessManagementService.GetAuthorizedParties(userParty, cancellationToken);
-            var authorizedPartiesDict = authorizedParties.ToDictionary(c => c.PartyId);
+            foreach (var party in authorizedParties.Where(c => c.SubUnits != null && c.SubUnits.Count > 0))
+            {
+                authorizedParties.AddRange(party.SubUnits);
+            }
+            var authorizedPartiesDict = authorizedParties.ToDictionary(p => p.PartyId, p => p);
             foreach (int instanceOwnerPartyId in request.InstanceOwnerPartyIdList)
             {
                 if (!authorizedPartiesDict.TryGetValue(instanceOwnerPartyId, out var mappedInstanceOwner))

--- a/src/Altinn.Correspondence.Core/Models/Entities/PartyWithSubUnits.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/PartyWithSubUnits.cs
@@ -1,0 +1,10 @@
+namespace Altinn.Correspondence.Core.Models.Entities
+{
+    /// <summary>
+    /// Class representing a party
+    /// </summary>
+    public class PartyWithSubUnits : Party
+    {
+        public List<PartyWithSubUnits> SubUnits { get; set; } = new List<PartyWithSubUnits>();
+    }
+}

--- a/src/Altinn.Correspondence.Core/Repositories/IAltinnAccessManangementService.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IAltinnAccessManangementService.cs
@@ -4,5 +4,5 @@ namespace Altinn.Correspondence.Core.Repositories;
 
 public interface IAltinnAccessManagementService
 {
-    Task<List<Party>> GetAuthorizedParties(Party partyToRequestFor, CancellationToken cancellationToken = default);
+    Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementDevService.cs
@@ -8,9 +8,9 @@ namespace Altinn.Correspondence.Integrations.Altinn.AccessManagement;
 public class AltinnAccessManagementDevService : IAltinnAccessManagementService
 {
     private readonly int _digdirPartyId = 50952483;
-    public Task<List<Party>> GetAuthorizedParties(Party partyToRequestFor, CancellationToken cancellationToken = default)
+    public Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, CancellationToken cancellationToken = default)
     {
-        Party party = new()
+        PartyWithSubUnits party = new()
         {
             PartyId = _digdirPartyId,
             OrgNumber = "991825827",
@@ -20,6 +20,6 @@ public class AltinnAccessManagementDevService : IAltinnAccessManagementService
             UnitType = "Virksomhet",
             Name = "Digitaliseringsdirektoratet",
         };
-        return Task.FromResult(new List<Party> { party });
+        return Task.FromResult(new List<PartyWithSubUnits> { party });
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
@@ -45,17 +45,24 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
             _logger.LogError("Unexpected null or invalid json response from Authorization GetAuthorizedParties.");
             throw new Exception("Unexpected null or invalid json response from Authorization GetAuthorizedParties.");
         }
-
-        return responseContent.Select(p => new PartyWithSubUnits
+        List<PartyWithSubUnits> parties = new();
+        foreach (var p in responseContent)
         {
-            PartyId = p.partyId,
-            PartyUuid = p.partyUuid,
-            OrgNumber = p.organizationNumber,
-            SSN = p.personId,
-            Resources = p.authorizedResources,
-            PartyTypeName = GetType(p.type),
-            SubUnits = GetPartiesFromSubunits(p.subunits)
-        }).ToList();
+            parties.Add(new PartyWithSubUnits
+            {
+                PartyId = p.partyId,
+                OrgNumber = p.organizationNumber,
+                SSN = p.personId,
+                Resources = p.authorizedResources,
+                PartyTypeName = GetType(p.type),
+            });
+            if (p.subunits != null && p.subunits.Count > 0)
+            {
+                parties.AddRange(GetPartiesFromSubunits(p.subunits));
+            }
+        }
+
+        return parties;
     }
     public PartyType GetType(string type)
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now checks subunits for legacy search when checking access in legacy search

## Related Issue(s)
- #578 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `PartyWithSubUnits` class to support more comprehensive party representation.
	- Enhanced authorized parties retrieval to include sub-unit information.

- **Bug Fixes**
	- Improved clarity in mapping authorized parties to their identifiers.

- **Refactor**
	- Modified method signatures to return `List<PartyWithSubUnits>` instead of `List<Party>`.
	- Implemented recursive processing of party sub-units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->