### PR TITLE
remove pagination from legacy search

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
@@ -30,7 +30,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_serializerOptions);
 
             Assert.True(response?.Items.Count > 0);
-            Assert.True(response?.Pagination.TotalItems > 0);
         }
 
         [Fact]
@@ -45,7 +44,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", listPayload);
             var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_serializerOptions);
             Assert.Equal(HttpStatusCode.OK, correspondenceList.StatusCode);
-            Assert.True(response?.Pagination.TotalItems > 0);
         }
         [Fact]
         public async Task GetCorrespondences_With_Different_statuses()
@@ -58,20 +56,17 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", listPayload);
             var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_serializerOptions);
             Assert.True(response?.Items.Count > 0);
-            Assert.True(response?.Pagination.TotalItems > 0);
             await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{correspondence.CorrespondenceId}/overview"); // Fetch in order to be able to Confirm
             await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{correspondence.CorrespondenceId}/confirm", null); // Update to Confirmed in order to be able to Archive
             listPayload.Status = CorrespondenceStatusExt.Confirmed;
             correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", listPayload);
             response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_serializerOptions);
             Assert.True(response?.Items.Count > 0);
-            Assert.True(response?.Pagination.TotalItems > 0);
             await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{correspondence.CorrespondenceId}/archive", null);
             listPayload.Status = CorrespondenceStatusExt.Archived;
             correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", listPayload);
             response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_serializerOptions);
             Assert.True(response?.Items.Count > 0);
-            Assert.True(response?.Pagination.TotalItems > 0);
         }
 
         [Fact]
@@ -99,7 +94,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", listPayload);
             var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_serializerOptions);
             Assert.True(response?.Items.Count > 0);
-            Assert.True(response?.Pagination.TotalItems > 0);
         }
 
         [Fact]
@@ -122,7 +116,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", listPayload);
             var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_serializerOptions);
             Assert.True(response?.Items.Count > 0);
-            Assert.True(response?.Pagination.TotalItems > 0);
         }
 
         [Fact]

--- a/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
@@ -78,12 +78,12 @@ namespace Altinn.Correspondence.Tests.TestingRepository
             }, CancellationToken.None);
 
             // Act
-            var (correspondences, correspondenceCount) = await correspondenceRepository.GetCorrespondencesForParties(0, 1000, from, to, null, [recipient], [resource], true, false, false, "", CancellationToken.None);
+            var correspondences = await correspondenceRepository.GetCorrespondencesForParties(0, 1000, from, to, null, [recipient], [resource], true, false, false, "", CancellationToken.None);
 
             // Assert
             Assert.NotNull(correspondences);
             Assert.NotEmpty(correspondences);
-            Assert.Equal(1, correspondenceCount);
+            Assert.Equal(1, correspondences?.Count);
             Assert.Equal(addedCorrespondence.Id, correspondences.FirstOrDefault()?.Id);
         }
     }

--- a/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
@@ -78,7 +78,7 @@ namespace Altinn.Correspondence.Tests.TestingRepository
             }, CancellationToken.None);
 
             // Act
-            var correspondences = await correspondenceRepository.GetCorrespondencesForParties(0, 1000, from, to, null, [recipient], [resource], true, false, false, "", CancellationToken.None);
+            var correspondences = await correspondenceRepository.GetCorrespondencesForParties(1000, from, to, null, [recipient], [resource], true, false, false, "", CancellationToken.None);
 
             // Assert
             Assert.NotNull(correspondences);

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -68,7 +68,7 @@ public class LegacyGetCorrespondencesHandler(
         List<string> resourcesToSearch = new List<string>();
 
         // Get all correspondences owned by Recipients
-        var (correspondences, correspondencesCount) = await correspondenceRepository.GetCorrespondencesForParties(request.Offset, limit, from, to, request.Status, recipients, resourcesToSearch, request.IncludeActive, request.IncludeArchived, request.IncludeDeleted, request.SearchString, cancellationToken);
+        var correspondences = await correspondenceRepository.GetCorrespondencesForParties(request.Offset, limit, from, to, request.Status, recipients, resourcesToSearch, request.IncludeActive, request.IncludeArchived, request.IncludeDeleted, request.SearchString, cancellationToken);
 
         var resourceIds = correspondences.Select(c => c.ResourceId).Distinct().ToList();
         var authorizedCorrespondences = new List<CorrespondenceEntity>();
@@ -153,12 +153,6 @@ public class LegacyGetCorrespondencesHandler(
         var response = new LegacyGetCorrespondencesResponse
         {
             Items = correspondenceItems,
-            Pagination = new PaginationMetaData
-            {
-                Offset = request.Offset,
-                Limit = limit,
-                TotalItems = correspondencesCount - correspondenceToSubtractFromTotal
-            }
         };
         return response;
     }

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -68,7 +68,7 @@ public class LegacyGetCorrespondencesHandler(
         List<string> resourcesToSearch = new List<string>();
 
         // Get all correspondences owned by Recipients
-        var correspondences = await correspondenceRepository.GetCorrespondencesForParties(request.Offset, limit, from, to, request.Status, recipients, resourcesToSearch, request.IncludeActive, request.IncludeArchived, request.IncludeDeleted, request.SearchString, cancellationToken);
+        var correspondences = await correspondenceRepository.GetCorrespondencesForParties(limit, from, to, request.Status, recipients, resourcesToSearch, request.IncludeActive, request.IncludeArchived, request.IncludeDeleted, request.SearchString, cancellationToken);
 
         var resourceIds = correspondences.Select(c => c.ResourceId).Distinct().ToList();
         var authorizedCorrespondences = new List<CorrespondenceEntity>();
@@ -118,13 +118,11 @@ public class LegacyGetCorrespondencesHandler(
                 recipientDetails.Add(new PartyInfo(orgNr, null));
             }
         }
-        var correspondenceToSubtractFromTotal = 0;
         foreach (var correspondence in correspondences)
         {
             var authLevel = await altinnAuthorizationService.CheckUserAccessAndGetMinimumAuthLevel(user, userParty.SSN, correspondence.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Read }, correspondence.Recipient, cancellationToken);
             if (minAuthLevel == null || minAuthLevel < authLevel)
             {
-                correspondenceToSubtractFromTotal++;
                 continue;
             }
             var purgedStatus = correspondence.GetPurgedStatus();

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesResponse.cs
@@ -6,8 +6,6 @@ namespace Altinn.Correspondence.Application.GetCorrespondences
     public class LegacyGetCorrespondencesResponse
     {
         public List<LegacyCorrespondenceItem> Items { get; set; } = new List<LegacyCorrespondenceItem>();
-
-        public PaginationMetaData Pagination { get; set; } = new PaginationMetaData();
     }
 
     public class LegacyCorrespondenceItem

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -20,7 +20,7 @@ namespace Altinn.Correspondence.Core.Repositories
             CorrespondencesRoleType role,
             CancellationToken cancellationToken);
 
