### PR TITLE
set default limit to 1000 for legacy search

### DIFF
--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -24,7 +24,7 @@ public class LegacyGetCorrespondencesHandler(
 
     public async Task<OneOf<LegacyGetCorrespondencesResponse, Error>> Process(LegacyGetCorrespondencesRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
-        var limit = request.Limit == 0 ? 50 : request.Limit;
+        var limit = request.Limit == 0 ? 1000 : request.Limit;
         DateTimeOffset? to = request.To != null ? ((DateTimeOffset)request.To).ToUniversalTime() : null;
         DateTimeOffset? from = request.From != null ? ((DateTimeOffset)request.From).ToUniversalTime() : null;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
default search limit is 1000 when searching legacy correspondences

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
