### PR TITLE
add name to legacy attachment object

### DIFF
--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceAttachmentMapper.cs
@@ -31,8 +31,36 @@ internal static class CorrespondenceAttachmentMapper
         };
         return content;
     }
+    internal static LegacyCorrespondenceAttachmentExt MapToExternalLegacy(CorrespondenceAttachmentEntity attachment)
+    {
+        var fileName = attachment.Attachment.FileName;
+        var contentType = FileConstants.GetMIMEType(fileName);
+
+        var content = new LegacyCorrespondenceAttachmentExt
+        {
+            DataType = contentType,
+            FileName = attachment.Attachment.FileName,
+            Name = attachment.Attachment.FileName,
+            Id = attachment.AttachmentId,
+            IsEncrypted = attachment.Attachment.IsEncrypted,
+            SendersReference = attachment.Attachment.SendersReference,
+            Checksum = attachment.Attachment.Checksum,
+            DataLocationType = (AttachmentDataLocationTypeExt)attachment.Attachment.DataLocationType,
+            Status = (AttachmentStatusExt)attachment.Attachment.GetLatestStatus()!.Status,
+            StatusText = attachment.Attachment.GetLatestStatus()!.StatusText,
+            StatusChanged = attachment.Attachment.GetLatestStatus()!.StatusChanged,
+            Created = attachment.Created,
+            ExpirationTime = attachment.ExpirationTime
+        };
+        return content;
+    }
+
     internal static List<CorrespondenceAttachmentExt> MapListToExternal(List<CorrespondenceAttachmentEntity> attachments)
     {
         return attachments.Select(MapToExternal).ToList();
+    }
+    internal static List<LegacyCorrespondenceAttachmentExt> MapListToExternalLegacy(List<CorrespondenceAttachmentEntity> attachments)
+    {
+        return attachments.Select(MapToExternalLegacy).ToList();
     }
 }

--- a/src/Altinn.Correspondence.API/Mappers/LegacyCorrespondenceOverviewMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/LegacyCorrespondenceOverviewMapper.cs
@@ -21,7 +21,7 @@ internal static class LegacyCorrespondenceOverviewMapper
             Notifications = correspondenceOverview.Notifications,
             Recipient = correspondenceOverview.Recipient,
             Content = null,
-            Attachments = CorrespondenceAttachmentMapper.MapListToExternal(correspondenceOverview.Attachments),
+            Attachments = CorrespondenceAttachmentMapper.MapListToExternalLegacy(correspondenceOverview.Attachments),
             Language = correspondenceOverview.Language,
             MessageTitle = correspondenceOverview.MessageTitle,
             MessageSummary = correspondenceOverview.MessageSummary,

--- a/src/Altinn.Correspondence.API/Models/LegacyCorrespondenceAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/LegacyCorrespondenceAttachmentExt.cs
@@ -1,0 +1,59 @@
+using Altinn.Correspondence.API.Models.Enums;
+using System.Text.Json.Serialization;
+
+namespace Altinn.Correspondence.API.Models
+{
+    /// <summary>
+    /// Represents a binary attachment to a Correspondence
+    /// </summary>
+    public class LegacyCorrespondenceAttachmentExt : InitializeCorrespondenceAttachmentExt
+    {
+        /// <summary>
+        /// The date on which this attachment is created
+        /// </summary>
+        [JsonPropertyName("created")]
+        public DateTimeOffset Created { get; set; }
+
+        /// <summary>
+        /// Specifies the location of the attachment data
+        /// </summary>
+        [JsonPropertyName("dataLocationType")]
+        public new AttachmentDataLocationTypeExt DataLocationType { get; set; }
+
+        /// <summary>
+        /// Current attachment status
+        /// </summary>
+        [JsonPropertyName("status")]
+        public AttachmentStatusExt Status { get; set; }
+
+        /// <summary>
+        /// Current attachment status text description
+        /// </summary>
+        [JsonPropertyName("statusText")]
+        public string StatusText { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Timestamp for when the Current Attachment Status was changed
+        /// </summary>
+        [JsonPropertyName("statusChanged")]
+        public DateTimeOffset StatusChanged { get; set; }
+
+        /// <summary>
+        /// When the attachment expires
+        /// </summary>
+        [JsonPropertyName("expirationTime")]
+        public DateTimeOffset ExpirationTime { get; set; }
+
+        /// <summary>
+        /// The attachment data type in MIME format
+        /// </summary>
+        [JsonPropertyName("dataType")]
+        public string DataType { get; set; }
+
+        /// <summary>
+        /// The name of the attachment
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+    }
+}

--- a/src/Altinn.Correspondence.API/Models/LegacyCorrespondenceAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/LegacyCorrespondenceAttachmentExt.cs
@@ -6,50 +6,8 @@ namespace Altinn.Correspondence.API.Models
     /// <summary>
     /// Represents a binary attachment to a Correspondence
     /// </summary>
-    public class LegacyCorrespondenceAttachmentExt : InitializeCorrespondenceAttachmentExt
+    public class LegacyCorrespondenceAttachmentExt : CorrespondenceAttachmentExt
     {
-        /// <summary>
-        /// The date on which this attachment is created
-        /// </summary>
-        [JsonPropertyName("created")]
-        public DateTimeOffset Created { get; set; }
-
-        /// <summary>
-        /// Specifies the location of the attachment data
-        /// </summary>
-        [JsonPropertyName("dataLocationType")]
-        public new AttachmentDataLocationTypeExt DataLocationType { get; set; }
-
-        /// <summary>
-        /// Current attachment status
-        /// </summary>
-        [JsonPropertyName("status")]
-        public AttachmentStatusExt Status { get; set; }
-
-        /// <summary>
-        /// Current attachment status text description
-        /// </summary>
-        [JsonPropertyName("statusText")]
-        public string StatusText { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Timestamp for when the Current Attachment Status was changed
-        /// </summary>
-        [JsonPropertyName("statusChanged")]
-        public DateTimeOffset StatusChanged { get; set; }
-
-        /// <summary>
-        /// When the attachment expires
-        /// </summary>
-        [JsonPropertyName("expirationTime")]
-        public DateTimeOffset ExpirationTime { get; set; }
-
-        /// <summary>
-        /// The attachment data type in MIME format
-        /// </summary>
-        [JsonPropertyName("dataType")]
-        public string DataType { get; set; }
-
         /// <summary>
         /// The name of the attachment
         /// </summary>

--- a/src/Altinn.Correspondence.API/Models/LegacyCorrespondenceOverviewExt.cs
+++ b/src/Altinn.Correspondence.API/Models/LegacyCorrespondenceOverviewExt.cs
@@ -83,7 +83,7 @@ namespace Altinn.Correspondence.API.Models
         public required string MessageBody { get; set; }
 
         [JsonPropertyName("attachments")]
-        public required new List<CorrespondenceAttachmentExt> Attachments { get; set; }
+        public required new List<LegacyCorrespondenceAttachmentExt> Attachments { get; set; }
 
         /// <summary>
         /// Instance owner party id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds atathcment name to legacy overview requests


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced legacy support for processing correspondence attachments with richer metadata.
  - Added a new legacy attachment model to improve the handling of binary attachments.
- **Refactor**
  - Updated the correspondence overview mapping to utilize the new legacy attachment support, ensuring consistent attachment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->