### PR TITLE
add IsConfirmationNeeded to legacy 

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
@@ -41,7 +41,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
         public async Task Delete_Published_IsConfirmedRequired_Correspondence_GivesOk()
         {
             // Arrange
-            var payload = new CorrespondenceBuilder().CreateCorrespondence().WithConfirmationNeeded(true).Build();
+            var payload = new CorrespondenceBuilder().CreateCorrespondence().WithDueDateTime(DateTime.UtcNow.AddDays(5)).WithConfirmationNeeded(true).Build();
 
             var correspondence = await CorrespondenceHelper.GetInitializedCorrespondence(_senderClient, _serializerOptions, payload);
 

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
@@ -41,8 +41,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
         public async Task Delete_Published_IsConfirmedRequired_Correspondence_GivesOk()
         {
             // Arrange
-            var payload = new CorrespondenceBuilder().CreateCorrespondence().Build();
-            payload.Correspondence.IsConfirmationNeeded = true;
+            var payload = new CorrespondenceBuilder().CreateCorrespondence().WithConfirmationNeeded(true).Build();
+
             var correspondence = await CorrespondenceHelper.GetInitializedCorrespondence(_senderClient, _serializerOptions, payload);
 
             // Act

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
@@ -38,6 +38,23 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
         }
 
         [Fact]
+        public async Task Delete_Published_IsConfirmedRequired_Correspondence_GivesOk()
+        {
+            // Arrange
+            var payload = new CorrespondenceBuilder().CreateCorrespondence().Build();
+            payload.Correspondence.IsConfirmationNeeded = true;
+            var correspondence = await CorrespondenceHelper.GetInitializedCorrespondence(_senderClient, _serializerOptions, payload);
+
+            // Act
+            var deleteResponse = await _legacyClient.DeleteAsync($"correspondence/api/v1/legacy/correspondence/{correspondence.CorrespondenceId}/purge");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+            var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{correspondence.CorrespondenceId}", _serializerOptions);
+            Assert.Equal(CorrespondenceStatusExt.PurgedByRecipient, overview.Status);
+        }
+
+        [Fact]
         public async Task Delete_Correspondence_InvalidParyId_Gives()
         {
             // Arrange

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
@@ -108,24 +108,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
         }
 
         [Fact]
-        public async Task Delete_Published_Correspondence_WithoutConfirmation_WhenConfirmationNeeded_ReturnsBadRequest()
-        {
-            // Arrange
-            var payload = new CorrespondenceBuilder()
-                .CreateCorrespondence()
-                .WithDueDateTime(DateTimeOffset.UtcNow.AddDays(1))
-                .WithConfirmationNeeded(true)
-                .Build();
-            var correspondence = await CorrespondenceHelper.GetInitializedCorrespondence(_senderClient, _serializerOptions, payload);
-
-            // Act
-            var deleteResponse = await _legacyClient.DeleteAsync($"correspondence/api/v1/legacy/correspondence/{correspondence.CorrespondenceId}/purge");
-
-            // Assert
-            Assert.Equal(HttpStatusCode.BadRequest, deleteResponse.StatusCode);
-        }
-
-        [Fact]
         public async Task Delete_Published_Correspondence_WithConfirmation_WhenConfirmationNeeded_Gives_OK()
         {
             // Arrange

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -138,6 +138,7 @@ public class LegacyGetCorrespondencesHandler(
                 new LegacyCorrespondenceItem()
                 {
                     Altinn2CorrespondenceId = correspondence.Altinn2CorrespondenceId,
+                    IsConfirmationNeeded = correspondence.IsConfirmationNeeded,
                     ServiceOwnerName = resourceOwners?[correspondence.ResourceId],
                     InstanceOwnerPartyId = recipient?.PartyId ?? 0,
                     MessageTitle = correspondence.Content.MessageTitle,

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesResponse.cs
@@ -24,5 +24,6 @@ namespace Altinn.Correspondence.Application.GetCorrespondences
         public DateTimeOffset? Archived { get; set; }
         public string? MessageSender { get; set; }
         public DateTimeOffset? ConfirmationDate { get; set; }
+        public bool IsConfirmationNeeded { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
@@ -32,6 +32,7 @@ public class LegacyPurgeCorrespondenceHandler(
             return AuthorizationErrors.CouldNotFindOrgNo;
         }
         var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, false, cancellationToken);
+        Console.WriteLine(correspondence);
         if (correspondence == null)
         {
             return CorrespondenceErrors.CorrespondenceNotFound;
@@ -41,7 +42,7 @@ public class LegacyPurgeCorrespondenceHandler(
         {
             return AuthorizationErrors.LegacyNoAccessToCorrespondence;
         }
-        var recipientPurgeError = purgeCorrespondenceHelper.ValidatePurgeRequestRecipient(correspondence);
+        var recipientPurgeError = purgeCorrespondenceHelper.ValidatePurgeRequestRecipient(correspondence, true);
         if (recipientPurgeError is not null)
         {
             return recipientPurgeError;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
@@ -32,7 +32,6 @@ public class LegacyPurgeCorrespondenceHandler(
             return AuthorizationErrors.CouldNotFindOrgNo;
         }
         var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, false, cancellationToken);
-        Console.WriteLine(correspondence);
         if (correspondence == null)
         {
             return CorrespondenceErrors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
@@ -38,7 +38,7 @@ public class PurgeCorrespondenceHelper
         }
         return null;
     }
-    public Error? ValidatePurgeRequestRecipient(CorrespondenceEntity correspondence)
+    public Error? ValidatePurgeRequestRecipient(CorrespondenceEntity correspondence, bool IsLegacy = false)
     {
         var highestStatus = correspondence.GetHighestStatus();
         if (highestStatus == null)
@@ -53,7 +53,7 @@ public class PurgeCorrespondenceHelper
         {
             return CorrespondenceErrors.CorrespondenceNotFound;
         }
-        if (correspondence.IsConfirmationNeeded && !correspondence.StatusHasBeen(CorrespondenceStatus.Confirmed))
+        if (!IsLegacy && correspondence.IsConfirmationNeeded && !correspondence.StatusHasBeen(CorrespondenceStatus.Confirmed))
         {
             return CorrespondenceErrors.ArchiveBeforeConfirmed;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds IsConfirmationNeeded to legacy search. 
- Allows deletion of non confirmed correspondences
- 
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added `IsConfirmationNeeded` property to correspondence items.
    - Introduced a new boolean flag to indicate if confirmation is required for correspondence.
  
- **Bug Fixes**
    - Updated validation logic for purging correspondence to accommodate legacy cases without requiring confirmation.

- **Tests**
    - Added a new test for successful deletion of correspondence requiring confirmation.
    - Removed a test that checked for deletion without confirmation when it was needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->