### PR TITLE
Change purged to DialogDeleted

### DIFF
--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
@@ -114,14 +114,9 @@ public class PurgeCorrespondenceHelper
     }
     public async Task ReportActivityToDialogporten(bool isSender, Guid correspondenceId)
     {
-        if (isSender)
-        {
-            await _dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Sender, DialogportenTextType.CorrespondencePurged, "avsender");
-        }
-        else
-        {
-            await _dialogportenService.CreateInformationActivity(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondencePurged, "mottaker");
-        }
+        var actorType = isSender ? DialogportenActorType.Sender : DialogportenActorType.Recipient;
+        var actorName = isSender ? "avsender" : "mottaker";
+        await _dialogportenService.CreateDialogDeletedActivity(correspondenceId, actorType, actorName);
     }
 
     public void CancelNotification(Guid correspondenceId, CancellationToken cancellationToken)

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
@@ -116,7 +116,7 @@ public class PurgeCorrespondenceHelper
     {
         var actorType = isSender ? DialogportenActorType.Sender : DialogportenActorType.Recipient;
         var actorName = isSender ? "avsender" : "mottaker";
-        await _dialogportenService.CreateDialogDeletedActivity(correspondenceId, actorType, actorName);
+        await _dialogportenService.CreateCorrespondencePurgedActivity(correspondenceId, actorType, actorName);
     }
 
     public void CancelNotification(Guid correspondenceId, CancellationToken cancellationToken)

--- a/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
@@ -10,5 +10,5 @@ public interface IDialogportenService
     Task CreateOpenedActivity(Guid correspondenceId, DialogportenActorType actorType);
     Task PurgeCorrespondenceDialog(Guid correspondenceId);
     Task SoftDeleteDialog(string dialogId);
-    Task CreateDialogDeletedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName);
+    Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName);
 }

--- a/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
@@ -10,4 +10,5 @@ public interface IDialogportenService
     Task CreateOpenedActivity(Guid correspondenceId, DialogportenActorType actorType);
     Task PurgeCorrespondenceDialog(Guid correspondenceId);
     Task SoftDeleteDialog(string dialogId);
+    Task CreateDialogDeletedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName);
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
@@ -34,5 +34,10 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
         {
             return Task.CompletedTask;
         }
+
+        public Task CreateDialogDeletedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
@@ -35,7 +35,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
             return Task.CompletedTask;
         }
 
-        public Task CreateDialogDeletedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName)
+        public Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName)
         {
             return Task.CompletedTask;
         }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -170,9 +170,9 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         }
     }
 
-    public async Task CreateDialogDeletedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName)
+    public async Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName)
     {
-        logger.LogInformation("CreateDialogDeletedActivity by {actorType} for correspondence {correspondenceId}",
+        logger.LogInformation("CreateCorrespondencePurgedActivity by {actorType}: for correspondence {correspondenceId}",
             Enum.GetName(typeof(DialogportenActorType), actorType),
             correspondenceId
         );

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -170,6 +170,39 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         }
     }
 
+    public async Task CreateDialogDeletedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName)
+    {
+        logger.LogInformation("CreateDialogDeletedActivity by {actorType} for correspondence {correspondenceId}",
+            Enum.GetName(typeof(DialogportenActorType), actorType),
+            correspondenceId
+        );
+        var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+        var correspondence = await _correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, cancellationToken);
+        if (correspondence is null)
+        {
+            logger.LogError("Correspondence with id {correspondenceId} not found", correspondenceId);
+            throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
+        }
+        var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
+        if (dialogId is null)
+        {
+            throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
+        }
+
+        var createDialogActivityRequest = CreateDialogActivityRequestMapper.CreateDialogActivityRequest(correspondence, actorType, null, Models.ActivityType.DialogDeleted);
+        if (actorType != DialogportenActorType.ServiceOwner)
+        {
+            createDialogActivityRequest.PerformedBy.ActorName = actorName;
+            createDialogActivityRequest.PerformedBy.ActorId = null;
+        }
+        var response = await _httpClient.PostAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}/activities", createDialogActivityRequest, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+        }
+    }
+
     public async Task<CreateDialogRequest> GetDialog(string dialogId)
     {
         var cancellationTokenSource = new CancellationTokenSource();

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
@@ -21,7 +21,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {0}", tokens),
             DialogportenTextType.CorrespondencePublished => "Melding publisert.",
             DialogportenTextType.CorrespondenceConfirmed => "Melding bekreftet.",
-            DialogportenTextType.CorrespondencePurged => "Melding slettet.",
             _ => throw new ArgumentException("Invalid text type")
         };
 
@@ -32,7 +31,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             DialogportenTextType.DownloadStarted => string.Format("Startet nedlastning av vedlegg {0}", tokens),
             DialogportenTextType.CorrespondencePublished => "Melding publisert.",
             DialogportenTextType.CorrespondenceConfirmed => "Melding bekreftet.",
-            DialogportenTextType.CorrespondencePurged => "Melding slettet.",
             _ => throw new ArgumentException("Invalid text type")
         };
 
@@ -43,7 +41,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             DialogportenTextType.DownloadStarted => string.Format("Started downloading attachment {0}", tokens),
             DialogportenTextType.CorrespondencePublished => "Message published.",
             DialogportenTextType.CorrespondenceConfirmed => "Message confirmed.",
-            DialogportenTextType.CorrespondencePurged => "Message deleted.",
             _ => throw new ArgumentException("Invalid text type")
         };
     }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Models/CreateDialogActivityRequest.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Models/CreateDialogActivityRequest.cs
@@ -31,7 +31,8 @@ public enum ActivityType
     TransmissionOpened,
     PaymentMade,
     SignatureProvided,
-    DialogOpened
+    DialogOpened,
+    DialogDeleted
 }
 
 public class CreateDialogActivityRequest


### PR DESCRIPTION
## Description
This change makes purge use ActivityType instead of InformationAcitivy. Added DialogDeleted as a new ActivityType.

## Related Issue(s)
- #757 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to record dialog deletion events, enhancing overall activity tracking and reporting.
	- Added a new method for creating dialog deleted activities, expanding the capabilities of the service.

- **Refactor**
	- Streamlined the logic for reporting dialog activities, reducing redundancy and improving reliability.
	- Removed specific handling for a text type, simplifying the response logic in related methods.
	- Expanded the activity type enumeration to include dialog deletion events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->