### PR TITLE
Fix scope in xmldoc

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
@@ -25,7 +25,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// </summary>
     /// <remarks>
     /// Scopes: <br/>
-    /// - altinn:correspondence.send <br/>
+    /// - altinn:correspondence.write <br/>
     /// Only required if the attachment is to be shared, otherwise this is done as part of the Initialize Correspondence operation
     /// </remarks>
     /// <returns></returns>
@@ -56,7 +56,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// </summary>
     /// <remarks>
     /// Scopes: <br/>
-    /// - altinn:correspondence.send <br/>
+    /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <returns></returns>
     [HttpPost]
@@ -101,7 +101,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// </summary>
     /// <remarks>
     /// Scopes: <br/>
-    /// - altinn:correspondence.send <br/>
+    /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <returns>AttachmentOverviewExt</returns>
     [HttpGet]
@@ -131,7 +131,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// </summary>
     /// <remarks>
     /// Scopes: <br/>
-    /// - altinn:correspondence.send <br/>
+    /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <returns></returns>
     [HttpGet]
@@ -162,7 +162,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// </summary>
     /// <remarks>
     /// Scopes: <br/>
-    /// - altinn:correspondence.send <br/>
+    /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <returns></returns>
     [HttpDelete]
@@ -192,7 +192,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// </summary>
     /// <remarks>
     /// Scopes: <br/>
-    /// - altinn:correspondence.send <br/>
+    /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <returns></returns>
     [HttpGet]

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -37,7 +37,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </summary>
         /// <remarks>
         /// Scopes: <br />
-        /// - altinn:correspondence.send <br />
+        /// - altinn:correspondence.write <br />
         /// Requires uploads of specified attachments if any before it can be Published
         /// </remarks>
         [HttpPost]
@@ -72,7 +72,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// </summary>
         /// <remarks>
         /// Scopes: <br />
-        /// - altinn:correspondence.send
+        /// - altinn:correspondence.write
         /// </remarks>
         /// <returns>
         /// CorrespondenceIds
@@ -115,7 +115,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <remarks>
         ///  Scopes: <br />
         ///  - altinn:correspondence.read <br />
-        ///  - altinn:correspondence.send <br />
+        ///  - altinn:correspondence.write <br />
         /// Mostly for use by recipients and occasional status checks
         /// </remarks>
         /// <returns></returns>
@@ -151,7 +151,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <remarks>
         ///  Scopes: <br />
         ///  - altinn:correspondence.read <br />
-        ///  - altinn:correspondence.send <br />
+        ///  - altinn:correspondence.write <br />
         /// Meant for Senders that want a complete overview of the status and history of the Correspondence, but also available for Receivers
         /// </remarks>
         /// <returns>Detailed information about the correspondence with current status and status history</returns>
@@ -221,7 +221,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <remarks>
         /// Scopes: <br />
         /// - altinn:correspondence.read <br />
-        /// - altinn:correspondence.send <br />
+        /// - altinn:correspondence.write <br />
         /// Meant for Receivers, but also available for Senders to track Correspondences
         /// </remarks>
         /// <returns>A list of Correspondence ids</returns>
@@ -370,7 +370,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <remarks>
         /// Scopes: <br />
         /// - altinn:correspondence.read <br />
-        /// - altinn:correspondence.send <br /> (Can only purge before the correspondence is published)
+        /// - altinn:correspondence.write <br /> (Can only purge before the correspondence is published)
         /// </remarks>
         /// <returns>Ok</returns>
         [HttpDelete]


### PR DESCRIPTION
## Description
Fix documentation: altinn:correspondence.send is wrong, should use altinn:correspondence.write

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Revised API documentation to reflect updated authorization scope descriptions for attachment and correspondence operations, ensuring consistent access requirements across various features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->