### PR TITLE
Verify creation of dialogporten dialog before publishing correspondence

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -193,6 +193,6 @@ public class DialogportenTests
         Assert.NotNull(processedCorrespondence);
         Assert.Contains(processedCorrespondence.Statuses, s => s.Status == Core.Models.Enums.CorrespondenceStatus.Failed);
         var failedStatus = processedCorrespondence.Statuses.Find(s => s.Status == Core.Models.Enums.CorrespondenceStatus.Failed);
-        Assert.Equal($"Dialogporten dialog not yet created for correspondence {correspondenceId}", failedStatus?.StatusText);
+        Assert.Equal($"Dialogporten dialog not created for correspondence {correspondenceId}", failedStatus?.StatusText);
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -192,7 +192,7 @@ public class DialogportenTests
         // Assert
         Assert.NotNull(processedCorrespondence);
         Assert.Contains(processedCorrespondence.Statuses, s => s.Status == Core.Models.Enums.CorrespondenceStatus.Failed);
-        var FailedStatus = processedCorrespondence.Statuses.Find(s => s.Status == Core.Models.Enums.CorrespondenceStatus.Failed);
-        Assert.Equal($"Dialogporten dialog not yet created for correspondence {correspondenceId}", FailedStatus?.StatusText);
+        var failedStatus = processedCorrespondence.Statuses.Find(s => s.Status == Core.Models.Enums.CorrespondenceStatus.Failed);
+        Assert.Equal($"Dialogporten dialog not yet created for correspondence {correspondenceId}", failedStatus?.StatusText);
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -135,6 +135,14 @@ public class DialogportenTests
                     Status = Core.Models.Enums.CorrespondenceStatus.Initialized,
                     StatusChanged = DateTimeOffset.UtcNow
                 }
+            },
+            ExternalReferences = new List<Core.Models.Entities.ExternalReferenceEntity>()
+            {
+                new Core.Models.Entities.ExternalReferenceEntity()
+                {
+                    ReferenceType = Core.Models.Enums.ReferenceType.DialogportenDialogId,
+                    ReferenceValue = "dialogId"
+                }
             }
         }, CancellationToken.None);
         var correspondenceId = initializedCorrespondence.Id;
@@ -194,5 +202,6 @@ public class DialogportenTests
         Assert.Contains(processedCorrespondence.Statuses, s => s.Status == Core.Models.Enums.CorrespondenceStatus.Failed);
         var failedStatus = processedCorrespondence.Statuses.Find(s => s.Status == Core.Models.Enums.CorrespondenceStatus.Failed);
         Assert.Equal($"Dialogporten dialog not created for correspondence {correspondenceId}", failedStatus?.StatusText);
+        Assert.DoesNotContain(hangfireBackgroundJobClient.Invocations, invocation => invocation.Arguments[0].ToString() == "IDialogportenService.PurgeCorrespondenceDialog");
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -1,4 +1,6 @@
 ﻿using Altinn.Correspondence.API.Models;
+using Altinn.Correspondence.Application;
+using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Application.InitializeCorrespondences;
 using Altinn.Correspondence.Application.PublishCorrespondence;
 using Altinn.Correspondence.Common.Constants;
@@ -142,5 +144,55 @@ public class DialogportenTests
 
         // Assert
         Assert.True(hangfireBackgroundJobClient.Invocations.Any(invocation => invocation.Arguments[0].ToString() == "IDialogportenService.PurgeCorrespondenceDialog"));
