### PR TITLE
Cache API responses in ResourceRightsService

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/ResourceRightsServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/ResourceRightsServiceTests.cs
@@ -1,0 +1,183 @@
+using Moq;
+using Microsoft.Extensions.Caching.Distributed;
+using System.Text.Json;
+using System.Text;
+using Altinn.Correspondence.Integrations.Altinn.ResourceRegistry;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Altinn.Correspondence.Core.Options;
+using System.Net;
+using Moq.Protected;
+
+namespace Altinn.Correspondence.Tests.TestingFeature
+{
+    public class ResourceRightsServiceTests
+    {
+        private readonly Mock<HttpMessageHandler> _mockHandler;
+        private readonly Mock<IDistributedCache> _mockCache;
+        private readonly HttpClient _httpClient;
+        private readonly Mock<ILogger<ResourceRightsService>> _mockLogger;
+        private readonly Mock<IOptions<AltinnOptions>> _mockOptions;
+        private readonly ResourceRightsService _service;
+
+        public ResourceRightsServiceTests()
+        {
+            _mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            SetupMessageHandler();
+            _httpClient = new HttpClient(_mockHandler.Object);
+            _mockCache = new Mock<IDistributedCache>();
+            _mockLogger = new Mock<ILogger<ResourceRightsService>>();
+            _mockOptions = new Mock<IOptions<AltinnOptions>>();
+            
+            _mockOptions.Setup(o => o.Value).Returns(new AltinnOptions { PlatformGatewayUrl = "https://example.com" });
+
+            _service = new ResourceRightsService(_httpClient, _mockOptions.Object, _mockLogger.Object, _mockCache.Object);
+        }
+
+        private void SetupMessageHandler()
+        {
+            var TestResourceResponse = CreateTestResourceResponse();
+            var serializedMockResponse = JsonSerializer.Serialize(TestResourceResponse);
+            var mockHttpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(serializedMockResponse, Encoding.UTF8, "application/json")
+            };
+            _mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get && 
+                        req.RequestUri != null && req.RequestUri.AbsoluteUri == "https://example.com/resourceregistry/api/v1/resource/12345"), 
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(mockHttpResponse);
+        }
+
+        private static GetResourceResponse CreateTestResourceResponse()
+        {
+            return new GetResourceResponse
+            {
+                Identifier = "12345",
+                Title = new Dictionary<string, string> { { "en", "Resource Title" } },
+                Description = new Dictionary<string, string> { { "en", "Resource Description" } },
+                HasCompetentAuthority = new HasCompetentAuthority
+                {
+                    Organization = "Org Name",
+                    Orgcode = "123",
+                    Name = new Dictionary<string, string> { { "en", "John Doe from API" } }
+                },
+                ResourceType = "SampleResourceType"
+            };
+        }
+
+        private void MockSetupSimulateCacheMiss(string key, CancellationToken cancellationToken)
+        {
+            _mockCache.Setup(cache => cache.GetAsync(key, cancellationToken))
+                .ReturnsAsync(null as byte[]);
+        }
+
+        private void MockSetupSimulateStoreInCache(string key, string serializedValue, CancellationToken cancellationToken)
+        {
+            _mockCache.Setup(cache => cache.SetAsync(
+                key,
+                It.Is<byte[]>(bytes => bytes.SequenceEqual(Encoding.UTF8.GetBytes(serializedValue))),
+                It.IsAny<DistributedCacheEntryOptions>(),
+                cancellationToken
+            )).Returns(Task.CompletedTask);
+        }
+
+        private void MockSetupSimulateCacheHit(string key, string serializedValue, CancellationToken cancellationToken)
+        {
+            _mockCache.Setup(cache => cache.GetAsync(key, cancellationToken))
+                .ReturnsAsync(Encoding.UTF8.GetBytes(serializedValue));
+        }
+
+        [Fact]
+        public async Task GetServiceOwnerOfResource_ShouldCallApi_WhenCacheDoesNotExist()
+        {
+            // Arrange
+            string resourceId = "12345";
+            string cacheKey = $"ServiceOwnerOfResource_{resourceId}";
+            string expectedResult = CreateTestResourceResponse().HasCompetentAuthority?.Name?["en"] ?? string.Empty;
+            string expectedResultSerialized = JsonSerializer.Serialize(expectedResult);
+            var cancellationToken = CancellationToken.None;
+
+            MockSetupSimulateCacheMiss(cacheKey, cancellationToken);
+            MockSetupSimulateStoreInCache(cacheKey, expectedResultSerialized, cancellationToken);
+
+            // Act
+            var result = await _service.GetServiceOwnerOfResource(resourceId, cancellationToken);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+            _mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            );
+            _mockCache.Verify(cache => cache.SetAsync(
+                cacheKey,
+                It.Is<byte[]>(bytes => bytes.SequenceEqual(Encoding.UTF8.GetBytes(expectedResultSerialized))),
+                It.IsAny<DistributedCacheEntryOptions>(), 
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetServiceOwnerOfResource_ShouldRetrieveFromCache_WhenCacheExists()
+        {
+            // Arrange
+            string resourceId = "12345";
+            string cacheKey = $"ServiceOwnerOfResource_{resourceId}";
+            string cachedValue = "John Doe from cache";
+            var serializedData = JsonSerializer.Serialize(cachedValue);
+            var cancellationToken = CancellationToken.None;
+
+            MockSetupSimulateCacheHit(cacheKey, serializedData, cancellationToken);
+
+            // Act
+            var result = await _service.GetServiceOwnerOfResource(resourceId, cancellationToken);
+
+            // Assert
+            Assert.Equal(cachedValue, result);
+            _mockCache.Verify(cache => cache.GetAsync(cacheKey, cancellationToken), Times.Once);
+            _mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        [Fact]
+        public async Task GetServiceOwnerOfResource_ShouldNotStoreInCache_WhenApiCallFails()
+        {
+            // Arrange
+            string resourceId = "12345";
+            string cacheKey = $"ServiceOwnerOfResource_{resourceId}";
+            var cancellationToken = CancellationToken.None;
+
+            _mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+            // Act
+            var result = await _service.GetServiceOwnerOfResource(resourceId, cancellationToken);
+
+            // Assert
+            Assert.Null(result);
+            _mockCache.Verify(cache => cache.SetAsync(
+                cacheKey,
+                It.IsAny<byte[]>(),
+                It.IsAny<DistributedCacheEntryOptions>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Never);
+        }
+    }
+}

--- a/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/GetResourceResponse.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/GetResourceResponse.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 
+[assembly: InternalsVisibleTo("Altinn.Correspondence.Tests")]
 namespace Altinn.Correspondence.Integrations.Altinn.ResourceRegistry;
 
 internal class GetResourceResponse

--- a/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/ResourceRightsService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/ResourceRightsService.cs
@@ -72,10 +72,14 @@ public class ResourceRightsService : IResourceRightsService
                 break;
             }
         }
