### PR TITLE
Feat/set recipientname as messsage recipient

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -595,9 +595,9 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Theory]
-        [InlineData("97661466", null)]
+        [InlineData("+4791702158", null)]
         [InlineData(null, "test@example.com")]
-        public async Task Correspondence_CustomRecipient_WithPhoneNumberOrEmailAndRecipientTag_GivesBadRequest(string? number, string? email)
+        public async Task Correspondence_CustomRecipient_WithPhoneNumberOrEmailAndRecipientTag_GivesOk(string? number, string? email)
         {
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
             var customRecipients = new List<CustomNotificationRecipientExt>()
@@ -624,13 +624,13 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .Build();
 
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
-            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, initResponse.StatusCode);
         }
 
         [Theory]
-        [InlineData("97661466", null)]
+        [InlineData("+4797661466", null)]
         [InlineData(null, "test@example.com")]
-        public async Task Correspondence_CustomRecipient_WithNumberOrEmailAndCustomRecipientTag_GivesBadRequest(string? number, string? email)
+        public async Task Correspondence_CustomRecipient_WithNumberOrEmailAndCustomRecipientTag_GivesOK(string? number, string? email)
         {
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
             var customRecipients = new List<CustomNotificationRecipientExt>()
@@ -660,7 +660,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             payload.Correspondence.Notification.EmailBody = email != null ? "Test $recipientName$" : null;
 
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
-            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, initResponse.StatusCode);
         }
 
         [Fact]

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -68,9 +68,7 @@ public static class NotificationErrors
     public static Error InvalidMobileNumberProvided = new Error(3012, "Invalid mobile number provided. Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard.", HttpStatusCode.BadRequest);
     public static Error OrgNumberWithSsnEmailOrMobile = new Error(3013, "Organization number cannot be combined with email address, mobile number, or national identity number.", HttpStatusCode.BadRequest);
     public static Error SsnWithOrgNoEmailOrMobile = new Error(3014, "National identity number cannot be combined with email address, mobile number, or organization number.", HttpStatusCode.BadRequest);
