### PR TITLE
Pass only ID as job parameter, not entire entity

### DIFF
--- a/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
@@ -3,7 +3,7 @@ using Hangfire;
 
 namespace Altinn.Correspondence.Application.Helpers
 {
-    public class HangfireScheduleHelper(IBackgroundJobClient backgroundJobClient, PublishCorrespondenceHandler publishCorrespondenceHandler)
+    public class HangfireScheduleHelper(IBackgroundJobClient backgroundJobClient)
     {
 
         public void SchedulePublish(Guid correspondenceId, DateTimeOffset publishTime, CancellationToken cancellationToken)

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -227,7 +227,7 @@ public class InitializeCorrespondencesHandler(
         foreach (var correspondence in correspondences)
         {
             logger.LogInformation("Correspondence {correspondenceId} initialized", correspondence.Id);
-            var dialogJob = backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence));
+            var dialogJob = backgroundJobClient.Enqueue(() => CreateDialogportenDialog(correspondence.Id));
             if (correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Initialized ||
                 correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.ReadyForPublish ||
                 correspondence.GetHighestStatus()?.Status == CorrespondenceStatus.Published)
@@ -458,6 +458,11 @@ public class InitializeCorrespondencesHandler(
     {
         var dialogId = await dialogportenService.CreateCorrespondenceDialog(correspondence.Id);
         await correspondenceRepository.AddExternalReference(correspondence.Id, ReferenceType.DialogportenDialogId, dialogId);
+    }
+    public async Task CreateDialogportenDialog(Guid correspondenceId)
+    {
+        var dialogId = await dialogportenService.CreateCorrespondenceDialog(correspondenceId);
+        await correspondenceRepository.AddExternalReference(correspondenceId, ReferenceType.DialogportenDialogId, dialogId);
     }
 
     public void SchedulePublish(Guid correspondenceId, DateTimeOffset publishTime, CancellationToken cancellationToken)

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -454,6 +454,7 @@ public class InitializeCorrespondencesHandler(
     }
 
     // Must be public to be run by Hangfire
+    [Obsolete("Use the CreateDialogportenDialog(Guid correspondenceId) overload instead to reduce database storage. Delete this method after the new method has been dpeloyed.")]
     public async Task CreateDialogportenDialog(CorrespondenceEntity correspondence)
     {
         var dialogId = await dialogportenService.CreateCorrespondenceDialog(correspondence.Id);

--- a/src/Altinn.Correspondence.Integrations/Slack/SlackExceptionNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Integrations/Slack/SlackExceptionNotificationHandler.cs
@@ -115,7 +115,7 @@ public class SlackExceptionNotificationHandler(
                 $"*Type:* {exception.GetType().Name}\n" +
                 $"*Message:* {exception.Message}\n" +
                 $"*Stacktrace:* \n{exception.StackTrace}\n" + 
-                $"*InnerStacktrace:* \n{exception.InnerException.StackTrace}";
+                $"*InnerStacktrace:* \n{exception.InnerException?.StackTrace}";
     }
     
 


### PR DESCRIPTION
## Description
Better to pass just the correspondenceId, especially when that is the only one passed. Takes up much more space in our database too.

## Related Issue(s)
- #843 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the scheduling component by removing an unnecessary dependency.
  - Simplified the dialog creation process by updating method parameters to work with unique identifiers only.

- **Bug Fixes**
  - Improved error notification formatting to handle missing details more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->