### PR TITLE
Return notification history in A2 format

### DIFF
--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -59,11 +59,11 @@ public class LegacyGetCorrespondenceHistoryHandler(
 
             if (notificationDetails?.NotificationsStatusDetails is null) continue;
 
-            var firstEmailDelivery = notificationDetails.NotificationsStatusDetails.Emails
+            var firstEmailDelivery = notificationDetails.NotificationsStatusDetails.Emails?
                 .Where(email => email.Succeeded)
                 .OrderBy(email => email.SendStatus.LastUpdate)
                 .FirstOrDefault();
-            var firstSmsDelivery = notificationDetails.NotificationsStatusDetails.Smses
+            var firstSmsDelivery = notificationDetails.NotificationsStatusDetails.Smses?
                 .Where(sms => sms.Succeeded)
                 .OrderBy(sms => sms.SendStatus.LastUpdate)
                 .FirstOrDefault();
@@ -78,8 +78,8 @@ public class LegacyGetCorrespondenceHistoryHandler(
                     IsReserved = anySucceededDeliveryRecipient.IsReserved,
                     NationalIdentityNumber = anySucceededDeliveryRecipient.NationalIdentityNumber,
                     OrganizationNumber = anySucceededDeliveryRecipient.OrganizationNumber,
-                    EmailAddress = string.Join(';', notificationDetails.NotificationsStatusDetails.Emails.Select(email => email.Recipient)),
-                    MobileNumber = string.Join(';', notificationDetails.NotificationsStatusDetails.Smses.Select(sms => sms.Recipient))
+                    EmailAddress = string.Join(';', notificationDetails.NotificationsStatusDetails.Emails?.Select(email => email.Recipient.EmailAddress) ?? []),
+                    MobileNumber = string.Join(';', notificationDetails.NotificationsStatusDetails.Smses?.Select(sms => sms.Recipient.MobileNumber) ?? [])
                 };
                 notificationHistory.Add(await GetNotificationStatus(anySucceededDeliveryStatus, assemblededRecipient, notification.IsReminder, cancellationToken));
             }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -78,8 +78,8 @@ public class LegacyGetCorrespondenceHistoryHandler(
                     IsReserved = anySucceededDeliveryRecipient.IsReserved,
                     NationalIdentityNumber = anySucceededDeliveryRecipient.NationalIdentityNumber,
                     OrganizationNumber = anySucceededDeliveryRecipient.OrganizationNumber,
-                    EmailAddress = string.Join(';', notificationDetails.NotificationsStatusDetails.Emails?.Select(email => email.Recipient.EmailAddress) ?? []),
-                    MobileNumber = string.Join(';', notificationDetails.NotificationsStatusDetails.Smses?.Select(sms => sms.Recipient.MobileNumber) ?? [])
+                    EmailAddress = string.Join("; ", notificationDetails.NotificationsStatusDetails.Emails?.Select(email => email.Recipient.EmailAddress) ?? []),
+                    MobileNumber = string.Join("; ", notificationDetails.NotificationsStatusDetails.Smses?.Select(sms => sms.Recipient.MobileNumber) ?? [])
                 };
                 notificationHistory.Add(await GetNotificationStatus(anySucceededDeliveryStatus, assemblededRecipient, notification.IsReminder, cancellationToken));
             }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -61,19 +61,13 @@ public class LegacyGetCorrespondenceHistoryHandler(
 
             if (notificationDetails.NotificationsStatusDetails.Sms is not null)
             {
-                notificationHistory.Add(await GetNotificationStatus(
-                    notificationDetails.NotificationsStatusDetails.Sms.SendStatus,
-                    notificationDetails.NotificationsStatusDetails.Sms.Recipient,
-                    notification.IsReminder,
-                    cancellationToken));
+                var getNotificationStatusTasks = notificationDetails.NotificationsStatusDetails.Smses.Select(sms => GetNotificationStatus(sms.SendStatus, sms.Recipient, notification.IsReminder, cancellationToken));
+                notificationHistory.AddRange(await Task.WhenAll(getNotificationStatusTasks));
             }
             if (notificationDetails.NotificationsStatusDetails.Email is not null)
             {
-                notificationHistory.Add(await GetNotificationStatus(
-                    notificationDetails.NotificationsStatusDetails.Email.SendStatus,
-                    notificationDetails.NotificationsStatusDetails.Email.Recipient,
-                    notification.IsReminder,
-                    cancellationToken));
+                var getNotificationStatusTasks = notificationDetails.NotificationsStatusDetails.Emails.Select(email => GetNotificationStatus(email.SendStatus, email.Recipient, notification.IsReminder, cancellationToken));
+                notificationHistory.AddRange(await Task.WhenAll(getNotificationStatusTasks));
             }
         }
         List<LegacyGetCorrespondenceHistoryResponse> joinedList = [.. correspondenceHistory.Concat(notificationHistory).OrderByDescending(s => s.StatusChanged)];

