### PR TITLE
Deploy to at22 after test because they cannot be deployed concurrently

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: test
     if: always() && !failure() && !cancelled() 
-    needs: [get-version, publish, test]
+    needs: [get-version, publish, test, deploy-test]
     permissions: 
       id-token: write
       contents: read


### PR DESCRIPTION
## Description
Deploy to at22 after test because they cannot be deployed concurrently

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
