### PR TITLE
Removed InitializeCorrespondences operation status

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -463,7 +463,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
             var responseObject = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
             Assert.NotNull(responseObject);
-            Assert.True(responseObject.Status == API.Models.Enums.InitializedCorrespondecesStatusExt.PartialSuccess);
             Assert.True(responseObject.Correspondences.Exists(responseObject => responseObject.Status == API.Models.Enums.CorrespondenceStatusExt.Published));
             Assert.True(responseObject.Correspondences.Exists(responseObject => responseObject.Status != API.Models.Enums.CorrespondenceStatusExt.Published));
         }

--- a/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
@@ -60,8 +60,8 @@ namespace Altinn.Correspondence.API.Auth
                         ValidateIssuerSigningKey = true,
                         ValidateIssuer = false,
                         ValidateAudience = false,
-                        RequireExpirationTime = false,
-                        ValidateLifetime = false, // Do not validate lifetime in tests
+                        RequireExpirationTime = true,
+                        ValidateLifetime = !hostEnvironment.IsDevelopment(), // Do not validate lifetime in tests
                         ClockSkew = TimeSpan.Zero
                     };
                     options.Events = new JwtBearerEvents()

--- a/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
@@ -60,8 +60,8 @@ namespace Altinn.Correspondence.API.Auth
                         ValidateIssuerSigningKey = true,
                         ValidateIssuer = false,
                         ValidateAudience = false,
-                        RequireExpirationTime = true,
-                        ValidateLifetime = !hostEnvironment.IsDevelopment(), // Do not validate lifetime in tests
+                        RequireExpirationTime = false,
+                        ValidateLifetime = false, // Do not validate lifetime in tests
                         ClockSkew = TimeSpan.Zero
                     };
                     options.Events = new JwtBearerEvents()

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
@@ -51,7 +51,6 @@ internal static class InitializeCorrespondencesMapper
     {
         return new InitializeCorrespondencesResponseExt
         {
-            Status = GetOperationStatus(response),
             Correspondences = response.Correspondences.Select(correspondence => new InitializedCorrespondencesExt
             {
                 CorrespondenceId = correspondence.CorrespondenceId,
@@ -66,22 +65,5 @@ internal static class InitializeCorrespondencesMapper
             }).ToList(),
             AttachmentIds = response.AttachmentIds
         };
-    }
-
-    private static InitializedCorrespondecesStatusExt GetOperationStatus(InitializeCorrespondencesResponse response)
-    {
-        var notificationsCount = response.Correspondences.SelectMany(c => c.Notifications).Count();
-        var notificationsThatSucceeded = response.Correspondences.SelectMany(c => c.Notifications).Where(n => n.Status == InitializedNotificationStatus.Success).Count();
-        var correspondencesCount = response.Correspondences.Count;
-        var correspondencesThatSucceeded = response.Correspondences.Where(c => c.Status == CorrespondenceStatus.ReadyForPublish || c.Status == CorrespondenceStatus.Published).Count();
-        if (notificationsCount == notificationsThatSucceeded && correspondencesCount == correspondencesThatSucceeded)
-        {
-            return InitializedCorrespondecesStatusExt.Success;
-        }
-        if (notificationsThatSucceeded == 0 && correspondencesThatSucceeded == 0)
-        {
-            return InitializedCorrespondecesStatusExt.Failed;
-        }
-        return InitializedCorrespondecesStatusExt.PartialSuccess;
     }
 }

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondencesResponseExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondencesResponseExt.cs
@@ -1,4 +1,3 @@
-using Altinn.Correspondence.API.Models.Enums;
 using System.Text.Json.Serialization;
 
 namespace Altinn.Correspondence.API.Models;
@@ -8,11 +7,6 @@ namespace Altinn.Correspondence.API.Models;
 /// </summary>
 public class InitializeCorrespondencesResponseExt
 {
-    /// <summary>
-    /// The status of the initialize correspondences operation as a whole (Success/PartialSuccess/Failed)
-    /// </summary>
-    public required InitializedCorrespondecesStatusExt Status { get; set; }
-
     /// <summary>
     /// The initialized correspondences
     /// </summary>


### PR DESCRIPTION
## Description
Removed InitializeCorrespondeces operation status because it was a bit tricky to wrap head around, and the status term collided with the existing status term.

## Related Issue(s)
- #564

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed status tracking logic for correspondence initialization.
	- Eliminated status property from correspondence response model.

- **Tests**
	- Modified correspondence initialization test to remove status assertion.

These changes streamline the correspondence initialization process and adjust token handling in the legacy authentication scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->