### PR TITLE
Default to zero minimum auth level if no obligation is given.

### DIFF
--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -48,7 +48,7 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     storage: {
       storageSizeGB: prodLikeEnvironment ? 2048 : 32
       autoGrow: 'Enabled'
-      tier: prodLikeEnvironment ? 'P20': 'P4'
+      tier: prodLikeEnvironment ? 'P40': 'P4'
     }
     backup: { backupRetentionDays: 35 }
     authConfig: {

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -38,7 +38,7 @@ module saveMigrationConnectionString '../keyvault/upsertSecret.bicep' = {
   }
 }
 
-resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' = {
+resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: '${namePrefix}-dbserver'
   location: location
   properties: {
@@ -46,7 +46,6 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview'
     administratorLogin: databaseUser
     administratorLoginPassword: administratorLoginPassword
     storage: {
-      storageSizeGB: prodLikeEnvironment ? 512 : 32
       autoGrow: 'Enabled'
       tier: prodLikeEnvironment ? 'P20': 'P4'
     }
@@ -66,7 +65,7 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview'
   }
 }
 
-resource database 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2023-06-01-preview' = {
+resource database 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
   name: databaseName
   parent: postgres
   properties: {
@@ -75,7 +74,7 @@ resource database 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2023-06-0
   }
 }
 
-resource extensionsConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2022-12-01' = {
+resource extensionsConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = {
   name: 'azure.extensions'
   parent: postgres
   dependsOn: [database]
@@ -85,7 +84,7 @@ resource extensionsConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/conf
   }
 }
 
-resource maxConnectionsConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2022-12-01' = {
+resource maxConnectionsConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = {
   name: 'max_connections'
   parent: postgres
   dependsOn: [database, extensionsConfiguration]
@@ -95,7 +94,7 @@ resource maxConnectionsConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/
   }
 }
 
-resource workMemConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2022-12-01' = {
+resource workMemConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = {
   name: 'work_mem'
   parent: postgres
   dependsOn: [database, maxConnectionsConfiguration]
@@ -105,7 +104,7 @@ resource workMemConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/configu
   }
 }
 
-resource maintenanceWorkMemConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2022-12-01' = {
+resource maintenanceWorkMemConfiguration 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = {
   name: 'maintenance_work_mem'
   parent: postgres
   dependsOn: [database, workMemConfiguration]

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -46,6 +46,7 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     administratorLogin: databaseUser
     administratorLoginPassword: administratorLoginPassword
     storage: {
+      storageSizeGB: prodLikeEnvironment ? 0 : 32
       autoGrow: 'Enabled'
       tier: prodLikeEnvironment ? 'P20': 'P4'
     }

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -46,7 +46,7 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     administratorLogin: databaseUser
     administratorLoginPassword: administratorLoginPassword
     storage: {
-      storageSizeGB: prodLikeEnvironment ? 0 : 32
+      storageSizeGB: prodLikeEnvironment ? 2048 : 32
       autoGrow: 'Enabled'
       tier: prodLikeEnvironment ? 'P20': 'P4'
     }

--- a/src/Altinn.Correspondence.Integrations/Idporten/IdPortenXacmlMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Idporten/IdPortenXacmlMapper.cs
@@ -55,6 +55,10 @@ namespace Altinn.Correspondence.Integrations.Idporten
         }
         public static int? GetMinimumAuthLevel(XacmlJsonResponse response, ClaimsPrincipal user)
         {
+            if (!response.Response.Any())
+            {
+                return null;
+            }
             int? minimumAuthLevel = null;
             foreach (var result in response.Response)
             {
@@ -78,7 +82,7 @@ namespace Altinn.Correspondence.Integrations.Idporten
                 }
             }
 
-            return minimumAuthLevel;
+            return minimumAuthLevel ?? 0;
         }
 
 


### PR DESCRIPTION
## Description
Default to zero minimum auth level if no obligation is given.

## Related Issue(s)
- #640 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure Updates**
	- Updated PostgreSQL flexible server API versions to the latest release (2024-08-01)
	- Removed `storageSizeGB` property from PostgreSQL resource definition

- **Authentication Improvements**
	- Enhanced authentication level validation in ID Porten mapper
	- Modified method to return a default integer value when no minimum auth level is set

<!-- end of auto-generated comment: release notes by coderabbit.ai -->