### PR TITLE
Set tls version to 1.2

### DIFF
--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -134,9 +134,6 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
         targetPort: 2525
         external: true
         transport: 'Auto'
-        tls: {
-          minTlsVersion: '1.2'
-        }
       }
       secrets: [
         {

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -134,6 +134,9 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
         targetPort: 2525
         external: true
         transport: 'Auto'
+        tls: {
+          minTlsVersion: '1.2'
+        }
       }
       secrets: [
         {

--- a/.azure/modules/storageAccount/create.bicep
+++ b/.azure/modules/storageAccount/create.bicep
@@ -12,6 +12,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   }
   properties: {
     accessTier: 'Cool'
+    minimumTlsVersion: 'TLS1_2'
   }
 }
 


### PR DESCRIPTION
## Description
We need to update tls version to 1.2 during deploy.

## Related Issue(s)
- #779 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced security by ensuring that secure connections use at least TLS 1.2 for improved compliance and protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->