### PR TITLE
Remove pagination from search endpoints

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
@@ -153,8 +153,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
         {
             return new LegacyGetCorrespondencesRequestExt
             {
-                Offset = 0,
-                Limit = 10,
                 InstanceOwnerPartyIdList = new int[] { },
                 IncludeActive = true,
                 IncludeArchived = true,

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -193,8 +193,6 @@ namespace Altinn.Correspondence.API.Controllers
         [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         public async Task<ActionResult<CorrespondencesExt>> GetCorrespondences(
             [FromQuery] string resourceId,
-            [FromQuery] int offset,
-            [FromQuery] int limit,
             [FromQuery] DateTimeOffset? from,
             [FromQuery] DateTimeOffset? to,
             [FromServices] GetCorrespondencesHandler handler,
@@ -210,8 +208,6 @@ namespace Altinn.Correspondence.API.Controllers
                 ResourceId = resourceId,
                 From = from,
                 To = to,
-                Limit = limit,
-                Offset = offset,
                 Status = status is null ? null : (CorrespondenceStatus)status,
                 Role = role,
                 OnBehalfOf = onBehalfOf

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -187,7 +187,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <remarks>
         /// Meant for Receivers, but also available for Senders to track Correspondences
         /// </remarks>
-        /// <returns>A list of Correspondence ids and pagination metadata</returns>
+        /// <returns>A list of Correspondence ids</returns>
         [HttpGet]
         [Produces("application/json")]
         [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]

--- a/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
@@ -77,7 +77,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <summary>
         /// Gets a list of Correspondences for the authenticated user based on complex search criteria
         /// </summary>
-        /// <returns>A list of overall Correspondence data and pagination metadata</returns>
+        /// <returns>A list of overall Correspondence data</returns>
         [HttpPost]
         public async Task<ActionResult<CorrespondencesExt>> GetCorrespondences(
             LegacyGetCorrespondencesRequestExt request,

--- a/src/Altinn.Correspondence.API/Mappers/LegacyGetCorrespondencesMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/LegacyGetCorrespondencesMapper.cs
@@ -16,8 +16,6 @@ internal static class LegacyGetCorrespondencesMapper
             IncludeArchived = requestExt.IncludeArchived,
             IncludeDeleted = requestExt.IncludeDeleted,
             InstanceOwnerPartyIdList = requestExt.InstanceOwnerPartyIdList,
-            Offset = requestExt.Offset,
-            Limit = requestExt.Limit,
             Language = requestExt.Language,
             SearchString = requestExt.SearchString,
             Status = requestExt.Status is null ? null : (CorrespondenceStatus)requestExt.Status

--- a/src/Altinn.Correspondence.API/Models/CorrespondencesExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondencesExt.cs
@@ -12,11 +12,5 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("ids")]
         public List<Guid> Ids { get; set; } = new List<Guid>();
-
-        /// <summary>
-        /// Metadata for pagination
-        /// </summary>
-        [JsonPropertyName("pagination")]
-        public PaginationMetaDataExt Pagination { get; set; } = new PaginationMetaDataExt();
     }
 }

--- a/src/Altinn.Correspondence.API/Models/LegacyGetCorrespondencesRequestExt.cs
+++ b/src/Altinn.Correspondence.API/Models/LegacyGetCorrespondencesRequestExt.cs
@@ -10,18 +10,6 @@ namespace Altinn.Correspondence.API.Models
     public class LegacyGetCorrespondencesRequestExt
     {
         /// <summary>
-        /// Pagination offset
-        /// </summary>
-        [JsonPropertyName("offset")]
-        public int Offset { get; set; }
-
-        /// <summary>
-        /// Pagination limit
-        /// </summary>
-        [JsonPropertyName("limit")]
-        public int Limit { get; set; }
-
-        /// <summary>
         /// A list of the parties/recipients that own the Correspondence instances
         /// </summary>
         [JsonPropertyName("instanceOwnerPartyIdList")]

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
@@ -13,11 +13,7 @@ public class GetCorrespondencesHandler(
 {
     public async Task<OneOf<GetCorrespondencesResponse, Error>> Process(GetCorrespondencesRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
-        if (request.Limit < 0 || request.Offset < 0)
-        {
-            return CorrespondenceErrors.OffsetAndLimitIsNegative;
-        }
-        var limit = request.Limit == 0 ? 50 : request.Limit;
+        const int limit = 1000;
         DateTimeOffset? to = request.To != null ? ((DateTimeOffset)request.To).ToUniversalTime() : null;
         DateTimeOffset? from = request.From != null ? ((DateTimeOffset)request.From).ToUniversalTime() : null;
         if (from != null && to != null && from > to)
@@ -42,7 +38,6 @@ public class GetCorrespondencesHandler(
 
         var correspondences = await correspondenceRepository.GetCorrespondences(
             request.ResourceId,
-            request.Offset,
             limit,
             from,
             to,
@@ -52,13 +47,7 @@ public class GetCorrespondencesHandler(
             cancellationToken);
         var response = new GetCorrespondencesResponse
         {
-            Items = correspondences.Item1,
-            Pagination = new PaginationMetaData
-            {
-                Offset = request.Offset,
-                Limit = limit,
-                TotalItems = correspondences.Item2
-            }
+            Ids = correspondences.Item1,
         };
         return response;
     }

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesRequest.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesRequest.cs
@@ -5,8 +5,6 @@ namespace Altinn.Correspondence.Application.GetCorrespondences;
 public class GetCorrespondencesRequest
 {
     public required string ResourceId { get; set; }
-    public int Offset { get; set; }
-    public int Limit { get; set; }
 
     public DateTimeOffset? From { get; set; }
 

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesResponse.cs
@@ -2,17 +2,6 @@ namespace Altinn.Correspondence.Application.GetCorrespondences
 {
     public class GetCorrespondencesResponse
     {
-        public List<Guid> Items { get; set; } = new List<Guid>();
-
-        public PaginationMetaData Pagination { get; set; } = new PaginationMetaData();
-    }
-
-    public class PaginationMetaData
-    {
-        public int Offset { get; set; }
-
-        public int Limit { get; set; }
-
-        public int TotalItems { get; set; }
+        public List<Guid> Ids { get; set; } = new List<Guid>();
     }
 }

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -25,7 +25,7 @@ public class LegacyGetCorrespondencesHandler(
 
     public async Task<OneOf<LegacyGetCorrespondencesResponse, Error>> Process(LegacyGetCorrespondencesRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
-        var limit = request.Limit == 0 ? 1000 : request.Limit;
+        const int limit = 1000;
         DateTimeOffset? to = request.To != null ? ((DateTimeOffset)request.To).ToUniversalTime() : null;
         DateTimeOffset? from = request.From != null ? ((DateTimeOffset)request.From).ToUniversalTime() : null;
 

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesRequest.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesRequest.cs
@@ -7,10 +7,6 @@ public class LegacyGetCorrespondencesRequest
 {
     public required int[] InstanceOwnerPartyIdList { get; set; }
 
-    public int Offset { get; set; }
-
-    public int Limit { get; set; }
-
     public bool IncludeActive { get; set; }
 
     public bool IncludeArchived { get; set; }

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -11,7 +11,6 @@ namespace Altinn.Correspondence.Core.Repositories
 
         Task<(List<Guid>, int)> GetCorrespondences(
             string resourceId,
-            int offset,
             int limit,
             DateTimeOffset? from,
             DateTimeOffset? to,

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -26,7 +26,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
 
         public async Task<(List<Guid>, int)> GetCorrespondences(
             string resourceId,
-            int offset,
             int limit,
             DateTimeOffset? from,
             DateTimeOffset? to,
@@ -45,7 +44,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .Select(c => c.Id);
 
             var totalItems = await correspondences.CountAsync(cancellationToken);
-            var result = await correspondences.Skip(offset).Take(limit).ToListAsync(cancellationToken);
+            var result = await correspondences.Take(limit).ToListAsync(cancellationToken);
             return (result, totalItems);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We want to remove pagination from the search endpoints. This PR removes pagination and pagination metadata from the GET /correspondence and POST /legacy/correspondence endpoints. These search endpoints now have a set limit of 1000 results per query to prevent overload.

## Related Issue(s)
- #625 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