-
-        try 
+        if (name == null)
         {
-            await CacheHelpers.StoreObjectInCacheAsync(cacheKey, resourceId, _cache, _cacheOptions, cancellationToken);
+            return name;
+        }
+
+        try
+        {
+            await CacheHelpers.StoreObjectInCacheAsync(cacheKey, name, _cache, _cacheOptions, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/ResourceRightsService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/ResourceRightsService.cs
@@ -5,22 +5,46 @@ using Altinn.Correspondence.Core.Options;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Altinn.Correspondence.Common.Helpers;
+using Microsoft.Extensions.Caching.Distributed;
 
 namespace Altinn.Correspondence.Integrations.Altinn.ResourceRegistry;
 public class ResourceRightsService : IResourceRightsService
 {
     private readonly HttpClient _client;
     private readonly ILogger<ResourceRightsService> _logger;
+    
+    private readonly IDistributedCache _cache;
+    private readonly DistributedCacheEntryOptions _cacheOptions;
 
-    public ResourceRightsService(HttpClient httpClient, IOptions<AltinnOptions> options, ILogger<ResourceRightsService> logger)
+    public ResourceRightsService(HttpClient httpClient, IOptions<AltinnOptions> options, ILogger<ResourceRightsService> logger, IDistributedCache cache)
     {
         httpClient.BaseAddress = new Uri(options.Value.PlatformGatewayUrl);
         _client = httpClient;
         _logger = logger;
+        _cache = cache;
+        _cacheOptions = new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(24)
+        };
     }
 
     public async Task<string?> GetServiceOwnerOfResource(string resourceId, CancellationToken cancellationToken)
     {
+        string cacheKey = $"ServiceOwnerOfResource_{resourceId}";
+        try 
+        {
+            string? cachedResource = await CacheHelpers.GetObjectFromCacheAsync<string>(cacheKey, _cache, cancellationToken);
+            if (cachedResource != null)
+            {
+                return cachedResource;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error retrieving service owner from cache when looking up service owner of resource in Resource Rights Service.");
+        }
+
         var response = await _client.GetAsync($"resourceregistry/api/v1/resource/{resourceId}", cancellationToken);
         if (response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == HttpStatusCode.NoContent)
         {
@@ -48,6 +72,16 @@ public class ResourceRightsService : IResourceRightsService
                 break;
             }
         }
+
+        try 
+        {
+            await CacheHelpers.StoreObjectInCacheAsync(cacheKey, resourceId, _cache, _cacheOptions, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error storing service owner name to cache when looking up service owner of resource in Resource Rights Service.");
+        }
+
         return name;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To improve performance and avoid unnecessary API calls, this PR introduces caching for API responses in ResourceRightsService. By caching the responses, subsequent lookups with the same parameter are retrieved from cache, resulting in reduced latency and faster retrieval times.

## Related Issue(s)
- #611 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
	- Added caching mechanism to the Resource Rights Service
	- Reduced HTTP requests to Altinn Resource Registry
	- Implemented 24-hour cache expiration for service owner resource lookups

- **New Features**
	- Introduced a new test class for comprehensive testing of the Resource Rights Service functionality. 

- **Documentation**
	- Added assembly attribute to grant test assembly access to internal members for improved testing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->