### PR TITLE
add validation for custom recipients with tags

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -564,8 +564,10 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
         }
 
-        [Fact]
-        public async Task Correspondence_CustomRecipient_WithEmailAndRecipientTag_GivesBadRequest()
+        [Theory]
+        [InlineData("97661466", null)]
+        [InlineData(null, "test@example.com")]
+        public async Task Correspondence_CustomRecipient_WithPhoneNumberOrEmailAndRecipientTag_GivesBadRequest(string? number, string? email)
         {
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
             var customRecipients = new List<CustomNotificationRecipientExt>()
@@ -577,7 +579,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                     {
                         new NotificationRecipientExt()
                         {
-                            EmailAddress = "andreas@hammerbeck.no",
+                            MobileNumber = number,
+                            EmailAddress = email
                         }
                     }
                 }
@@ -586,15 +589,18 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .CreateCorrespondence()
                 .WithRecipients([recipient])
                 .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
-                .WithNotificationChannel(NotificationChannelExt.Sms)
+                .WithNotificationChannel(number != null ? NotificationChannelExt.Sms : NotificationChannelExt.Email)
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
 
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
         }
-        [Fact]
-        public async Task Correspondence_CustomRecipient_WithPhoneNumberAndRecipientTag_GivesBadRequest()
+
+        [Theory]
+        [InlineData("97661466", null)]
+        [InlineData(null, "test@example.com")]
+        public async Task Correspondence_CustomRecipient_WithNumberOrEmailAndCustomRecipientTag_GivesBadRequest(string? number, string? email)
         {
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
             var customRecipients = new List<CustomNotificationRecipientExt>()
@@ -606,7 +612,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                     {
                         new NotificationRecipientExt()
                         {
-                            MobileNumber = "97661466",
+                            MobileNumber = number,
+                            EmailAddress = email
                         }
                     }
                 }
@@ -615,40 +622,12 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .CreateCorrespondence()
                 .WithRecipients([recipient])
                 .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
-                .WithNotificationChannel(NotificationChannelExt.Sms)
+                .WithNotificationChannel(number != null ? NotificationChannelExt.Sms : NotificationChannelExt.Email)
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
 
-            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
-            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
-        }
-        [Fact]
-        public async Task Correspondence_CustomRecipient_WithPhoneNumberAndCustomRecipientTag_GivesBadRequest()
-        {
-            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
-            var customRecipients = new List<CustomNotificationRecipientExt>()
-            {
-                new CustomNotificationRecipientExt()
-                {
-                    RecipientToOverride = recipient,
-                    Recipients = new List<NotificationRecipientExt>()
-                    {
-                        new NotificationRecipientExt()
-                        {
-                            MobileNumber = "97661466",
-                        }
-                    }
-                }
-            };
-            var payload = new CorrespondenceBuilder()
-                .CreateCorrespondence()
-                .WithRecipients([recipient])
-                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
-                .WithNotificationChannel(NotificationChannelExt.Sms)
-                .WithCustomNotificationRecipients(customRecipients)
-                .Build();
-
-            payload.Correspondence.Notification.SmsBody = "Test $recipientName$";
+            payload.Correspondence.Notification.SmsBody = number != null ? "Test $recipientName$" : null;
+            payload.Correspondence.Notification.EmailBody = email != null ? "Test $recipientName$" : null;
 
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
@@ -699,7 +678,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Act
             var initializeCorrespondenceResponse = await senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             var content = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
-
             // Assert
             Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
             Assert.Equal(CorrespondenceStatusExt.Published, content?.Correspondences.First().Status);

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -259,7 +259,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var payload = new CorrespondenceBuilder()
                 .CreateCorrespondence()
                 .WithRecipients([recipientToOverride])
-                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationTemplate(NotificationTemplateExt.CustomMessage)
                 .WithNotificationChannel(NotificationChannelExt.SmsPreferred)
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
@@ -675,7 +675,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var payload = new CorrespondenceBuilder()
                 .CreateCorrespondence()
                 .WithRecipients([recipient])
-                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationTemplate(NotificationTemplateExt.CustomMessage)
                 .WithNotificationChannel(NotificationChannelExt.Email)
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -261,6 +261,10 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithRecipients([recipientToOverride])
                 .WithNotificationTemplate(NotificationTemplateExt.CustomMessage)
                 .WithNotificationChannel(NotificationChannelExt.SmsPreferred)
+                .WithEmailContent()
+                .WithEmailReminder()
+                .WithSmsContent()
+                .WithSmsReminder()
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
 
@@ -656,6 +660,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithRecipients([recipient])
                 .WithNotificationTemplate(NotificationTemplateExt.CustomMessage)
                 .WithNotificationChannel(NotificationChannelExt.Email)
+                .WithEmailContent()
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
 

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -661,6 +661,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithNotificationTemplate(NotificationTemplateExt.CustomMessage)
                 .WithNotificationChannel(NotificationChannelExt.Email)
                 .WithEmailContent()
+                .WithEmailReminder()
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
 

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -468,7 +468,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithNotificationChannel(NotificationChannelExt.Email)
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
-            
+
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
         }
