### PR TITLE
Made Accept header in requests optional

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/AcceptHeaderValidationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/AcceptHeaderValidationTests.cs
@@ -32,7 +32,7 @@ public class CorrespondenceInitializationTests : CorrespondenceTestBase
     }
 
     [Fact]
-    public async Task InitializeEndpoint_WithNoAcceptHeader_ReturnsNotAcceptable()
+    public async Task InitializeEndpoint_WithNoAcceptHeader_ReturnsOk()
     {
         // Arrange
         _senderClient.DefaultRequestHeaders.Accept.Clear();
@@ -42,7 +42,7 @@ public class CorrespondenceInitializationTests : CorrespondenceTestBase
         var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
 
         // Assert
-        Assert.Equal(HttpStatusCode.NotAcceptable, initializeCorrespondenceResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
     }
 
     [Fact]

--- a/altinn-correspondence-postman-collection.json
+++ b/altinn-correspondence-postman-collection.json
@@ -202,7 +202,7 @@
 									},
 									{
 										"key": "Accept",
-										"value": "text/plain"
+										"value": "application/json"
 									}
 								],
 								"body": {
@@ -304,7 +304,7 @@
 									},
 									{
 										"key": "Accept",
-										"value": "text/plain"
+										"value": "application/json"
 									}
 								],
 								"body": {
@@ -406,7 +406,7 @@
 									},
 									{
 										"key": "Accept",
-										"value": "text/plain"
+										"value": "application/json"
 									}
 								],
 								"body": {
@@ -571,7 +571,7 @@
 								"header": [
 									{
 										"key": "Accept",
-										"value": "text/plain"
+										"value": "application/json"
 									}
 								],
 								"url": {

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -229,6 +229,7 @@ namespace Altinn.Correspondence.API.Controllers
         [HttpPost]
         [Authorize(Policy = AuthorizationConstants.Recipient, AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [Route("{correspondenceId}/markasread")]
+        [Produces("application/json")]
         public async Task<ActionResult> MarkAsRead(
             Guid correspondenceId,
             [FromServices] UpdateCorrespondenceStatusHandler handler,
@@ -259,6 +260,7 @@ namespace Altinn.Correspondence.API.Controllers
         [Authorize(Policy = AuthorizationConstants.Recipient, AuthenticationSchemes = AuthorizationConstants.AltinnTokenOrDialogportenScheme)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
         [Route("{correspondenceId}/confirm")]
+        [Produces("application/json")]
         public async Task<ActionResult> Confirm(
             Guid correspondenceId,
             [FromServices] UpdateCorrespondenceStatusHandler handler,
@@ -289,6 +291,7 @@ namespace Altinn.Correspondence.API.Controllers
         [Authorize(Policy = AuthorizationConstants.Recipient, AuthenticationSchemes = AuthorizationConstants.AltinnTokenOrDialogportenScheme)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
         [Route("{correspondenceId}/archive")]
+        [Produces("application/json")]
         public async Task<ActionResult> Archive(
             Guid correspondenceId,
             [FromServices] UpdateCorrespondenceStatusHandler handler,
@@ -319,6 +322,7 @@ namespace Altinn.Correspondence.API.Controllers
         [Route("{correspondenceId}/purge")]
         [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
+        [Produces("application/json")]
         public async Task<ActionResult> Purge(
             Guid correspondenceId,
             [FromServices] PurgeCorrespondenceHandler handler,

--- a/src/Altinn.Correspondence.API/Helpers/AcceptHeaderValidationMiddleware.cs
+++ b/src/Altinn.Correspondence.API/Helpers/AcceptHeaderValidationMiddleware.cs
@@ -21,16 +21,10 @@ public class AcceptHeaderValidationMiddleware
                 .OfType<ProducesAttribute>()
                 .FirstOrDefault();
             
-            if (producesAttribute != null)
+            if (producesAttribute != null && acceptHeaders.Length > 0)
             {
                 var validMimeTypes = producesAttribute.ContentTypes.ToList();
-
-                if (acceptHeaders.Length == 0)
-                {
-                    context.Response.StatusCode = StatusCodes.Status406NotAcceptable;
-                    await context.Response.WriteAsync("Accept header is required");
-                    return;
-                }
+                validMimeTypes.Add("*/*");
                 if (!acceptHeaders.Any(header => header != null && IsValidAcceptHeader(header, validMimeTypes)))
                 {
                     context.Response.StatusCode = StatusCodes.Status406NotAcceptable;
@@ -53,6 +47,6 @@ public class AcceptHeaderValidationMiddleware
                 return parts[0].Trim().ToLowerInvariant();
             })
             .ToList();
-        return acceptHeader == "*/*" || acceptedMimeTypes.Any(mimeType => validMimeTypes.Contains(mimeType));
+        return acceptedMimeTypes.Any(mimeType => validMimeTypes.Contains(mimeType));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the Accept-header is required for endpoints where the accept-header is validated however it should be an optional header. This PR makes the accept-header optional. The Accept header validation is also expanded to validate the Mark as read, Confirm, Archive and Purge endpoints.

## Related Issue(s)
- #687
- #496 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted request handling so that calls without specific header information now receive a successful response instead of an error.
- **New Features**
	- Standardized API endpoint responses to consistently return data in JSON format.
	- Updated sample API calls to reflect the new JSON response expectations, streamlining integration for API consumers. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->