### PR TITLE
Added validation to prevent empty recipients lists for custom recipients

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -594,8 +594,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
         }
 
-        
-
         [Theory]
         [InlineData("97661466", null)]
         [InlineData(null, "test@example.com")]

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -541,6 +541,30 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
+        public async Task Correspondence_CustomRecipient_EmptyNotificationRecipientList_GivesBadRequest()
+        {
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+            var customRecipients = new List<CustomNotificationRecipientExt>()
+            {
+                new CustomNotificationRecipientExt()
+                {
+                    RecipientToOverride = recipient,
+                    Recipients = []
+                }
+            };
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationChannel(NotificationChannelExt.Sms)
+                .WithCustomNotificationRecipients(customRecipients)
+                .Build();
+
+            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
+        }
+
+        [Fact]
         public async Task Correspondence_CustomRecipient_MissingMobileNumber_GivesBadRequest()
         {
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
@@ -569,6 +593,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
         }
+
+        
 
         [Theory]
         [InlineData("97661466", null)]

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -70,6 +70,7 @@ public static class NotificationErrors
     public static Error SsnWithOrgNoEmailOrMobile = new Error(3014, "National identity number cannot be combined with email address, mobile number, or organization number.", HttpStatusCode.BadRequest);
     public static Error RecipientOverridesWithNumberOrEmailNotAllowedWithCustomTemplate = new Error(3015, "Recipient overrides with email or mobile number are not allowed when using a custom notification template because of name lookup", HttpStatusCode.BadRequest);
     public static Error RecipientOverridesWithNumberOrEmailNotAllowedWithRecipientName = new Error(3016, "Recipient overrides with email or mobile number are not allowed when using recipient name because of name lookup", HttpStatusCode.BadRequest);
+    public static Error MissingRecipientsForRecipientOverride = new Error(3017, "No recipients provided for one or more recipient overrides", HttpStatusCode.BadRequest);
 }
 public static class AuthorizationErrors
 {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -181,6 +181,10 @@ namespace Altinn.Correspondence.Application.Helpers
                 {
                     return NotificationErrors.CouldNotFindRecipientToOverride(recipientToOverride.RecipientToOverride);
                 }
+                if (recipientToOverride.Recipients.Count == 0)
+                {
+                    return NotificationErrors.MissingRecipientsForRecipientOverride;
+                }
             }
 
             foreach (var recipientOverride in customRecipients)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When creating a correspondence one can add a customrecipient with an empty list of recipients. This should not be possible. This PR adds a validation that returns BadRequests for requests that have one or more customrecipients with an empty list of recipients.

## Related Issue(s)
- #669 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling to return a clear Bad Request when a custom notification recipient list is empty.
	- Introduced validation to ensure recipient overrides cannot be created without specifying recipients.
- **Tests**
	- Added a test to validate that the system responds with a Bad Request for empty notification recipient lists.
- **Style**
	- Improved formatting consistency for enhanced code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->