### PR TITLE
Affirm correspondence status before publish

### DIFF
--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -27,6 +27,7 @@ public class InitializeCorrespondencesHandler(
     ICorrespondenceRepository correspondenceRepository,
     ICorrespondenceNotificationRepository correspondenceNotificationRepository,
     INotificationTemplateRepository notificationTemplateRepository,
+    ICorrespondenceStatusRepository correspondenceStatusRepository,
     IEventBus eventBus,
     IBackgroundJobClient backgroundJobClient,
     IDialogportenService dialogportenService,

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -44,5 +44,6 @@ namespace Altinn.Correspondence.Core.Repositories
         Task<List<Guid>> GetCorrespondenceIdsByAttachmentId(Guid attachmentId, CancellationToken cancellationToken = default);
         Task AddExternalReference(Guid correspondenceId, ReferenceType referenceType, string referenceValue, CancellationToken cancellationToken = default);
         Task UpdatePublished(Guid correspondenceId, DateTimeOffset published, CancellationToken cancellationToken);
+        Task<bool> AreAllAttachmentsPublished(Guid correspondenceId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -139,5 +139,13 @@ namespace Altinn.Correspondence.Persistence.Repositories
             var result = await correspondences.Take(limit).ToListAsync(cancellationToken);
             return result;
         }
+        public async Task<bool> AreAllAttachmentsPublished(Guid correspondenceId, CancellationToken cancellationToken = default)
+        {
+            return await _context.CorrespondenceContents
+                .Where(content => content.CorrespondenceId == correspondenceId)
+                .Select(content => content.Attachments
+                    .All(correspondenceAttachment => correspondenceAttachment.Attachment!.Statuses.Any(status => status.Status == AttachmentStatus.Published)))
+                .SingleOrDefaultAsync(cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
## Description
Attachments are uploaded before the correspondence is recorded in the database. In some cases, the malware scan result is also processed before the correspondence is stored. This leads to a situation where the system checks whether all correspondences linked to a published attachment are set to ReadyForPublish before the correspondence itself exists. As a result, the correspondence is never marked as ReadyForPublish, causing the publish process to fail.

Although we verify whether all attachments are published in GetCurrentCorrespondenceStatus, this check occurs before the correspondence is stored in the database. If an attachment is marked as published after this check but before the correspondence is recorded, it leads to inconsistencies.

Since correspondences are processed sequentially in batches, some succeed while others fail, depending on whether the correspondence was created in time.

The solution is simple and we should probably look at re-engineering this in the future. 

## Related Issue(s)
- #698

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
