### PR TITLE
Fix information activity after purge

### DIFF
--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
@@ -16,7 +16,7 @@ public class PurgeCorrespondenceHelper
     private readonly ICorrespondenceStatusRepository _correspondenceStatusRepository;
     private readonly IAttachmentStatusRepository _attachmentStatusRepository;
     private readonly IBackgroundJobClient _backgroundJobClient;
-    IDialogportenService _dialogportenService;
+    private readonly IDialogportenService _dialogportenService;
     public PurgeCorrespondenceHelper(IAttachmentRepository attachmentRepository, IStorageRepository storageRepository, IAttachmentStatusRepository attachmentStatusRepository, ICorrespondenceRepository correspondenceRepository, ICorrespondenceStatusRepository correspondenceStatusRepository, IDialogportenService dialogportenService, IBackgroundJobClient backgroundJobClient)
     {
         _attachmentRepository = attachmentRepository;
@@ -116,11 +116,11 @@ public class PurgeCorrespondenceHelper
     {
         if (isSender)
         {
-            _backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Sender, DialogportenTextType.CorrespondencePurged, "avsender"));
+            _dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Sender, DialogportenTextType.CorrespondencePurged, "avsender");
         }
         else
         {
-            _backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondencePurged, "mottaker"));
+            _dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondencePurged, "mottaker");
         }
     }
 


### PR DESCRIPTION
## Description
It is not possible to set status on a dialog after it has been purged. Therefore the information activity reports must be performed synchronously.

This is the cause of our Slack spams.

## Related Issue(s)
- #848

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined correspondence activity processing by eliminating intermediary steps to directly update notifications.
  - Improved internal handling of activity reporting to ensure more consistent and reliable performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->