-        Task<(List<CorrespondenceEntity>, int)> GetCorrespondencesForParties(
+        Task<List<CorrespondenceEntity>> GetCorrespondencesForParties(
             int offset,
             int limit,
             DateTimeOffset? from,

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -21,7 +21,6 @@ namespace Altinn.Correspondence.Core.Repositories
             CancellationToken cancellationToken);
 
         Task<List<CorrespondenceEntity>> GetCorrespondencesForParties(
-            int offset,
             int limit,
             DateTimeOffset? from,
             DateTimeOffset? to,

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -122,7 +122,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
             }
         }
 
-        public async Task<List<CorrespondenceEntity>> GetCorrespondencesForParties(int offset, int limit, DateTimeOffset? from, DateTimeOffset? to, CorrespondenceStatus? status, List<string> recipientIds, List<string> resourceIds, bool includeActive, bool includeArchived, bool includePurged, string searchString, CancellationToken cancellationToken)
+        public async Task<List<CorrespondenceEntity>> GetCorrespondencesForParties(int limit, DateTimeOffset? from, DateTimeOffset? to, CorrespondenceStatus? status, List<string> recipientIds, List<string> resourceIds, bool includeActive, bool includeArchived, bool includePurged, string searchString, CancellationToken cancellationToken)
         {
             var correspondences = recipientIds.Count == 1
                 ? _context.Correspondences.Where(c => c.Recipient == recipientIds[0])     // Filter by single recipient
@@ -138,7 +138,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .Include(c => c.Content)
                 .OrderByDescending(c => c.RequestedPublishTime);             // Sort by RequestedPublishTime
 
-            var result = await correspondences.Skip(offset).Take(limit).ToListAsync(cancellationToken);
+            var result = await correspondences.Take(limit).ToListAsync(cancellationToken);
             return result;
         }
     }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -122,7 +122,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
             }
         }
 
-        public async Task<(List<CorrespondenceEntity>, int)> GetCorrespondencesForParties(int offset, int limit, DateTimeOffset? from, DateTimeOffset? to, CorrespondenceStatus? status, List<string> recipientIds, List<string> resourceIds, bool includeActive, bool includeArchived, bool includePurged, string searchString, CancellationToken cancellationToken)
+        public async Task<List<CorrespondenceEntity>> GetCorrespondencesForParties(int offset, int limit, DateTimeOffset? from, DateTimeOffset? to, CorrespondenceStatus? status, List<string> recipientIds, List<string> resourceIds, bool includeActive, bool includeArchived, bool includePurged, string searchString, CancellationToken cancellationToken)
         {
             var correspondences = recipientIds.Count == 1
                 ? _context.Correspondences.Where(c => c.Recipient == recipientIds[0])     // Filter by single recipient
@@ -138,9 +138,8 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .Include(c => c.Content)
                 .OrderByDescending(c => c.RequestedPublishTime);             // Sort by RequestedPublishTime
 
-            var totalItems = await correspondences.CountAsync(cancellationToken);
             var result = await correspondences.Skip(offset).Take(limit).ToListAsync(cancellationToken);
-            return (result, totalItems);
+            return result;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes pagination from legacy search. It is not used in A2. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
	- Removed pagination metadata from correspondence retrieval
	- Modified method signatures to return only correspondence list without total count

- **Refactor**
	- Simplified correspondence retrieval process
	- Removed count tracking from repository and response methods

- **Impact**
	- Applications using these methods will need to update their pagination logic
	- Clients will no longer receive automatic pagination metadata with correspondence requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->