### PR TITLE
Background jobs must be scheduled using service from its own service scope

### DIFF
--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
@@ -89,11 +89,11 @@ public class UpdateCorrespondenceStatusHelper(
     {
         if (status == CorrespondenceStatus.Confirmed)
         {
-            _backgroundJobClient.Enqueue(() => _dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondenceConfirmed));
+            _backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondenceConfirmed));
         }
         else if (status == CorrespondenceStatus.Archived)
         {
-            _backgroundJobClient.Enqueue(() => _dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondenceArchived));
+            _backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondenceArchived));
         }
         return;
     }


### PR DESCRIPTION
## Description
Background jobs must be scheduled using service from its own service scope. Lead to errors of type:
"An invalid request URI was provided. Either the request URI must be an absolute URI or BaseAddress must be set."
## Related Issue(s)
- [#721](https://github.com/Altinn/altinn-correspondence/issues/721)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal processing for correspondence status updates, ensuring reliable background activity scheduling without impacting overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->