--- a/src/Altinn.Correspondence.Core/Models/Notifications/NotificationStatusDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Core/Models/Notifications/NotificationStatusDetailsResponse.cs
@@ -5,4 +5,8 @@ public class NotificationsStatusDetails
     public EmailNotificationWithResult? Email { get; set; }
 
     public SmsNotificationWithResult? Sms { get; set; }
+
+    public List<EmailNotificationWithResult> Emails { get; set; }
+
+    public List<SmsNotificationWithResult> Smses { get; set; }
 }

--- a/src/Altinn.Correspondence.Core/Models/Notifications/NotificationStatusDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Core/Models/Notifications/NotificationStatusDetailsResponse.cs
@@ -6,7 +6,7 @@ public class NotificationsStatusDetails
 
     public SmsNotificationWithResult? Sms { get; set; }
 
-    public List<EmailNotificationWithResult> Emails { get; set; }
+    public List<EmailNotificationWithResult>? Emails { get; set; }
 
-    public List<SmsNotificationWithResult> Smses { get; set; }
+    public List<SmsNotificationWithResult>? Smses { get; set; }
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/Notifications/AltinnNotificationService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Notifications/AltinnNotificationService.cs
@@ -92,9 +92,10 @@ public class AltinnNotificationService : IAltinnNotificationService
                 throw new BadHttpRequestException("Failed to process response from Altinn Notification");
             }
             var data = await emailResponse.Content.ReadFromJsonAsync<EmailNotificationSummary>(cancellationToken);
+            notificationStatusResponse.NotificationsStatusDetails.Emails = data.Notifications;
             if (data?.Notifications.Count > 0) notificationStatusResponse.NotificationsStatusDetails.Email = data?.Notifications[0];
         }
-        else if (notificationSummary.NotificationsStatusSummary?.Sms != null)
+        if (notificationSummary.NotificationsStatusSummary?.Sms != null)
         {
             var smsResponse = await _httpClient.GetAsync(notificationSummary.NotificationsStatusSummary.Sms.Links.Self, cancellationToken: cancellationToken);
             if (!smsResponse.IsSuccessStatusCode)
@@ -104,6 +105,7 @@ public class AltinnNotificationService : IAltinnNotificationService
                 throw new BadHttpRequestException("Failed to process response from Altinn Notification");
             }
             var data = await smsResponse.Content.ReadFromJsonAsync<SmsNotificationSummary>(cancellationToken);
+            notificationStatusResponse.NotificationsStatusDetails.Smses = data.Notifications;
             if (data?.Notifications.Count > 0) notificationStatusResponse.NotificationsStatusDetails.Sms = data.Notifications[0];
         }
         return notificationStatusResponse;


### PR DESCRIPTION
## Description
To make A2 inbox work correctly with recipient addresses we should pre-format them, and reduce it to one entry.

Example response before change:
```
[
    {
        "status": "Delivered",
        "statusChanged": "2025-02-05T12:29:09.901259+00:00",
        "statusText": "[Notification] The email was delivered to the recipient. No errors reported, making it likely it was received by the recipient.",
        "user": {
            "partyId": 12345678,
            "nationalIdentityNumber": null,
            "name": "KJEMPENDE TOM TIGER AS"
        },
        "notification": {
            "emailAddress": "aromj@selskap.no",
            "mobileNumber": null,
            "organizationNumber": "550521167",
            "nationalIdentityNumber": null
        }
    },
    {
        "status": "Published",
        "statusChanged": "2025-02-05T12:23:05.030635+00:00",
        "statusText": "[Correspondence] Published",
        "user": {
            "partyId": 12345678,
            "nationalIdentityNumber": "",
            "name": "PRIKKETE PARISK KATT TOMAT"
        },
        "notification": null
    }
]
```

Example response after change:
```
[
    {
        "status": "Delivered",
        "statusChanged": "2025-02-05T12:29:09.901259+00:00",
        "statusText": "[Notification] The email was delivered to the recipient. No errors reported, making it likely it was received by the recipient.",
        "user": {
            "partyId": 12345678,
            "nationalIdentityNumber": null,
            "name": "KJEMPENDE TOM TIGER AS"
        },
        "notification": {
            "emailAddress": "aromj@selskap.no; aromj@gmail.com; aromj@gmail.com",
            "mobileNumber": "",
            "organizationNumber": "550521167",
            "nationalIdentityNumber": null
        }
    },
    {
        "status": "Published",
        "statusChanged": "2025-02-05T12:23:05.030635+00:00",
        "statusText": "[Correspondence] Published",
        "user": {
            "partyId": 12345678,
            "nationalIdentityNumber": "",
            "name": "PRIKKETE PARISK KATT TOMAT"
        },
        "notification": null
    }
]
```

## Related Issue(s)
- #673 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded notification details to support multiple email and SMS notifications, enabling richer responses.

- **Refactor**
  - Enhanced the notification status handling by processing email and SMS notifications concurrently for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->