### PR TITLE
Updated CorrespondenceMigration to accept correspondences with Html

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -33,6 +33,9 @@ public class MigrationControllerTests
         var basicCorrespondence = new CorrespondenceBuilder()
             .CreateCorrespondence()
             .Build();
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+        basicCorrespondence.Correspondence.Content.MessageBody = "<html><header>test header</header><body>test body</body></html>";
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
         MigrateCorrespondenceExt migrateCorrespondenceExt = new()
         {
             CorrespondenceData = basicCorrespondence,

--- a/src/Altinn.Correspondence.API/Mappers/MigrateCorrespondenceMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/MigrateCorrespondenceMapper.cs
@@ -12,12 +12,13 @@ internal static class MigrateCorrespondenceMapper
     {
         var correspondence = new CorrespondenceEntity
         {
-            Statuses = migrateCorrespondenceExt.EventHistory.Select(eh => new CorrespondenceStatusEntity() 
+            Altinn2CorrespondenceId = migrateCorrespondenceExt.Altinn2CorrespondenceId,
+            Statuses = [.. migrateCorrespondenceExt.EventHistory.Select(eh => new CorrespondenceStatusEntity() 
             { 
                 Status = (CorrespondenceStatus)eh.Status, 
                 StatusChanged = eh.StatusChanged, 
                 StatusText = eh.StatusText ?? eh.Status.ToString()
-            }).ToList(),
+            })],
             Notifications = migrateCorrespondenceExt.NotificationHistory.Select(n => new CorrespondenceNotificationEntity() 
             {
                 Created = n.NotificationSent,

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -22,7 +22,7 @@ public class MigrateCorrespondenceHandler(
             return AuthorizationErrors.NoAccessToResource;
         }
 
-        var contentError = initializeCorrespondenceHelper.ValidateCorrespondenceContent(request.CorrespondenceEntity.Content);
+        var contentError = MigrationValidateCorrespondenceContent(request.CorrespondenceEntity.Content);
         if (contentError != null)
         {
             return contentError;
@@ -63,5 +63,40 @@ public class MigrateCorrespondenceHandler(
             };
         }, logger, cancellationToken);
 
+    }
+
+    public Error? MigrationValidateCorrespondenceContent(CorrespondenceContentEntity? content)
+    {
+        if (content == null)
+        {
+            return CorrespondenceErrors.MissingContent;
+        }
+        if (string.IsNullOrWhiteSpace(content.MessageTitle))
+        {
+            return CorrespondenceErrors.MessageTitleEmpty;
+        }
+        if (!TextValidation.ValidatePlainText(content.MessageTitle))
+        {
+            return CorrespondenceErrors.MessageTitleIsNotPlainText;
+        }
+        if (string.IsNullOrWhiteSpace(content.MessageBody))
+        {
+            return CorrespondenceErrors.MessageBodyEmpty;
+        }
+        if (string.IsNullOrWhiteSpace(content.MessageSummary))
+        {
+            return CorrespondenceErrors.MessageSummaryEmpty;
+        }
+        if (!IsLanguageValid(content.Language))
+        {
+            return CorrespondenceErrors.InvalidLanguage;
+        }
+
+        return null;
+    }
+    private static bool IsLanguageValid(string language)
+    {
+        List<string> supportedLanguages = ["nb", "nn", "en"];
+        return supportedLanguages.Contains(language.ToLower());
     }
 }


### PR DESCRIPTION

Updated MigrateCorrespondenceMapper to include Altinn2CorrespondenceId in internal Correspondence entity.

Altinn 2 Correspondenes have Html bodies. These should be migrated to Altinn 3 with no changes.
In order to achieve this, Correspondence Migration should not demand that Correspondence Body and CustomData be in Markdown format. 

## Description
I've added an internal validation procedure to the MigrationHandler which uses a pared-down validation procedure rather than the standard validation procedure. The pared-down validation procedure doesn't check for valid Markdown in Correspondence Body and Customdata.

## Related Issue(s)
- #658 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