-    public static Error RecipientOverridesWithNumberOrEmailNotAllowedWithCustomTemplate = new Error(3015, "Recipient overrides with email or mobile number are not allowed when using a custom notification template because of name lookup", HttpStatusCode.BadRequest);
-    public static Error RecipientOverridesWithNumberOrEmailNotAllowedWithRecipientName = new Error(3016, "Recipient overrides with email or mobile number are not allowed when using recipient name because of name lookup", HttpStatusCode.BadRequest);
-    public static Error MissingRecipientsForRecipientOverride = new Error(3017, "No recipients provided for one or more recipient overrides", HttpStatusCode.BadRequest);
+    public static Error MissingRecipientsForRecipientOverride = new Error(3015, "No recipients provided for one or more recipient overrides", HttpStatusCode.BadRequest);
 }
 public static class AuthorizationErrors
 {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -161,20 +161,6 @@ namespace Altinn.Correspondence.Application.Helpers
             {
                 return null;
             }
-            var recipientWithNumberOrEmail = customRecipients.Where(recipient => recipient.Recipients.Any(r => r.EmailAddress != null || r.MobileNumber != null)).ToList();
-            if (recipientWithNumberOrEmail.Count > 0)
-            {
-                if (notification.NotificationTemplate != NotificationTemplate.CustomMessage)
-                {
-                    return NotificationErrors.RecipientOverridesWithNumberOrEmailNotAllowedWithCustomTemplate;
-                }
-                if (TextContainsTag(notification.EmailBody, "$recipientName$") || TextContainsTag(notification.SmsBody, "$recipientName$")
-                    || TextContainsTag(notification.EmailSubject, "$recipientName$") || TextContainsTag(notification.ReminderEmailBody, "$recipientName$")
-                    || TextContainsTag(notification.ReminderSmsBody, "$recipientName$") || TextContainsTag(notification.ReminderEmailSubject, "$recipientName$"))
-                {
-                    return NotificationErrors.RecipientOverridesWithNumberOrEmailNotAllowedWithRecipientName;
-                }
-            }
             foreach (var recipientToOverride in customRecipients)
             {
                 if (!recipients.Any(recipient => recipient.WithoutPrefix() == recipientToOverride.RecipientToOverride.WithoutPrefix()))

--- a/src/Altinn.Correspondence.Persistence/Migrations/20240927122054_add_Notification_templates.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20240927122054_add_Notification_templates.cs
@@ -34,40 +34,84 @@ namespace Altinn.Correspondence.Persistence.Migrations
                 });
 
             migrationBuilder.InsertData(
-           schema: "correspondence",
-           table: "NotificationTemplates",
-           columns: new[] { "EmailBody", "EmailSubject", "Language", "RecipientType", "ReminderEmailBody", "ReminderEmailSubject", "ReminderSmsBody", "SmsBody", "Template" },
-           values: new object[,]
-           {
-                    { "{textToken}", "{textToken}", null, null, "{textToken}", "{textToken}", "{textToken}", "{textToken}", 0 },
-                    { "Hei $recipientName$, du har mottatt en ny melding i Altinn fra $sendersName$. {textToken} Logg deg inn i Altinn inboks for å se denne meldingen.",
-                    "Du har mottatt en melding i Altinn {textToken}", "no", 0, "Hei $recipientName$, dette er en påminnelse om at du har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.",
-                    "Påminnelse - du har mottatt en melding i Altinn {textToken}", "Hei $recipientName$, dette er en påminnelse om at du har mottatt en ny melding i Altinn fra $sendersName$. {textToken} Logg deg inn i Altinn inboks for å se denne meldingen.",
-                     "Hei $recipientName$, du har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.", 1 },
-                    { "Hei $recipientName$, du har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.",
-                    "Du har mottatt en melding i Altinn {textToken}", "no", 1, "Hei $recipientName$, dette er en påminnelse om at du har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.",
-                    "Påminnelse - du har mottatt en melding i Altinn {textToken}", "Hei $recipientName$, dette er en påminnelse om at du har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.",
-                     "Hei $recipientName$, du har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.", 1 },
-                    
-                    //english
-                    { "Hello $recipientName$, you have received a new message in Altinn from $sendersName$. {textToken} Log in to Altinn inbox to see this message.",
-                    "You have received a message in Altinn {textToken}", "en", 0, "Hello $recipientName$, this is a reminder that you have received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.",
-                    "Reminder - you have received a message in Altinn {textToken}", "Hello $recipientName$, this is a reminder that you have received a new message in Altinn from $sendersName$. {textToken} Log in to Altinn inbox to see this message.",
-                     "Hello $recipientName$, you have received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.", 1 },
-                    { "Hello $recipientName$, you have received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.",
-                    "You have received a message in Altinn {textToken}", "en", 1, "Hello $recipientName$, this is a reminder that you have received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.",
-                    "Reminder - you have received a message in Altinn {textToken}", "Hello $recipientName$, this is a reminder that you have received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.",
-                     "Hello $recipientName$, you have received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.", 1 },
+            schema: "correspondence",
+            table: "NotificationTemplates",
+            columns: new[] { "EmailBody", "EmailSubject", "Language", "RecipientType", "ReminderEmailBody", "ReminderEmailSubject", "ReminderSmsBody", "SmsBody", "Template" },
+            values: new object[,]
+            {
+                { "{textToken}", "{textToken}", null, null, "{textToken}", "{textToken}", "{textToken}", "{textToken}", 0 },
 
-                     //nynorsk
-                    { "Hei $recipientName$, du har motteke ei ny melding i Altinn frå $sendersName$. {textToken} Logg deg inn i Altinn inboks for å sjå denne meldinga.",
-                    "Du har motteke ei melding i Altinn {textToken}", "nn", 0, "Hei $recipientName$, dette er ei påminning om at du har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.",
-                    "Påminning - du har motteke ei melding i Altinn {textToken}", "Hei $recipientName$, dette er ei påminning om at du har motteke ei ny melding i Altinn frå $sendersName$. {textToken} Logg deg inn i Altinn inboks for å sjå denne meldinga.",
-                     "Hei $recipientName$, du har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.", 1 },
-                    { "Hei $recipientName$, du har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.",
-                    "Du har motteke ei melding i Altinn {textToken}", "nn", 1, "Hei $recipientName$, dette er ei påminning om at du har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.",
-                    "Påminning - du har motteke ei melding i Altinn {textToken}", "Hei $recipientName$, dette er ei påminning om at du har motteke ei ny melding i Altinn frå $sendersName$. {textToken} Logg deg inn i Altinn inboks for å sjå denne meldinga.",
-                     "Hei $recipientName$, du har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.", 1 }
+                //bokmål
+                { 
+                    "Hei. $recipientName$ har mottatt en ny melding i Altinn fra $sendersName$. {textToken} Logg deg inn i Altinn inboks for å se denne meldingen.",
+                    "$recipientName$ har mottatt en melding i Altinn {textToken}",
+                    "no", 
+                    0, 
+                    "Hei. Dette er en påminnelse om at $recipientName$ har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.",
+                    "Påminnelse - $recipientName$ har mottatt en melding i Altinn {textToken}", 
+                    "Hei. Dette er en påminnelse om at $recipientName$ har mottatt en ny melding i Altinn fra $sendersName$. {textToken} Logg deg inn i Altinn inboks for å se denne meldingen.",
+                    "Hei. $recipientName$ har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.", 
+                    1
+                },
+                { 
+                    "Hei. $recipientName$ har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.",
+                    "$recipientName$ har mottatt en melding i Altinn {textToken}", 
+                    "no", 
+                    1,
+                    "Hei. Dette er en påminnelse om at $recipientName$ har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.",
+                    "Påminnelse - $recipientName$ har mottatt en melding i Altinn {textToken}", 
+                    "Hei. Dette er en påminnelse om at $recipientName$ har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.",
+                    "Hei. $recipientName$ har mottatt en ny melding i Altinn fra $sendersName$. {textToken}Logg deg inn i Altinn inboks for å se denne meldingen.", 
+                    1 
+                },
+
+                //english
+                { 
+                    "Hello. $recipientName$ has received a new message in Altinn from $sendersName$. {textToken} Log in to Altinn inbox to see this message.",
+                    "$recipientName$ has received a message in Altinn {textToken}", 
+                    "en", 
+                    0, 
+                    "Hello. This is a reminder that $recipientName$ has received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.",
+                    "Reminder - $recipientName$ has received a message in Altinn {textToken}", 
+                    "Hello. This is a reminder that $recipientName$ has received a new message in Altinn from $sendersName$. {textToken} Log in to Altinn inbox to see this message.",
+                    "Hello. $recipientName$ has received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.", 
+                    1 
+                },
+                { 
+                    "Hello. $recipientName$ has received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.",
+                    "$recipientName$ has received a message in Altinn {textToken}", 
+                    "en", 
+                    1, 
+                    "Hello. This is a reminder that $recipientName$ has received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.",
+                    "Reminder - $recipientName$ has received a message in Altinn {textToken}", 
+                    "Hello. This is a reminder that $recipientName$ has received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.",
+                    "Hello $recipientName$ has received a new message in Altinn from $sendersName$. {textToken}Log in to Altinn inbox to see this message.", 
+                    1 
+                },
+
+                //nynorsk
+                { 
+                    "Hei. $recipientName$ har motteke ei ny melding i Altinn frå $sendersName$. {textToken} Logg deg inn i Altinn inboks for å sjå denne meldinga.",
+                    "$recipientName$ har motteke ei melding i Altinn {textToken}", 
+                    "nn", 
+                    0, 
+                    "Hei. Dette er ei påminning om at $recipientName$ har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.",
+                    "Påminning - $recipientName$ har motteke ei melding i Altinn {textToken}", 
+                    "Hei. Dette er ei påminning om at $recipientName$ har motteke ei ny melding i Altinn frå $sendersName$. {textToken} Logg deg inn i Altinn inboks for å sjå denne meldinga.",
+                    "Hei. $recipientName$ har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.", 
+                    1 
+                },
+                {
+                    "Hei. $recipientName$ har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.",
+                    "$recipientName$ har motteke ei melding i Altinn {textToken}", 
+                    "nn", 
+                    1, 
+                    "Hei. Dette er ei påminning om at $recipientName$ har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.",
+                    "Påminning - $recipientName$ har motteke ei melding i Altinn {textToken}", 
+                    "Hei. Dette er ei påminning om at $recipientName$ har motteke ei ny melding i Altinn frå $sendersName$. {textToken} Logg deg inn i Altinn inboks for å sjå denne meldinga.",
+                    "Hei. $recipientName$ har motteke ei ny melding i Altinn frå $sendersName$. {textToken}Logg deg inn i Altinn inboks for å sjå denne meldinga.", 
+                    1 
+                }
            });
         }
 