+    }
+
+    [Fact]
+    public async Task PublishCorrespondence_WithMissingDialogPortenExternalReference_Fails()
+    {
+        // Arrange
+        var hangfireBackgroundJobClient = new Mock<IBackgroundJobClient>();
+        var contactReservationRegistry = new Mock<IContactReservationRegistryService>();
+        contactReservationRegistry.Setup(contactReservationRegistry => contactReservationRegistry.IsPersonReserved(It.IsAny<string>())).ReturnsAsync(false);
+        contactReservationRegistry.Setup(contactReservationRegistry => contactReservationRegistry.GetReservedRecipients(It.IsAny<List<string>>())).ReturnsAsync(new List<string>());
+        var testFactory = new UnitWebApplicationFactory((IServiceCollection services) =>
+        {
+            services.AddSingleton(hangfireBackgroundJobClient.Object);
+            services.AddSingleton(contactReservationRegistry.Object);
+        });
+
+        var correspondence = new CorrespondenceBuilder().CreateCorrespondence().Build();
+        var testClient = testFactory.CreateSenderClient();
+
+        // Act
+        using var scope = testFactory.Services.CreateScope();
+        var correspondenceRepository = scope.ServiceProvider.GetRequiredService<ICorrespondenceRepository>();
+        var initializedCorrespondence = await correspondenceRepository.CreateCorrespondence(new Core.Models.Entities.CorrespondenceEntity()
+        {
+            Created = DateTimeOffset.UtcNow,
+            Recipient = correspondence.Recipients[0],
+            RequestedPublishTime = DateTimeOffset.UtcNow.AddSeconds(-5),
+            ResourceId = correspondence.Correspondence.ResourceId,
+            Sender = correspondence.Correspondence.Sender,
+            SendersReference = correspondence.Correspondence.SendersReference,
+            Statuses = new List<Core.Models.Entities.CorrespondenceStatusEntity>()
+            {
+                new Core.Models.Entities.CorrespondenceStatusEntity()
+                {
+                    Status = Core.Models.Enums.CorrespondenceStatus.ReadyForPublish,
+                    StatusChanged = DateTimeOffset.UtcNow
+                }
+            },
+        }, CancellationToken.None);
+        var correspondenceId = initializedCorrespondence.Id;
+        var handler = scope.ServiceProvider.GetRequiredService<PublishCorrespondenceHandler>();
+        var result = await handler.Process(correspondenceId, null, CancellationToken.None);
+
+        var processedCorrespondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, false, false, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(processedCorrespondence);
+        Assert.Contains(processedCorrespondence.Statuses, s => s.Status == Core.Models.Enums.CorrespondenceStatus.Failed);
+        var FailedStatus = processedCorrespondence.Statuses.Find(s => s.Status == Core.Models.Enums.CorrespondenceStatus.Failed);
+        Assert.Equal($"Dialogporten dialog not yet created for correspondence {correspondenceId}", FailedStatus?.StatusText);
     }
 }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -235,7 +235,7 @@ public class InitializeCorrespondencesHandler(
                     //Adds a 1 minute delay for malware scan to finish if not running locally
                     publishTime = correspondence.RequestedPublishTime.UtcDateTime.AddSeconds(-30) < DateTimeOffset.UtcNow ? DateTimeOffset.UtcNow.AddMinutes(1) : correspondence.RequestedPublishTime.UtcDateTime;
                 }
-                backgroundJobClient.ContinueJobWith(dialogJob, () => backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), publishTime), JobContinuationOptions.OnAnyFinishedState);
+                backgroundJobClient.ContinueJobWith(dialogJob, () => SchedulePublish(correspondence.Id, publishTime, cancellationToken), JobContinuationOptions.OnAnyFinishedState);
             }
             var isReserved = correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Reserved;
             var notificationDetails = new List<InitializedCorrespondencesNotifications>();
@@ -454,15 +454,7 @@ public class InitializeCorrespondencesHandler(
 
     public void SchedulePublish(Guid correspondenceId, DateTimeOffset publishTime, CancellationToken cancellationToken)
     {
-        if (publishTime <= DateTimeOffset.UtcNow)
-        {
-            
-            backgroundJobClient.Enqueue<PublishCorrespondenceHandler>((handler) => handler.Process(correspondenceId, null, cancellationToken));
-        }
-        else
-        {
-            backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondenceId, null, cancellationToken), publishTime);
-        }
+        backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondenceId, null, cancellationToken), publishTime);
     }
 
     internal class NotificationContent

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -235,7 +235,7 @@ public class InitializeCorrespondencesHandler(
                     //Adds a 1 minute delay for malware scan to finish if not running locally
                     publishTime = correspondence.RequestedPublishTime.UtcDateTime.AddSeconds(-30) < DateTimeOffset.UtcNow ? DateTimeOffset.UtcNow.AddMinutes(1) : correspondence.RequestedPublishTime.UtcDateTime;
                 }
