### PR TITLE
Allow altinntoken authentication for content endpoint

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -191,7 +191,7 @@ namespace Altinn.Correspondence.API.Controllers
         [HttpGet]
         [Route("{correspondenceId}/content")]
         [Produces("text/plain")]
-        [Authorize(AuthenticationSchemes = AuthorizationConstants.DialogportenScheme)]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient, AuthenticationSchemes = AuthorizationConstants.AltinnTokenOrDialogportenScheme)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
         [ApiExplorerSettings(IgnoreApi = true)]
         public async Task<ActionResult> GetCorrespondenceContent(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The /content endpoint currently only works for arbeidsflate using dialogtokens. It should also support authentication with Altinn tokens. This PR adds support for authenticating using altinn token for the /content endpoint. This was done by changing the authorizationScheme for the endpoint from DialogportenScheme to AltinnTokenOrDialogportenScheme.

## Related Issue(s)
- #804 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced access control for correspondence content retrieval. The system now supports multiple authentication methods, ensuring authorized users with appropriate roles can access their content securely and with greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->