### PR TITLE
Fix use of formatting tokens

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
@@ -18,7 +18,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
         {
             DialogportenTextType.NotificationOrderCreated => "Varslingsordre opprettet.",
             DialogportenTextType.NotificationOrderCancelled => "Varslingsordre kansellert.",  
-            DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {name}", tokens),
+            DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {0}", tokens),
             DialogportenTextType.CorrespondencePublished => "Melding publisert.",
             DialogportenTextType.CorrespondenceConfirmed => "Melding bekreftet.",
             DialogportenTextType.CorrespondenceArchived => "Melding arkivert.",
@@ -30,7 +30,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
         {
             DialogportenTextType.NotificationOrderCreated => "Varslingsordre opprettet.",
             DialogportenTextType.NotificationOrderCancelled => "Varslingsordre kansellert.",
-            DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {name}", tokens),
+            DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {0}", tokens),
             DialogportenTextType.CorrespondencePublished => "Melding publisert.",
             DialogportenTextType.CorrespondenceConfirmed => "Melding bekreftet.",
             DialogportenTextType.CorrespondenceArchived => "Melding arkivert.",
@@ -42,7 +42,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
         {
             DialogportenTextType.NotificationOrderCreated => "Notification order created.",
             DialogportenTextType.NotificationOrderCancelled => "Notification order cancelled.",
-            DialogportenTextType.DownloadStarted => string.Format("Started downloading attachment {name}", tokens),
+            DialogportenTextType.DownloadStarted => string.Format("Started downloading attachment {0}", tokens),
             DialogportenTextType.CorrespondencePublished => "Message published.",
             DialogportenTextType.CorrespondenceConfirmed => "Message confirmed.",
             DialogportenTextType.CorrespondenceArchived => "Message archived.",


### PR DESCRIPTION
## Description
Fix use of formatting tokens in DialogActivity for DownloadStarted

## Related Issue(s)
- #571 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated string formatting for download started text across multiple languages to improve compatibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->