@@ -499,7 +499,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithNotificationChannel(NotificationChannelExt.Email)
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
-            
+
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
         }
@@ -529,7 +529,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithNotificationChannel(NotificationChannelExt.Sms)
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
-            
+
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
         }
@@ -555,11 +555,101 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var payload = new CorrespondenceBuilder()
                 .CreateCorrespondence()
                 .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.CustomMessage)
+                .WithNotificationChannel(NotificationChannelExt.Sms)
+                .WithCustomNotificationRecipients(customRecipients)
+                .Build();
+
+            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task Correspondence_CustomRecipient_WithEmailAndRecipientTag_GivesBadRequest()
+        {
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+            var customRecipients = new List<CustomNotificationRecipientExt>()
+            {
+                new CustomNotificationRecipientExt()
+                {
+                    RecipientToOverride = recipient,
+                    Recipients = new List<NotificationRecipientExt>()
+                    {
+                        new NotificationRecipientExt()
+                        {
+                            EmailAddress = "andreas@hammerbeck.no",
+                        }
+                    }
+                }
+            };
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
                 .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
                 .WithNotificationChannel(NotificationChannelExt.Sms)
                 .WithCustomNotificationRecipients(customRecipients)
                 .Build();
-            
+
+            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
+        }
+        [Fact]
+        public async Task Correspondence_CustomRecipient_WithPhoneNumberAndRecipientTag_GivesBadRequest()
+        {
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+            var customRecipients = new List<CustomNotificationRecipientExt>()
+            {
+                new CustomNotificationRecipientExt()
+                {
+                    RecipientToOverride = recipient,
+                    Recipients = new List<NotificationRecipientExt>()
+                    {
+                        new NotificationRecipientExt()
+                        {
+                            MobileNumber = "97661466",
+                        }
+                    }
+                }
+            };
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationChannel(NotificationChannelExt.Sms)
+                .WithCustomNotificationRecipients(customRecipients)
+                .Build();
+
+            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
+        }
+        [Fact]
+        public async Task Correspondence_CustomRecipient_WithPhoneNumberAndCustomRecipientTag_GivesBadRequest()
+        {
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+            var customRecipients = new List<CustomNotificationRecipientExt>()
+            {
+                new CustomNotificationRecipientExt()
+                {
+                    RecipientToOverride = recipient,
+                    Recipients = new List<NotificationRecipientExt>()
+                    {
+                        new NotificationRecipientExt()
+                        {
+                            MobileNumber = "97661466",
+                        }
+                    }
+                }
+            };
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationChannel(NotificationChannelExt.Sms)
+                .WithCustomNotificationRecipients(customRecipients)
+                .Build();
+
+            payload.Correspondence.Notification.SmsBody = "Test $recipientName$";
+
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
         }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -67,6 +67,8 @@ public static class NotificationErrors
     public static Error InvalidMobileNumberProvided = new Error(3012, "Invalid mobile number provided. Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard.", HttpStatusCode.BadRequest);
     public static Error OrgNumberWithSsnEmailOrMobile = new Error(3013, "Organization number cannot be combined with email address, mobile number, or national identity number.", HttpStatusCode.BadRequest);
     public static Error SsnWithOrgNoEmailOrMobile = new Error(3014, "National identity number cannot be combined with email address, mobile number, or organization number.", HttpStatusCode.BadRequest);
