### PR TITLE
Stop counting rows in search

### DIFF
--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
@@ -51,7 +51,7 @@ public class GetCorrespondencesHandler(
             cancellationToken);
         var response = new GetCorrespondencesResponse
         {
-            Ids = correspondences.Item1,
+            Ids = correspondences,
         };
         return response;
     }

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -9,7 +9,7 @@ namespace Altinn.Correspondence.Core.Repositories
 
         Task<List<CorrespondenceEntity>> CreateCorrespondences(List<CorrespondenceEntity> correspondences, CancellationToken cancellationToken);
 
-        Task<(List<Guid>, int)> GetCorrespondences(
+        Task<List<Guid>> GetCorrespondences(
             string resourceId,
             int limit,
             DateTimeOffset? from,

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -23,7 +23,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
             return correspondences;
         }
 
-        public async Task<(List<Guid>, int)> GetCorrespondences(
+        public async Task<List<Guid>> GetCorrespondences(
             string resourceId,
             int limit,
             DateTimeOffset? from,
@@ -42,9 +42,8 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .OrderByDescending(c => c.RequestedPublishTime)              // Sort by RequestedPublishTime
                 .Select(c => c.Id);
 
-            var totalItems = await correspondences.CountAsync(cancellationToken);
             var result = await correspondences.Take(limit).ToListAsync(cancellationToken);
-            return (result, totalItems);
+            return result;
         }
 
         public async Task<CorrespondenceEntity?> GetCorrespondenceById(


### PR DESCRIPTION
## Description
Counting all the rows is very expensive, and we no longer use that count for anything.


Before:
https://github.com/Altinn/altinn-correspondence/actions/runs/13524677911/job/37792117222
{ name:get correspondence }...........: 383     4.253964/s
     iteration_duration......................: avg=17.49s   min=6.64s    med=16.72s   max=27.[62](https://github.com/Altinn/altinn-correspondence/actions/runs/13524677911/job/37792117222#step:6:63)s   p(95)=25.47s   p(99)=26.23s   p(99.5)=26.41s   p(99.9)=27.2s    count=382  
     iterations..............................: 382     4.242857/s
     vus.....................................: 1       min=0              max=100
     vus_max.................................: 100     min=100            max=100


After:
https://github.com/Altinn/altinn-correspondence/actions/runs/13543592057/job/37849979803
{ name:get correspondence }...........: 1029   15.988128/s
     iteration_duration......................: avg=6.02s    min=891.23ms med=6.02s    max=24.57s   p(95)=7.75s    p(99)=9.22s    p(99.5)=9.69s    p(99.9)=13.[54](https://github.com/Altinn/altinn-correspondence/actions/runs/13543592057/job/37849979803#step:6:55)s   count=1029
     iterations..............................: 1029   15.988128/s
     vus.....................................: 5      min=0            max=100
     vus_max.................................: 100    min=100          max=100

## Related Issue(s)
- #582 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined correspondence retrieval so that results now return only the correspondence identifiers.
  - Removed extra count data to simplify the response and enhance clarity in correspondence outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->