### PR TITLE
Remove archive as a GUI action in dialogporten

### DIFF
--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/UpdateCorrespondenceStatusHelper.cs
@@ -89,10 +89,6 @@ public class UpdateCorrespondenceStatusHelper(
         {
             _backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondenceConfirmed));
         }
-        else if (status == CorrespondenceStatus.Archived)
-        {
-            _backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondenceArchived));
-        }
         return;
     }
 

--- a/src/Altinn.Correspondence.Core/Services/Enums/DialogportenTextType.cs
+++ b/src/Altinn.Correspondence.Core/Services/Enums/DialogportenTextType.cs
@@ -7,7 +7,6 @@
         DownloadStarted,
         CorrespondencePublished,
         CorrespondenceConfirmed,
-        CorrespondenceArchived,
         CorrespondencePurged
     }
 }

--- a/src/Altinn.Correspondence.Core/Services/Mappers/DialogportenText.cs
+++ b/src/Altinn.Correspondence.Core/Services/Mappers/DialogportenText.cs
@@ -7,7 +7,6 @@
         DownloadStarted,
         CorrespondencePublished,
         CorrespondenceConfirmed,
-        CorrespondenceArchived,
         CorrespondencePurged
     }
 
@@ -35,7 +34,6 @@
             DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {name}", tokens),
             DialogportenTextType.CorrespondencePublished => "Melding publisert.",
             DialogportenTextType.CorrespondenceConfirmed => "Melding bekreftet.",
-            DialogportenTextType.CorrespondenceArchived => "Melding arkivert.",
             DialogportenTextType.CorrespondencePurged => "Melding slettet.",
         };
         private static string GetNNText(DialogportenTextType type, params string[] tokens) => type switch
@@ -45,7 +43,6 @@
             DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {name}", tokens),
             DialogportenTextType.CorrespondencePublished => "Melding publisert.",
             DialogportenTextType.CorrespondenceConfirmed => "Melding bekreftet.",
-            DialogportenTextType.CorrespondenceArchived => "Melding arkivert.",
             DialogportenTextType.CorrespondencePurged => "Melding slettet.",
         };
         private static string GetENText(DialogportenTextType type, params string[] tokens) => type switch
@@ -55,7 +52,6 @@
             DialogportenTextType.DownloadStarted => string.Format("Started downloading attachment {name}", tokens),
             DialogportenTextType.CorrespondencePublished => "Message published.",
             DialogportenTextType.CorrespondenceConfirmed => "Message confirmed.",
-            DialogportenTextType.CorrespondenceArchived => "Message archived.",
             DialogportenTextType.CorrespondencePurged => "Message deleted.",
         };
     }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -144,18 +144,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     {
                         new Endpoint()
                         {
-                            HttpMethod = "POST",
-                            Url = $"{baseUrl.TrimEnd('/')}/correspondence/api/v1/correspondence/{correspondence.Id}/archive"
-                        }
-                    }
-                },
-                new ApiAction()
-                {
-                    Action = "write",
-                    Endpoints = new List<Endpoint>()
-                    {
-                        new Endpoint()
-                        {
                             HttpMethod = "DELETE",
                             Url = $"{baseUrl.TrimEnd('/')}/correspondence/api/v1/correspondence/{correspondence.Id}/purge"
                         }
@@ -227,35 +215,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     Priority = "Primary"
                 });
             }
-
-            guiActions.Add(new GuiAction()
-            {
-                Title = new List<Title>()
-                {
-                    new Title()
-                    {
-                        LanguageCode = "nb",
-                        MediaType = "text/plain",
-                        Value = "Arkiver"
-                    },
-                    new Title()
-                    {
-                        LanguageCode = "nn",
-                        MediaType = "text/plain",
-                        Value = "Arkiver"
-                    },
-                    new Title()
-                    {
-                        LanguageCode = "en",
-                        MediaType = "text/plain",
-                        Value = "Archive"
-                    },
-                },
-                Action = "read",
-                Url = $"{baseUrl.TrimEnd('/')}/correspondence/api/v1/correspondence/{correspondence.Id}/archive",
-                HttpMethod = "POST",
-                Priority = "Secondary"
-            });
 
             guiActions.Add(new GuiAction()
             {

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
@@ -21,7 +21,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {0}", tokens),
             DialogportenTextType.CorrespondencePublished => "Melding publisert.",
             DialogportenTextType.CorrespondenceConfirmed => "Melding bekreftet.",
-            DialogportenTextType.CorrespondenceArchived => "Melding arkivert.",
             DialogportenTextType.CorrespondencePurged => "Melding slettet.",
             _ => throw new ArgumentException("Invalid text type")
         };
@@ -33,7 +32,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {0}", tokens),
             DialogportenTextType.CorrespondencePublished => "Melding publisert.",
             DialogportenTextType.CorrespondenceConfirmed => "Melding bekreftet.",
-            DialogportenTextType.CorrespondenceArchived => "Melding arkivert.",
             DialogportenTextType.CorrespondencePurged => "Melding slettet.",
             _ => throw new ArgumentException("Invalid text type")
         };
@@ -45,7 +43,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             DialogportenTextType.DownloadStarted => string.Format("Started downloading attachment {0}", tokens),
             DialogportenTextType.CorrespondencePublished => "Message published.",
             DialogportenTextType.CorrespondenceConfirmed => "Message confirmed.",
-            DialogportenTextType.CorrespondenceArchived => "Message archived.",
             DialogportenTextType.CorrespondencePurged => "Message deleted.",
             _ => throw new ArgumentException("Invalid text type")
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We no longer need the archived status now that we have moved to arbeidsflate. This PR removes the archive status as a GUI action in dialogporten.

## Related Issue(s)
- #532 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed support for archiving correspondence across the application.
	- Updated text displays and actions, so archived items are no longer represented.
	- Simplified status reporting to focus on active and confirmed correspondence only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->