-                backgroundJobClient.ContinueJobWith(dialogJob, () => backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), publishTime));
+                backgroundJobClient.ContinueJobWith<IBackgroundJobClient>(dialogJob, (BackgroundJobClient) => backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), publishTime));
             }
             var isReserved = correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Reserved;
             var notificationDetails = new List<InitializedCorrespondencesNotifications>();

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -235,8 +235,7 @@ public class InitializeCorrespondencesHandler(
                     //Adds a 1 minute delay for malware scan to finish if not running locally
                     publishTime = correspondence.RequestedPublishTime.UtcDateTime.AddSeconds(-30) < DateTimeOffset.UtcNow ? DateTimeOffset.UtcNow.AddMinutes(1) : correspondence.RequestedPublishTime.UtcDateTime;
                 }
-                
-                backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), publishTime);
+                backgroundJobClient.ContinueJobWith(dialogJob, () => backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), publishTime));
             }
             var isReserved = correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Reserved;
             var notificationDetails = new List<InitializedCorrespondencesNotifications>();

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -223,7 +223,8 @@ public class InitializeCorrespondencesHandler(
         foreach (var correspondence in correspondences)
         {
             logger.LogInformation("Correspondence {correspondenceId} initialized", correspondence.Id);
-            var dialogJob = backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
+            var dialogJob = backgroundJobClient.Schedule(() => CreateDialogportenDialog(correspondence), DateTimeOffset.UtcNow.AddMinutes(2));
+            //backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
             if (correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Initialized ||
                 correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.ReadyForPublish)
             {

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -223,8 +223,8 @@ public class InitializeCorrespondencesHandler(
         foreach (var correspondence in correspondences)
         {
             logger.LogInformation("Correspondence {correspondenceId} initialized", correspondence.Id);
-            var dialogJob = backgroundJobClient.Schedule(() => CreateDialogportenDialog(correspondence), DateTimeOffset.UtcNow.AddMinutes(2));
-            //backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
+            var dialogJob = backgroundJobClient.Schedule(() => CreateDialogportenDialog(correspondence), DateTimeOffset.UtcNow.AddMinutes(2)); //simulate slow dialog creation
+            //var dialogJob = backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
             if (correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Initialized ||
                 correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.ReadyForPublish)
             {
@@ -235,7 +235,7 @@ public class InitializeCorrespondencesHandler(
                     //Adds a 1 minute delay for malware scan to finish if not running locally
                     publishTime = correspondence.RequestedPublishTime.UtcDateTime.AddSeconds(-30) < DateTimeOffset.UtcNow ? DateTimeOffset.UtcNow.AddMinutes(1) : correspondence.RequestedPublishTime.UtcDateTime;
                 }
-                backgroundJobClient.ContinueJobWith<IBackgroundJobClient>(dialogJob, (BackgroundJobClient) => backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), publishTime));
+                backgroundJobClient.ContinueJobWith(dialogJob, () => backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), publishTime), JobContinuationOptions.OnAnyFinishedState);
             }
             var isReserved = correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Reserved;
             var notificationDetails = new List<InitializedCorrespondencesNotifications>();
@@ -450,6 +450,19 @@ public class InitializeCorrespondencesHandler(
     {
         var dialogId = await dialogportenService.CreateCorrespondenceDialog(correspondence.Id);
         await correspondenceRepository.AddExternalReference(correspondence.Id, ReferenceType.DialogportenDialogId, dialogId);
+    }
+
+    public void SchedulePublish(Guid correspondenceId, DateTimeOffset publishTime, CancellationToken cancellationToken)
+    {
+        if (publishTime <= DateTimeOffset.UtcNow)
+        {
+            
+            backgroundJobClient.Enqueue<PublishCorrespondenceHandler>((handler) => handler.Process(correspondenceId, null, cancellationToken));
+        }
+        else
+        {
+            backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondenceId, null, cancellationToken), publishTime);
+        }
     }
 
     internal class NotificationContent

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -223,8 +223,7 @@ public class InitializeCorrespondencesHandler(
         foreach (var correspondence in correspondences)
         {
             logger.LogInformation("Correspondence {correspondenceId} initialized", correspondence.Id);
-            var dialogJob = backgroundJobClient.Schedule(() => CreateDialogportenDialog(correspondence), DateTimeOffset.UtcNow.AddMinutes(2)); //simulate slow dialog creation
-            //var dialogJob = backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
+            var dialogJob = backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
             if (correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Initialized ||
                 correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.ReadyForPublish)
             {

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -35,6 +35,7 @@ public class PublishCorrespondenceHandler(
         {
             return AuthorizationErrors.CouldNotFindPartyUuid;
         }
+        bool hasDialogportenDialog = correspondence.ExternalReferences.Any(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId);
         var errorMessage = "";
         if (correspondence == null)
         {
@@ -69,7 +70,7 @@ public class PublishCorrespondenceHandler(
         {
             errorMessage = $"Correspondence {correspondenceId} not visible yet";
         }
-        else if (!correspondence.ExternalReferences.Any(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId))
+        else if (!hasDialogportenDialog)
         {
             errorMessage = $"Dialogporten dialog not created for correspondence {correspondenceId}";
         }
@@ -102,7 +103,10 @@ public class PublishCorrespondenceHandler(
                 {
                     backgroundJobClient.Enqueue<CancelNotificationHandler>(handler => handler.Process(null, correspondenceId, null, cancellationToken));
                 }
-                backgroundJobClient.Enqueue<IDialogportenService>(dialogportenService => dialogportenService.PurgeCorrespondenceDialog(correspondenceId));
+                if (hasDialogportenDialog)
+                {
+                    backgroundJobClient.Enqueue<IDialogportenService>(dialogportenService => dialogportenService.PurgeCorrespondenceDialog(correspondenceId));
+                }
             }
             else
             {

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -71,7 +71,7 @@ public class PublishCorrespondenceHandler(
         }
         else if (!correspondence.ExternalReferences.Any(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId))
         {
-            errorMessage = $"Dialogporten dialog not yet created for correspondence {correspondenceId}";
+            errorMessage = $"Dialogporten dialog not created for correspondence {correspondenceId}";
         }
         else if (correspondence.IgnoreReservation != true && correspondence.GetRecipientUrn().IsSocialSecurityNumber())
         {

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -69,6 +69,10 @@ public class PublishCorrespondenceHandler(
         {
             errorMessage = $"Correspondence {correspondenceId} not visible yet";
         }
+        else if (!correspondence.ExternalReferences.Any(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId))
+        {
+            errorMessage = $"Dialogporten dialog not yet created for correspondence {correspondenceId}";
+        }
         else if (correspondence.IgnoreReservation != true && correspondence.GetRecipientUrn().IsSocialSecurityNumber())
         {
             var isReserved = await contactReservationRegistryService.IsPersonReserved(correspondence.GetRecipientUrn().WithoutPrefix());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For the correspondences to appear in Arbeidsflate they must also have been created in Dialogporten. This PR makes PublishCorrespondence always run after CreateDialog has finished as opposed to the two jobs running at the same time. This was done by creating a backgroundjob that is triggered when the createDialog job has finished. This backgroundjob schedules a job to publish the correspondence at the given publishtime. This PR also adds a validation in PublishCorrespondence that checks if the correspondence has a externalreference of type DialogportenDialogId. If it doesn't the publish fails without trying to purge the dialog because the dialog was never created.

## Related Issue(s)
- #759 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for correspondence processing by providing clear, specific error notifications when required dialog references are missing.
  - Adjusted the scheduling of background jobs to ensure timely execution of dialog creation.

- **New Features**
  - Introduced a new method for scheduling the publishing of correspondence based on the specified publish time.

- **Tests**
  - Added a new test to verify failure scenarios when the DialogPorten external reference is missing during correspondence publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->