### PR TITLE
Set max file size on attachment

### DIFF
--- a/src/Altinn.Correspondence.Application/ApplicationConstants.cs
+++ b/src/Altinn.Correspondence.Application/ApplicationConstants.cs
@@ -1,0 +1,6 @@
+namespace Altinn.Correspondence.Application.Settings;
+
+public static class ApplicationConstants
+{
+    public const long MaxFileUploadSize = 250 * 1024 * 1024;
+}

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -41,7 +41,7 @@ public static class AttachmentErrors
     public static Error AttachmentNotFound = new Error(2001, "The requested attachment was not found", HttpStatusCode.NotFound);
     public static Error UploadFailed = new Error(2002, "Error occurred during upload", HttpStatusCode.BadGateway);
     public static Error CantUploadToExistingCorrespondence = new Error(2003, "Cannot upload attachment to a correspondence that has been created", HttpStatusCode.BadRequest);
-    public static Error InvalidFileSize = new Error(2004, "File must have content and has a max file size of 2GB", HttpStatusCode.BadRequest);
+    public static Error InvalidFileSize = new Error(2004, "File must have content and has a max file size of 250 MB", HttpStatusCode.BadRequest);
     public static Error FileAlreadyUploaded = new Error(2005, "File has already been or is being uploaded", HttpStatusCode.BadRequest);
     public static Error FileHasBeenPurged = new Error(2006, "File has already been purged", HttpStatusCode.BadRequest);
     public static Error PurgeAttachmentWithExistingCorrespondence = new Error(2007, "Attachment cannot be purged as it is linked to at least one existing correspondence", HttpStatusCode.BadRequest);

--- a/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/UploadAttachment/UploadAttachmentHandler.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Application.Settings;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
@@ -35,8 +36,7 @@ public class UploadAttachmentHandler(
         {
             return AuthorizationErrors.NoAccessToResource;
         }
-        var maxUploadSize = long.Parse(int.MaxValue.ToString());
-        if (request.ContentLength > maxUploadSize || request.ContentLength == 0)
+        if (request.ContentLength > ApplicationConstants.MaxFileUploadSize || request.ContentLength == 0)
         {
             return AttachmentErrors.InvalidFileSize;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the file size limit is 2 GB because files larger than 2 GB does not work for multiform data. This PR sets the max file size to 250 MB which is a more appropiate limit for the attachments.

## Related Issue(s)
- #604 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a centralized constant for file upload size limit

- **Bug Fixes**
	- Updated file upload size limit from 2GB to 250 MB
	- Corrected maximum file size validation mechanism

- **Documentation**
	- Updated error message to reflect new file size restriction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->