### PR TITLE
get name instead of orgNumber for service owner

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/ResourceRightsService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/ResourceRightsService.cs
@@ -38,6 +38,16 @@ public class ResourceRightsService : IResourceRightsService
             _logger.LogError("Failed to deserialize response from Altinn Resource Registry");
             throw new BadHttpRequestException("Failed to process response from Altinn Resource Registry");
         }
-        return altinnResourceResponse.HasCompetentAuthority.Organization;
+        var nameAttributes = new List<string> { "en", "nb-no", "nn-no" };
+        string? name = null;
+        foreach (var nameAttribute in nameAttributes)
+        {
+            if (altinnResourceResponse.HasCompetentAuthority.Name?.ContainsKey(nameAttribute) == true)
+            {
+                name = altinnResourceResponse.HasCompetentAuthority.Name[nameAttribute];
+                break;
+            }
+        }
+        return name;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Gets name when gathering info abour resource owner. 


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource owner retrieval process with more robust error handling
	- Enhanced service owner name lookup to support multiple language attributes

- **Refactor**
	- Simplified resource owner data management by switching from list to dictionary
	- Streamlined resource owner information retrieval logic

The changes optimize the correspondence and resource management systems, providing more flexible and resilient data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->