### PR TITLE
Cache API responses in AltinnRegisterService 

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingUtility/CacheHelpersTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/CacheHelpersTests.cs
@@ -1,0 +1,84 @@
+using Moq;
+using Microsoft.Extensions.Caching.Distributed;
+using Altinn.Correspondence.Common.Helpers;
+using System.Text.Json;
+using System.Text;
+
+namespace Altinn.Correspondence.Tests.TestingUtility
+{
+    public class CacheHelpersTests
+    {
+        [Fact]
+        public async Task StoreObjectInCacheAsync_ShouldStoreSerializedObjectInCache()
+        {
+            // Arrange
+            var key = "myKey";
+            Dictionary<string, object> value = new()
+            {
+                { "Name", "John" },
+                { "Age", 30 }
+            };
+            var cacheOptions = new DistributedCacheEntryOptions();
+            var cancellationToken = CancellationToken.None;
+            var serializedDataString = JsonSerializer.Serialize(value);
+            var mockCache = new Mock<IDistributedCache>();
+
+            mockCache.Setup(cache => cache.SetAsync(
+                key,
+                It.Is<byte[]>(bytes => bytes != null && bytes.Length > 0),
+                cacheOptions,
+                cancellationToken
+            )).Returns(Task.CompletedTask);
+
+            // Act
+            await CacheHelpers.StoreObjectInCacheAsync(key, value, mockCache.Object, cacheOptions, cancellationToken);
+
+            // Assert
+            mockCache.Verify(cache => cache.SetAsync(
+                key, 
+                It.Is<byte[]>(bytes => bytes.SequenceEqual(Encoding.UTF8.GetBytes(serializedDataString))),
+                cacheOptions, 
+                cancellationToken),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetObjectFromCacheAsync_ShouldReturnDeserializedObject_WhenDataIsFound()
+        {
+            // Arrange
+            var key = "myKey";
+            string storedValue = "John";
+            var serializedData = JsonSerializer.Serialize(storedValue);
+            var cancellationToken = CancellationToken.None;
+            var mockCache = new Mock<IDistributedCache>();
+            
+            mockCache.Setup(cache => cache.GetAsync(key, cancellationToken))
+                .ReturnsAsync(Encoding.UTF8.GetBytes(serializedData));
+
+            // Act
+            var result = await CacheHelpers.GetObjectFromCacheAsync<string>(key, mockCache.Object, cancellationToken);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(storedValue, result);
+        }
+
+        [Fact]
+        public async Task GetObjectFromCacheAsync_ShouldReturnNull_WhenDataIsNotFound()
+        {
+            // Arrange
+            var key = "unknownKey";
+            var cancellationToken = CancellationToken.None;
+            var mockCache = new Mock<IDistributedCache>();
+
+            mockCache.Setup(cache => cache.GetAsync(key, cancellationToken))
+                .ReturnsAsync(Array.Empty<byte>());
+
+            // Act
+            var result = await CacheHelpers.GetObjectFromCacheAsync<object>(key, mockCache.Object, cancellationToken);
+
+            // Assert
+            Assert.Null(result);
+        }
+    }
+}

--- a/src/Altinn.Correspondence.Common/Helpers/CacheHelpers.cs
+++ b/src/Altinn.Correspondence.Common/Helpers/CacheHelpers.cs
@@ -5,13 +5,13 @@ namespace Altinn.Correspondence.Common.Helpers
 {
     public static class CacheHelpers
     {
-        private static async Task StoreObjectInCacheAsync<T>(string key, T value, IDistributedCache cache, DistributedCacheEntryOptions cacheOptions, CancellationToken cancellationToken = default)
+        public static async Task StoreObjectInCacheAsync<T>(string key, T value, IDistributedCache cache, DistributedCacheEntryOptions cacheOptions, CancellationToken cancellationToken = default)
         {
             string serializedDataString = JsonSerializer.Serialize(value);
             await cache.SetStringAsync(key, serializedDataString, cacheOptions, cancellationToken);
         }
 
-        private static async Task<T?> GetObjectFromCacheAsync<T>(string key, IDistributedCache cache, CancellationToken cancellationToken = default)
+        public static async Task<T?> GetObjectFromCacheAsync<T>(string key, IDistributedCache cache, CancellationToken cancellationToken = default)
         {
             string? cachedDataString = await cache.GetStringAsync(key, cancellationToken);
             if (!string.IsNullOrEmpty(cachedDataString))

--- a/src/Altinn.Correspondence.Common/Helpers/CacheHelpers.cs
+++ b/src/Altinn.Correspondence.Common/Helpers/CacheHelpers.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Altinn.Correspondence.Common.Helpers
+{
+    public static class CacheHelpers
+    {
+        private static async Task StoreObjectInCacheAsync<T>(string key, T value, IDistributedCache cache, DistributedCacheEntryOptions cacheOptions, CancellationToken cancellationToken = default)
+        {
+            string serializedDataString = JsonSerializer.Serialize(value);
+            await cache.SetStringAsync(key, serializedDataString, cacheOptions, cancellationToken);
+        }
+
+        private static async Task<T?> GetObjectFromCacheAsync<T>(string key, IDistributedCache cache, CancellationToken cancellationToken = default)
+        {
+            string? cachedDataString = await cache.GetStringAsync(key, cancellationToken);
+            if (!string.IsNullOrEmpty(cachedDataString))
+            {
+                return JsonSerializer.Deserialize<T?>(cachedDataString);
+            }
+            return default;
+        }
+    }
+}

--- a/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterService.cs
@@ -54,7 +54,7 @@ public class AltinnRegisterService : IAltinnRegisterService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error retrieving Party from cache when looking up Party in Altinn Register.");
+            _logger.LogWarning(ex, "Error retrieving Party from cache when looking up Party in Altinn Register Service.");
         }
 
         if (partyId <= 0)
@@ -82,7 +82,7 @@ public class AltinnRegisterService : IAltinnRegisterService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error saving response content to cache when looking up Party in Altinn Register.");
+            _logger.LogWarning(ex, "Error storing response content to cache when looking up Party in Altinn Register Service.");
         }
 
         return party;
@@ -101,7 +101,7 @@ public class AltinnRegisterService : IAltinnRegisterService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error retrieving organization from cache when looking up organization in Altinn Register.");
+            _logger.LogWarning(ex, "Error retrieving organization from cache when looking up organization in Altinn Register Service.");
         }
 
         identificationId = identificationId.WithoutPrefix();
@@ -131,7 +131,7 @@ public class AltinnRegisterService : IAltinnRegisterService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error saving response content to cache when looking up organization in Altinn Register.");
+            _logger.LogWarning(ex, "Error storing response content to cache when looking up organization in Altinn Register Service.");
         }
 
         return party;
@@ -150,7 +150,7 @@ public class AltinnRegisterService : IAltinnRegisterService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error retrieving party names from cache when looking up party names in Altinn Register.");
+            _logger.LogWarning(ex, "Error retrieving party names from cache when looking up party names in Altinn Register Service.");
         }
 
         var organizations = identificationIds.Where(x => x.IsOrganizationNumber()).Select(x => new PartyLookup() { OrgNo = x }).ToList();