+    public static Error RecipientOverridesWithNumberOrEmailNotAllowedWithCustomTemplate = new Error(3015, "Recipient overrides with email or mobile number are not allowed when using a custom notification template because of name lookup", HttpStatusCode.BadRequest);
+    public static Error RecipientOverridesWithNumberOrEmailNotAllowedWithRecipientName = new Error(3016, "Recipient overrides with email or mobile number are not allowed when using recipient name because of name lookup", HttpStatusCode.BadRequest);
 }
 public static class AuthorizationErrors
 {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -160,7 +160,20 @@ namespace Altinn.Correspondence.Application.Helpers
             {
                 return null;
             }
-
+            var recipientWithNumberOrEmail = customRecipients.Where(recipient => recipient.Recipients.Any(r => r.EmailAddress != null || r.MobileNumber != null)).ToList();
+            if (recipientWithNumberOrEmail.Count > 0)
+            {
+                if (notification.NotificationTemplate != NotificationTemplate.CustomMessage)
+                {
+                    return NotificationErrors.RecipientOverridesWithNumberOrEmailNotAllowedWithCustomTemplate;
+                }
+                if (TextContainsTag(notification.EmailBody, "$recipientName$") || TextContainsTag(notification.SmsBody, "$recipientName$")
+                    || TextContainsTag(notification.EmailSubject, "$recipientName$") || TextContainsTag(notification.ReminderEmailBody, "$recipientName$")
+                    || TextContainsTag(notification.ReminderSmsBody, "$recipientName$") || TextContainsTag(notification.ReminderEmailSubject, "$recipientName$"))
+                {
+                    return NotificationErrors.RecipientOverridesWithNumberOrEmailNotAllowedWithRecipientName;
+                }
+            }
             foreach (var recipientToOverride in customRecipients)
             {
                 if (!recipients.Any(recipient => recipient.WithoutPrefix() == recipientToOverride.RecipientToOverride.WithoutPrefix()))
@@ -186,6 +199,11 @@ namespace Altinn.Correspondence.Application.Helpers
                 }
             }
             return null;
+        }
+        private bool TextContainsTag(string? text, string tag)
+        {
+            if (text == null) return false;
+            return text.Contains(tag, StringComparison.CurrentCultureIgnoreCase);
         }
 
         /// <summary>

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -306,15 +306,15 @@ public class InitializeCorrespondencesHandler(
             RequestedSendTime = correspondence.RequestedPublishTime.UtcDateTime <= DateTime.UtcNow ? DateTime.UtcNow.AddMinutes(5) : correspondence.RequestedPublishTime.UtcDateTime.AddMinutes(5),
             SendersReference = correspondence.SendersReference,
             NotificationChannel = notification.NotificationChannel,
-            EmailTemplate = new EmailTemplate
+            EmailTemplate = !string.IsNullOrWhiteSpace(content.EmailSubject) && !string.IsNullOrWhiteSpace(content.EmailBody) ? new EmailTemplate
             {
                 Subject = content.EmailSubject,
                 Body = content.EmailBody,
-            },
-            SmsTemplate = new SmsTemplate
+            } : null,
+            SmsTemplate = !string.IsNullOrWhiteSpace(content.SmsBody) ? new SmsTemplate
             {
                 Body = content.SmsBody,
-            }
+            } : null
         };
         notifications.Add(notificationOrder);
         if (notification.SendReminder)
@@ -328,15 +328,15 @@ public class InitializeCorrespondencesHandler(
                 ConditionEndpoint = CreateConditionEndpoint(correspondence.Id.ToString()),
                 SendersReference = correspondence.SendersReference,
                 NotificationChannel = notification.ReminderNotificationChannel ?? notification.NotificationChannel,
-                EmailTemplate = new EmailTemplate
+                EmailTemplate = !string.IsNullOrWhiteSpace(content.ReminderEmailSubject) && !string.IsNullOrWhiteSpace(content.ReminderEmailBody) ? new EmailTemplate
                 {
                     Subject = content.ReminderEmailSubject,
                     Body = content.ReminderEmailBody,
-                },
-                SmsTemplate = new SmsTemplate
+                } : null,
+                SmsTemplate = !string.IsNullOrWhiteSpace(content.ReminderSmsBody) ? new SmsTemplate
                 {
                     Body = content.ReminderSmsBody,
-                }
+                } : null
             });
         }
         return notifications;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds validation for custom recipients with email/phone since recipientName lookup does not work in Notification
- Fixes a bug where SMSBody/EmailBody was a object with null values

## Related Issue(s)
- #601 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added new test methods to validate correspondence notifications with custom recipients.
	- Enhanced existing tests for better coverage of notification scenarios.

- **Bug Fixes**
	- Improved validation for notification templates and recipient overrides.
	- Enhanced error handling for email and SMS template creation.

- **New Features**
	- Implemented stricter rules for recipient information in notifications.
	- Added new error definitions for recipient override scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->