### PR TITLE
Fix showing of correct party in LegacyHistory

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/Base/LegacyTestBase.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/Base/LegacyTestBase.cs
@@ -13,6 +13,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy.Base
         public readonly HttpClient _senderClient;
         public readonly string _partyIdClaim = "urn:altinn:partyid";
         public readonly int _digdirPartyId = 50952483;
+        public readonly int _delegatedUserPartyid = 100;
 
         public LegacyTestBase(CustomWebApplicationFactory factory)
         {
@@ -27,6 +28,13 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy.Base
             _legacyClient = _factory.CreateClientWithAddedClaims(
                 ("scope", AuthorizationConstants.LegacyScope),
                 (_partyIdClaim, _digdirPartyId.ToString()));
+        }
+
+        public HttpClient CreateLegacyTestClient(int legacyPartyId)
+        {
+            return _factory.CreateClientWithAddedClaims(
+                ("scope", AuthorizationConstants.LegacyScope),
+                (_partyIdClaim, legacyPartyId.ToString()));
         }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyRetrievalTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyRetrievalTests.cs
@@ -17,11 +17,8 @@ using Altinn.Correspondence.Tests.Fixtures;
 namespace Altinn.Correspondence.Tests.TestingController.Legacy
 {
     [Collection(nameof(CustomWebApplicationTestsCollection))]
-    public class LegacyRetrievalTests : LegacyTestBase
+    public class LegacyRetrievalTests(CustomWebApplicationFactory factory) : LegacyTestBase(factory)
     {
-        public LegacyRetrievalTests(CustomWebApplicationFactory factory) : base(factory)
-        {
-        }
         [Fact]
         public async Task LegacyGetCorrespondenceOverview_WithValidRequest_ReturnsOk()
         {

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -94,9 +94,17 @@ public class LegacyGetCorrespondenceHistoryHandler(
         List<CorrespondenceStatus> statusBySender =
         [
             CorrespondenceStatus.Published,
-        ];
-        var partyId = statusBySender.Contains(status.Status) ? senderParty.PartyId : recipientParty.PartyId;
-        var party = await altinnRegisterService.LookUpPartyByPartyId(partyId, cancellationToken);
+        ];        
+        
+        var party = (Party?)null;
+        if (statusBySender.Contains(status.Status))
+        {
+            party = senderParty;
+        }
+        else
+        {
+            party = await altinnRegisterService.LookUpPartyByPartyUuid(status.PartyUuid, cancellationToken);
+        }        
 
         return new LegacyGetCorrespondenceHistoryResponse
         {
@@ -105,8 +113,8 @@ public class LegacyGetCorrespondenceHistoryHandler(
             StatusText = $"[Correspondence] {status.StatusText}",
             User = new LegacyUser
             {
-                PartyId = party?.PartyId,
-                NationalIdentityNumber = party?.SSN,
+                PartyId = party?.PartyId,                
+                NationalIdentityNumber = party?.SSN,                
                 Name = party?.Name
             }
         };

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -113,8 +113,8 @@ public class LegacyGetCorrespondenceHistoryHandler(
             StatusText = $"[Correspondence] {status.StatusText}",
             User = new LegacyUser
             {
-                PartyId = party?.PartyId,                
-                NationalIdentityNumber = party?.SSN,                
+                PartyId = party?.PartyId,
+                NationalIdentityNumber = party?.SSN,
                 Name = party?.Name
             }
         };

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -53,7 +53,7 @@ public static class CorrespondenceStatusExtensions
     {
         List<CorrespondenceStatus> validStatuses =
         [
-            CorrespondenceStatus.Published, CorrespondenceStatus.Fetched, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
+            CorrespondenceStatus.Published, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
             CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved, CorrespondenceStatus.PurgedByAltinn, CorrespondenceStatus.PurgedByRecipient
         ];
         return validStatuses.Contains(correspondenceStatus);

--- a/src/Altinn.Correspondence.Core/Services/IAltinnRegisterService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IAltinnRegisterService.cs
@@ -7,6 +7,7 @@ public interface IAltinnRegisterService
     Task<int?> LookUpPartyId(string identificationId, CancellationToken cancellationToken);
     Task<string?> LookUpName(string identificationId, CancellationToken cancellationToken);
     Task<Party?> LookUpPartyByPartyId(int partyId, CancellationToken cancellationToken);
+    Task<Party?> LookUpPartyByPartyUuid(Guid partyUuid, CancellationToken cancellationToken);    
     Task<Party?> LookUpPartyById(string identificationId, CancellationToken cancellationToken);
     Task<List<Party>?> LookUpPartiesByIds(List<string> identificationIds, CancellationToken cancellationToken);
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
@@ -10,6 +10,8 @@ public class AltinnRegisterDevService : IAltinnRegisterService
     private const string _identificationIDPattern = @"^(?:\d{11}|\d{9}|0192:\d{9})$";
     private static readonly Regex IdentificationIDRegex = new(_identificationIDPattern);
     private readonly int _digdirPartyId = 50952483;
+    private readonly Guid _digdirPartyUuid = new Guid("36E2BCC6-D5B8-4399-AA90-4AFEB2D1A0BF");
+
     public Task<int?> LookUpPartyId(string identificationId, CancellationToken cancellationToken)
     {
         if (IdentificationIDRegex.IsMatch(identificationId))
@@ -40,7 +42,7 @@ public class AltinnRegisterDevService : IAltinnRegisterService
                 PartyTypeName = PartyType.Organization,
                 UnitType = "Virksomhet",
                 Name = "Digitaliseringsdirektoratet",
-                PartyUuid = Guid.NewGuid(),
+                PartyUuid = _digdirPartyUuid,
             });
         }
         return Task.FromResult<Party?>(null);
@@ -57,10 +59,27 @@ public class AltinnRegisterDevService : IAltinnRegisterService
             PartyTypeName = PartyType.Organization,
             UnitType = "Virksomhet",
             Name = "Digitaliseringsdirektoratet",
-            PartyUuid = Guid.NewGuid(),
+            PartyUuid = _digdirPartyUuid,
         };
         return Task.FromResult<Party?>(party);
     }
+
+    public Task<Party?> LookUpPartyByPartyUuid(Guid partyUuid, CancellationToken cancellationToken)
+    {
+        var party = new Party
+        {
+            PartyId = _digdirPartyId,
+            OrgNumber = "991825827",
+            SSN = "",
+            Resources = new List<string>(),
+            PartyTypeName = PartyType.Organization,
+            UnitType = "Virksomhet",
+            Name = "Digitaliseringsdirektoratet",
+            PartyUuid = _digdirPartyUuid,
+        }; 
+        return Task.FromResult<Party?>(party);
+    }
+
     public Task<List<Party>?> LookUpPartiesByIds(List<string> identificationIds, CancellationToken cancellationToken)
     {
         var parties = new List<Party>();

--- a/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Register/AltinnRegisterDevService.cs
@@ -11,6 +11,8 @@ public class AltinnRegisterDevService : IAltinnRegisterService
     private static readonly Regex IdentificationIDRegex = new(_identificationIDPattern);
     private readonly int _digdirPartyId = 50952483;
     private readonly Guid _digdirPartyUuid = new Guid("36E2BCC6-D5B8-4399-AA90-4AFEB2D1A0BF");
+    private readonly int _delegatedUserPartyid = 100;
+    private readonly Guid _delegatedUserPartyUuid = new Guid("358C48B4-74A7-461F-A86F-48801DEEC920");
 
     public Task<int?> LookUpPartyId(string identificationId, CancellationToken cancellationToken)
     {
@@ -50,33 +52,70 @@ public class AltinnRegisterDevService : IAltinnRegisterService
 
     public Task<Party?> LookUpPartyByPartyId(int partyId, CancellationToken cancellationToken)
     {
-        var party = new Party
+        var party = (Party?)null;
+        if (partyId == _digdirPartyId)
         {
-            PartyId = _digdirPartyId,
-            OrgNumber = "991825827",
-            SSN = "",
-            Resources = new List<string>(),
-            PartyTypeName = PartyType.Organization,
-            UnitType = "Virksomhet",
-            Name = "Digitaliseringsdirektoratet",
-            PartyUuid = _digdirPartyUuid,
-        };
+            party = new Party
+            {
+                PartyId = _digdirPartyId,
+                OrgNumber = "991825827",
+                SSN = "",
+                Resources = new List<string>(),
+                PartyTypeName = PartyType.Organization,
+                UnitType = "Virksomhet",
+                Name = "Digitaliseringsdirektoratet",
+                PartyUuid = _digdirPartyUuid,
+            };
+        }
+        else if (partyId == _delegatedUserPartyid)
+        {
+            party = new Party
+            {
+                PartyId = _delegatedUserPartyid,
+                OrgNumber = "",
+                SSN = "01018045678",
+                Resources = new List<string>(),
+                PartyTypeName = PartyType.Person,
+                UnitType = "Person",
+                Name = "Delegert test bruker",
+                PartyUuid = _delegatedUserPartyUuid,
+            };
+        }
         return Task.FromResult<Party?>(party);
     }
 
     public Task<Party?> LookUpPartyByPartyUuid(Guid partyUuid, CancellationToken cancellationToken)
     {
-        var party = new Party
+        var party = (Party?)null;
+        if (partyUuid == _digdirPartyUuid)
         {
-            PartyId = _digdirPartyId,
-            OrgNumber = "991825827",
-            SSN = "",
-            Resources = new List<string>(),
-            PartyTypeName = PartyType.Organization,
-            UnitType = "Virksomhet",
-            Name = "Digitaliseringsdirektoratet",
-            PartyUuid = _digdirPartyUuid,
-        }; 
+            party = new Party
+            {
+                PartyId = _digdirPartyId,
+                OrgNumber = "991825827",
+                SSN = "",
+                Resources = new List<string>(),
+                PartyTypeName = PartyType.Organization,
+                UnitType = "Virksomhet",
+                Name = "Digitaliseringsdirektoratet",
+                PartyUuid = _digdirPartyUuid,
+            };
+        }
+        else if (partyUuid == _delegatedUserPartyUuid)
+        {
+            party = new Party
+            {
+                PartyId = _delegatedUserPartyid,
+                OrgNumber = "",
+                SSN = "01018045678",
+                Resources = new List<string>(),
+                PartyTypeName = PartyType.Person,
+                UnitType = "Person",
+                Name = "Delegert test bruker",
+                PartyUuid = _delegatedUserPartyUuid,
+            };
+        }
+
         return Task.FromResult<Party?>(party);
     }
 


### PR DESCRIPTION
Fixed GetCorrespondenceHistory returning the party that performed the call as the party responsible for all "recipient" actions.
- Also added a unit test to verify this.
- Removed a redundant call to register to Get Party for Sender.
- Added new method to Get Party from Register based on PartyUuid. - Not tested manually, but is near-identical to existing method.
- Removed "Fetched" status from being returned in LegacyHistory, as this is not used in Altinn 2.

## Related Issue(s)
- #835 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
