### PR TITLE
set sender as null if messageSender is not ovverriden

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -56,17 +56,18 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     }
                 }
             },
-            SenderName = new ContentValue()
-            {
-                MediaType = "text/plain",
-                Value = new List<DialogValue> {
+            SenderName = String.IsNullOrWhiteSpace(correspondence.MessageSender) ? null :
+             new ContentValue()
+             {
+                 MediaType = "text/plain",
+                 Value = new List<DialogValue> {
                     new DialogValue()
                     {
                         Value = correspondence.MessageSender ?? correspondence.Sender,
                         LanguageCode = correspondence.Content.Language
                     }
                 }
-            },
+             },
             MainContentReference = new ContentValue()
             {
                 MediaType = "application/vnd.dialogporten.frontchannelembed+json;type=markdown",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
set sender as null if messageSender is not overriden for Dialogporten

## Related Issue(s)
- #758 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the logic for processing correspondence so that sender details are now included only when provided. With this change, if a sender’s name is missing, it is gracefully omitted to avoid displaying unnecessary or confusing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->