### PR TITLE
Add flag for a2 correspondences

### DIFF
--- a/src/Altinn.Correspondence.API/Mappers/MigrateCorrespondenceMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/MigrateCorrespondenceMapper.cs
@@ -50,13 +50,14 @@ internal static class MigrateCorrespondenceMapper
                 Attachments = []
             } : null,
             IsConfirmationNeeded = migrateCorrespondenceExt.CorrespondenceData.Correspondence.IsConfirmationNeeded,
+            IsMigrating = migrateCorrespondenceExt.IsMigrating
         };
         
         return new MigrateCorrespondenceRequest()
         {
             CorrespondenceEntity = correspondence,
             Altinn2CorrespondenceId = migrateCorrespondenceExt.Altinn2CorrespondenceId,
-            ExistingAttachments = migrateCorrespondenceExt.CorrespondenceData.ExistingAttachments ?? new List<Guid>(),
+            ExistingAttachments = migrateCorrespondenceExt.CorrespondenceData.ExistingAttachments ?? new List<Guid>()
         };
     }
 

--- a/src/Altinn.Correspondence.API/Models/MigrateCorrespondenceExt.cs
+++ b/src/Altinn.Correspondence.API/Models/MigrateCorrespondenceExt.cs
@@ -15,5 +15,8 @@ namespace Altinn.Correspondence.API.Models
 
         [JsonPropertyName("notificationHistory")]
         public List<MigrateCorrespondenceNotificationExt> NotificationHistory { get; set; } = new List<MigrateCorrespondenceNotificationExt>();
+
+        [JsonPropertyName("IsMigrating")]
+        public bool IsMigrating { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceEntity.cs
@@ -62,5 +62,7 @@ namespace Altinn.Correspondence.Core.Models.Entities
         public DateTimeOffset? Published { get; set; }
 
         public bool IsConfirmationNeeded { get; set; }
+
+        public bool IsMigrating { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Migrations/20250220130047_AddIsMigratingFlagToCorrespondences.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20250220130047_AddIsMigratingFlagToCorrespondences.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Altinn.Correspondence.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250220130047_AddIsMigratingFlagToCorrespondences")]
+    partial class AddIsMigratingFlagToCorrespondences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20250220130047_AddIsMigratingFlagToCorrespondences.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20250220130047_AddIsMigratingFlagToCorrespondences.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsMigratingFlagToCorrespondences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsMigrating",
+                schema: "correspondence",
+                table: "Correspondences",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsMigrating",
+                schema: "correspondence",
+                table: "Correspondences");
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There is a new need to be able to flag correspondences that are migrating from A2 to A3. This PR adds a IsMigrating flag to Correspondences, and a new parameter to the migrateCorrespondence endpoint which sets the flag. The flag is set to false by default.

## Related Issue(s)
- #715 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a migration flag that clearly indicates when correspondence items are being migrated. This improvement enhances tracking accuracy and data consistency.
- **Tests**
  - Added tests to verify that the migration flag is correctly activated during operations.

Users will benefit from smoother and more consistent correspondence migration results, boosting overall system reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->