@@ -185,7 +185,7 @@ public class AltinnRegisterService : IAltinnRegisterService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error saving response content to cache when looking up organization in Altinn Register.");
+            _logger.LogWarning(ex, "Error storing response content to cache when looking up party names in Altinn Register Service.");
         }
 
         return partyNames;

--- a/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterService.cs
@@ -139,7 +139,7 @@ public class AltinnRegisterService : IAltinnRegisterService
 
     public async Task<List<Party>?> LookUpPartiesByIds(List<string> identificationIds, CancellationToken cancellationToken = default)
     {
-        string cacheKey = $"PartiesByIds_{string.Join("_", identificationIds)}";
+        string cacheKey = $"PartiesByIds_{string.Join("_", identificationIds).GetHashCode()}";
         try
         {
             var cachedParty = await CacheHelpers.GetObjectFromCacheAsync<List<Party>>(cacheKey, _cache, cancellationToken);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To improve performance and avoid unnecessary API calls, this PR introduces caching for API responses in AltinnRegisterService. By caching the responses, subsequent lookups with the same parameter are retrieved from cache, resulting in reduced latency and faster retrieval times.

## Related Issue(s)
- #609 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced caching mechanism for party lookups in the Altinn Register Service.
	- Added utility methods for storing and retrieving objects from a distributed cache.

- **Performance Improvements**
	- Enhanced service efficiency by reducing redundant API calls.
	- Streamlined caching process by eliminating unnecessary serialization steps.
	- Implemented 24-hour caching for party data retrieval.

- **Chores**
	- Updated service constructor to support distributed caching.
	- Added error handling for cache operations.
	- Introduced unit tests for cache utility methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->