### PR TITLE
Remove "Mark as Read" from Dialogporten

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -224,35 +224,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     {
                         LanguageCode = "nb",
                         MediaType = "text/plain",
-                        Value = "Marker som lest"
-                    },
-                    new Title()
-                    {
-                        LanguageCode = "nn",
-                        MediaType = "text/plain",
-                        Value = "Mark som lest"
-                    },
-                    new Title()
-                    {
-                        LanguageCode = "en",
-                        MediaType = "text/plain",
-                        Value = "Mark as read"
-                    },
-                },
-                Action = "read",
-                Url = $"{baseUrl.TrimEnd('/')}/correspondence/api/v1/correspondence/{correspondence.Id}/markasread",
-                HttpMethod = "POST",
-                Priority = "Tertiary"
-            });
-
-            guiActions.Add(new GuiAction()
-            {
-                Title = new List<Title>()
-                {
-                    new Title()
-                    {
-                        LanguageCode = "nb",
-                        MediaType = "text/plain",
                         Value = "Slett"
                     },
                     new Title()


### PR DESCRIPTION
## Description
Remove "Mark as Read" from Dialogporten

## Related Issue(s)
- #773 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Removed the "mark as read" option from the correspondence interface, so users will no longer see this action when managing their messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->