### PR TITLE
Remove DataType as required field

### DIFF
--- a/Test/Altinn.Correspondence.LoadTests/test_initialize_and_upload_correspondence.js
+++ b/Test/Altinn.Correspondence.LoadTests/test_initialize_and_upload_correspondence.js
@@ -35,7 +35,6 @@ formData.append('Correspondence.content.messageTitle', "Test");
 formData.append('Correspondence.content.messageSummary', "Test");
 formData.append('Correspondence.content.messageBody', "Test");
 formData.append('Correspondence.content.attachments[0].DataLocationType', "ExistingExternalStorage");
-formData.append('Correspondence.content.attachments[0].DataType', "1");
 formData.append('Correspondence.content.attachments[0].Name', "testfile.txt");
 formData.append('Correspondence.content.attachments[0].Sender', sender);
 formData.append('Correspondence.content.attachments[0].SendersReference', "1234");

--- a/Test/Altinn.Correspondence.Tests/Factories/AttachmentBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/AttachmentBuilder.cs
@@ -17,7 +17,7 @@ namespace Altinn.Correspondence.Tests.Factories
             _attachment = new InitializeAttachmentExt()
             {
                 ResourceId = "1",
-                DataType = "html",
+                //DataType = "html",
                 Name = "Test file logical name",
                 Sender = $"{UrnConstants.OrganizationNumberAttribute}:991825827",
                 SendersReference = "1234",

--- a/Test/Altinn.Correspondence.Tests/Factories/AttachmentBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/AttachmentBuilder.cs
@@ -17,7 +17,6 @@ namespace Altinn.Correspondence.Tests.Factories
             _attachment = new InitializeAttachmentExt()
             {
                 ResourceId = "1",
-                //DataType = "html",
                 Name = "Test file logical name",
                 Sender = $"{UrnConstants.OrganizationNumberAttribute}:991825827",
                 SendersReference = "1234",

--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
@@ -80,7 +80,6 @@ namespace Altinn.Correspondence.Tests.Factories
             _correspondence.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>() {
                 new InitializeCorrespondenceAttachmentExt()
                 {
-                    //DataType = "html",
                     Name = "2",
                     SendersReference = "1234",
                     FileName = "test-fil2e.txt",

--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
@@ -80,7 +80,7 @@ namespace Altinn.Correspondence.Tests.Factories
             _correspondence.Correspondence.Content!.Attachments = new List<InitializeCorrespondenceAttachmentExt>() {
                 new InitializeCorrespondenceAttachmentExt()
                 {
-                    DataType = "html",
+                    //DataType = "html",
                     Name = "2",
                     SendersReference = "1234",
                     FileName = "test-fil2e.txt",

--- a/Test/Altinn.Correspondence.Tests/Helpers/AttachmentHelper.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/AttachmentHelper.cs
@@ -14,7 +14,6 @@ namespace Altinn.Correspondence.Tests.Helpers
         {
             var attachmentData = new InitializeCorrespondenceAttachmentExt()
             {
-                //DataType = existingAttachmentData?.DataType ?? "txt",
                 Name = existingAttachmentData?.Name ?? fileName,
                 SendersReference = existingAttachmentData?.SendersReference ?? "1234",
                 FileName = existingAttachmentData?.FileName ?? fileName,

--- a/Test/Altinn.Correspondence.Tests/Helpers/AttachmentHelper.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/AttachmentHelper.cs
@@ -14,7 +14,7 @@ namespace Altinn.Correspondence.Tests.Helpers
         {
             var attachmentData = new InitializeCorrespondenceAttachmentExt()
             {
-                DataType = existingAttachmentData?.DataType ?? "txt",
+                //DataType = existingAttachmentData?.DataType ?? "txt",
                 Name = existingAttachmentData?.Name ?? fileName,
                 SendersReference = existingAttachmentData?.SendersReference ?? "1234",
                 FileName = existingAttachmentData?.FileName ?? fileName,

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
@@ -278,7 +278,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             correspondence.Content.Attachments.Select((attachment, index) => new[]
             {
             new { Key = $"correspondence.content.Attachments[{index}].DataLocationType", Value = attachment.DataLocationType.ToString() },
-            new { Key = $"correspondence.content.Attachments[{index}].DataType", Value = attachment.DataType },
+            //new { Key = $"correspondence.content.Attachments[{index}].DataType", Value = attachment.DataType },
             new { Key = $"correspondence.content.Attachments[{index}].Name", Value = attachment.Name },
             new { Key = $"correspondence.content.Attachments[{index}].FileName", Value = attachment.FileName ?? "" },
             new { Key = $"correspondence.content.Attachments[{index}].SendersReference", Value = attachment.SendersReference },

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
@@ -278,7 +278,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             correspondence.Content.Attachments.Select((attachment, index) => new[]
             {
             new { Key = $"correspondence.content.Attachments[{index}].DataLocationType", Value = attachment.DataLocationType.ToString() },
-            //new { Key = $"correspondence.content.Attachments[{index}].DataType", Value = attachment.DataType },
             new { Key = $"correspondence.content.Attachments[{index}].Name", Value = attachment.Name },
             new { Key = $"correspondence.content.Attachments[{index}].FileName", Value = attachment.FileName ?? "" },
             new { Key = $"correspondence.content.Attachments[{index}].SendersReference", Value = attachment.SendersReference },

--- a/src/Altinn.Correspondence.API/Models/AttachmentOverviewExt.cs
+++ b/src/Altinn.Correspondence.API/Models/AttachmentOverviewExt.cs
@@ -38,5 +38,12 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("correspondenceIds")]
         public required List<Guid> CorrespondenceIds { get; set; }
+
+        /// <summary>
+        /// The attachment data type in MIME format
+        /// </summary>
+        [JsonPropertyName("dataType")]
+        [Required]
+        public required string DataType { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.API/Models/AttachmentOverviewExt.cs
+++ b/src/Altinn.Correspondence.API/Models/AttachmentOverviewExt.cs
@@ -43,7 +43,6 @@ namespace Altinn.Correspondence.API.Models
         /// The attachment data type in MIME format
         /// </summary>
         [JsonPropertyName("dataType")]
-        [Required]
-        public required string DataType { get; set; }
+        public string DataType { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.API/Models/BaseAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/BaseAttachmentExt.cs
@@ -41,11 +41,5 @@ namespace Altinn.Correspondence.API.Models
         [Required]
         public required string SendersReference { get; set; }
 
-        /// <summary>
-        /// The attachment data type in MIME format
-        /// </summary>
-        [JsonPropertyName("dataType")]
-        [Required]
-        public required string DataType { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.API/Models/CorrespondenceAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceAttachmentExt.cs
@@ -43,5 +43,11 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("expirationTime")]
         public DateTimeOffset ExpirationTime { get; set; }
+
+        /// <summary>
+        /// The attachment data type in MIME format
+        /// </summary>
+        [JsonPropertyName("dataType")]
+        public required string DataType { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.API/Models/CorrespondenceAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceAttachmentExt.cs
@@ -48,6 +48,6 @@ namespace Altinn.Correspondence.API.Models
         /// The attachment data type in MIME format
         /// </summary>
         [JsonPropertyName("dataType")]
-        public required string DataType { get; set; }
+        public string DataType { get; set; }
     }
 }


### PR DESCRIPTION
## Description
As it is now DataType is still required as an input field under initialize and upload. The code must be updated to remove this functionality.

## Related Issue(s)
- #588 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Changes**
  - Modifications to attachment data type handling across multiple test and model files.
  - Removed `DataType` property from `BaseAttachmentExt`.
  - Added `DataType` property to `AttachmentOverviewExt` and `CorrespondenceAttachmentExt`.
  - Adjusted form data structure in tests to exclude `DataType` for attachments.

- **Impact**
  - Updates to how attachment metadata is processed and represented in the system.
  - Potential changes in attachment type handling and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->