### PR TITLE
Updated GetCorrespondenceContent endpoint to produce text/plain

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -94,6 +94,6 @@ public class DialogportenTests
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, contentResponse.StatusCode);
-        Assert.Equal("application/vnd.dialogporten.frontchannelembed+json; type=markdown; charset=utf-8", contentResponse.Content.Headers.ContentType?.ToString());
+        Assert.Equal("text/plain; charset=utf-8", contentResponse.Content.Headers.ContentType?.ToString());
     }
 }

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -157,7 +157,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <returns>Message body in markdown format</returns>
         [HttpGet]
         [Route("{correspondenceId}/content")]
-        [Produces("application/vnd.dialogporten.frontchannelembed+json;type=markdown")]
+        [Produces("text/plain")]
         [Authorize(AuthenticationSchemes = AuthorizationConstants.DialogportenScheme)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
         public async Task<ActionResult> GetCorrespondenceContent(
@@ -174,7 +174,7 @@ namespace Altinn.Correspondence.API.Controllers
             return commandResult.Match(
                 data =>
                 {
-                    var messageBody = data.Content.MessageBody?.Replace("\n", "<br />");
+                    var messageBody = data.Content.MessageBody;
                     return Ok(messageBody);
                 },
                 Problem


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR Updates the GetCorrespondenceContent endpoint to produce text/plain and removes the replacement of '\n' with '\<br /> ' in the response content. With these changes 'Arbeidsflate' manages to read and format the markdown text from the endpoint correctly.

## Related Issue(s)
- #646 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Modified the correspondence message endpoint to deliver plain text responses instead of a specialized markdown format.
  - Removed automatic conversion of newline characters to HTML, ensuring messages are returned in their original form.
  - These enhancements ensure consistent content delivery, offering clearer message displays and improved integration with client applications.
  - Clients should review updated usage guidelines to ensure optimal integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->