--- a/src/Altinn.Correspondence.Persistence/Migrations/20250129072844_update_notification_templates.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20250129072844_update_notification_templates.cs
@@ -11,15 +11,33 @@ namespace Altinn.Correspondence.Persistence.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.Sql(
-                "UPDATE correspondence.\"NotificationTemplates\" SET \"EmailBody\" = 'Hei $recipientName$, du har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.',\"ReminderEmailBody\" = 'Hei $recipientName$, dette er en påminnelse om at du har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.', \"SmsBody\" = 'Hei $recipientName$, du har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.' ,\"ReminderSmsBody\" = 'Hei $recipientName$, dette er en påminnelse om at du har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.' Where \"Language\" = 'nb' and \"Template\" = 1");
+                "UPDATE correspondence.\"NotificationTemplates\" SET " +
+                "\"EmailBody\" = 'Hei. $recipientName$ har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.', " +
+                "\"ReminderEmailBody\" = 'Hei. Dette er en påminnelse om at $recipientName$ har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.', " +
+                "\"SmsBody\" = 'Hei. $recipientName$ har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.' ," +
+                "\"ReminderSmsBody\" = 'Hei. Dette er en påminnelse om at $recipientName$ har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.' Where " +
+                "\"Language\" = 'nb' and " +
+                "\"Template\" = 1");
 
 
             migrationBuilder.Sql(
-                "UPDATE correspondence.\"NotificationTemplates\" SET \"EmailBody\" = 'Hello $recipientName$, you have received a new message from $sendersName$. {textToken}Log in to Altinn to see this message.', \"ReminderEmailBody\" = 'Hello $recipientName$, this is a reminder that you have received a new message from $sendersName$. {textToken}Log in to Altinn to see this message.',\"SmsBody\" = 'Hello $recipientName$, you have received a new message from $sendersName$. {textToken}Log in to Altinn to see this message.', \"ReminderSmsBody\" = 'Hello $recipientName$, this is a reminder that you have received a new message from $sendersName$. {textToken}Log in to Altinn to see this message.' Where \"Language\" = 'en' and \"Template\" = 1");
+                "UPDATE correspondence.\"NotificationTemplates\" SET " +
+                "\"EmailBody\" = 'Hello. $recipientName$ has received a new message from $sendersName$. {textToken}Log in to Altinn to see this message.', " +
+                "\"ReminderEmailBody\" = 'Hello. This is a reminder that $recipientName$ has received a new message from $sendersName$. {textToken}Log in to Altinn to see this message.'," +
+                "\"SmsBody\" = 'Hello. $recipientName$ has received a new message from $sendersName$. {textToken}Log in to Altinn to see this message.', " +
+                "\"ReminderSmsBody\" = 'Hello. This is a reminder that $recipientName$ has received a new message from $sendersName$. {textToken}Log in to Altinn to see this message.' Where " +
+                "\"Language\" = 'en' and " +
+                "\"Template\" = 1");
 
 
             migrationBuilder.Sql(
-                "UPDATE correspondence.\"NotificationTemplates\"  SET \"EmailBody\" = 'Hei $recipientName$, du har motteke ei ny melding frå $sendersName$. {textToken}Logg deg inn i Altinn for å sjå denne meldinga.', \"ReminderEmailBody\" = 'Hei $recipientName$, dette er ei påminning om at du har motteke ei ny melding frå $sendersName$. {textToken}Logg deg inn i Altinn for å sjå denne meldinga.', \"SmsBody\" = 'Hei $recipientName$, du har motteke ei ny melding frå $sendersName$. {textToken}Logg deg inn i Altinn for å sjå denne meldinga.', \"ReminderSmsBody\" = 'Hei $recipientName$, dette er ei påminning om at du har motteke ei ny melding frå $sendersName$. {textToken}Logg deg inn i Altinn for å sjå denne meldinga.' Where \"Language\" = 'nn' and \"Template\" = 1");
+                "UPDATE correspondence.\"NotificationTemplates\"  SET " +
+                "\"EmailBody\" = 'Hei. $recipientName$ har motteke ei ny melding frå $sendersName$. {textToken}Logg deg inn i Altinn for å sjå denne meldinga.', " +
+                "\"ReminderEmailBody\" = 'Hei. Dette er ei påminning om at $recipientName$ har motteke ei ny melding frå $sendersName$. {textToken}Logg deg inn i Altinn for å sjå denne meldinga.', " +
+                "\"SmsBody\" = 'Hei. $recipientName$ har motteke ei ny melding frå $sendersName$. {textToken}Logg deg inn i Altinn for å sjå denne meldinga.', " +
+                "\"ReminderSmsBody\" = 'Hei. Dette er ei påminning om at $recipientName$ har motteke ei ny melding frå $sendersName$. {textToken}Logg deg inn i Altinn for å sjå denne meldinga.' Where " +
+                "\"Language\" = 'nn' and " +
+                "\"Template\" = 1");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The recipientName in the notification Templates should be the name of the message recipient not the notification recipient. This PR adds logic that replaces the recipientName in the notification content to the message recipient.

## Related Issue(s)
- #692 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
