### PR TITLE
Use appropriate isolation level for transaction

### DIFF
--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -65,6 +65,7 @@ public class MalwareScanResultHandler(
             backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.Sender, CancellationToken.None));
             logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
             await CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, partyUuid, cancellationToken);
+            transaction.Complete();
             return Task.CompletedTask;
         }
         else

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -1,18 +1,16 @@
 ﻿using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Application.MalwareScanResult.Models;
-using Altinn.Correspondence.Application.PublishCorrespondence;
 using Altinn.Correspondence.Common.Caching;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
-using Azure.Core;
 using Hangfire;
 using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Security.Claims;
-using static Altinn.Correspondence.Application.InitializeCorrespondences.InitializeCorrespondencesHandler;
+using System.Transactions;
 
 namespace Altinn.Correspondence.Application;
 
@@ -47,25 +45,27 @@ public class MalwareScanResultHandler(
         {
             return AuthorizationErrors.CouldNotFindPartyUuid;
         }
-        
+
         if (data.ScanResultType.Equals("No threats found", StringComparison.InvariantCultureIgnoreCase))
         {
-            return await TransactionWithRetriesPolicy.Execute<Task>(async (cancellationToken) =>
+            using var transaction = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions()
             {
-                await attachmentStatusRepository.AddAttachmentStatus(new AttachmentStatusEntity()
-                {
-                    Attachment = attachment,
-                    AttachmentId = attachmentId,
-                    Status = AttachmentStatus.Published,
-                    StatusChanged = DateTimeOffset.UtcNow,
-                    StatusText = AttachmentStatus.Published.ToString(),
-                    PartyUuid = partyUuid
-                }, cancellationToken);
-                backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.Sender, CancellationToken.None));
-                logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
-                await CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, partyUuid, cancellationToken);
-                return Task.CompletedTask;
-            }, logger, cancellationToken);
+                IsolationLevel = IsolationLevel.ReadUncommitted,
+                Timeout = TimeSpan.FromSeconds(30)
+            }, TransactionScopeAsyncFlowOption.Enabled);
+            await attachmentStatusRepository.AddAttachmentStatus(new AttachmentStatusEntity()
+            {
+                Attachment = attachment,
+                AttachmentId = attachmentId,
+                Status = AttachmentStatus.Published,
+                StatusChanged = DateTimeOffset.UtcNow,
+                StatusText = AttachmentStatus.Published.ToString(),
+                PartyUuid = partyUuid
+            }, cancellationToken);
+            backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.Sender, CancellationToken.None));
+            logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
+            await CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, partyUuid, cancellationToken);
+            return Task.CompletedTask;
         }
         else
         {
@@ -95,6 +95,7 @@ public class MalwareScanResultHandler(
         var correspondences = await correspondenceRepository.GetNonPublishedCorrespondencesByAttachmentId(attachment.Id, cancellationToken);
         if (correspondences.Count == 0)
         {
+            logger.LogInformation("No correspondences associated with that attachmentId was found");
             return;
         }
 


### PR DESCRIPTION
## Description
In this case we should use read uncomitted transaction as we want to the uncommitted changes to be part of the evaluation in CheckCorrespondenceStatusesAfterDeleteAndPublish

## Related Issue(s)
- #869 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Optimized transaction handling to enhance reliability and ensure operations execute promptly.
  - Strengthened monitoring with improved logging to offer clearer tracking of correspondence statuses.
  - Enhanced process management minimizes delays for a smoother and more responsive system.
  - Collectively, these refinements contribute to a more dependable and consistent experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->