### PR TITLE
Use same transaction pattern

### DIFF
--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -61,10 +61,10 @@ public class MalwareScanResultHandler(
                 StatusChanged = DateTimeOffset.UtcNow,
                 StatusText = AttachmentStatus.Published.ToString(),
                 PartyUuid = partyUuid
-            }, cancellationToken);
+            }, cancellationToken);            
             backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.Sender, CancellationToken.None));
             logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
-            await CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, partyUuid, cancellationToken);
+            backgroundJobClient.Enqueue(() => CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, partyUuid, CancellationToken.None));
             transaction.Complete();
             return Task.CompletedTask;
         }

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -48,40 +48,40 @@ public class MalwareScanResultHandler(
 
         if (data.ScanResultType.Equals("No threats found", StringComparison.InvariantCultureIgnoreCase))
         {
-            using var transaction = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions()
+            return await TransactionWithRetriesPolicy.Execute<Task>(async (cancellationToken) =>
             {
-                IsolationLevel = IsolationLevel.ReadUncommitted,
-                Timeout = TimeSpan.FromSeconds(30)
-            }, TransactionScopeAsyncFlowOption.Enabled);
-            await attachmentStatusRepository.AddAttachmentStatus(new AttachmentStatusEntity()
-            {
-                Attachment = attachment,
-                AttachmentId = attachmentId,
-                Status = AttachmentStatus.Published,
-                StatusChanged = DateTimeOffset.UtcNow,
-                StatusText = AttachmentStatus.Published.ToString(),
-                PartyUuid = partyUuid
-            }, cancellationToken);            
-            backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.Sender, CancellationToken.None));
-            logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
-            backgroundJobClient.Enqueue(() => CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, partyUuid, CancellationToken.None));
-            transaction.Complete();
-            return Task.CompletedTask;
+                await attachmentStatusRepository.AddAttachmentStatus(new AttachmentStatusEntity()
+                {
+                    Attachment = attachment,
+                    AttachmentId = attachmentId,
+                    Status = AttachmentStatus.Published,
+                    StatusChanged = DateTimeOffset.UtcNow,
+                    StatusText = AttachmentStatus.Published.ToString(),
+                    PartyUuid = partyUuid
+                }, cancellationToken);
+                backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.AttachmentPublished, attachment.ResourceId, attachmentIdFromBlobUri, "Attachment Published", attachment.Sender, CancellationToken.None));
+                logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
+                backgroundJobClient.Enqueue(() => CheckCorrespondenceStatusesAfterDeleteAndPublish(attachmentId, partyUuid, CancellationToken.None));
+                return Task.CompletedTask;
+            }, logger, cancellationToken);
         }
         else
         {
-            await attachmentStatusRepository.AddAttachmentStatus(new AttachmentStatusEntity()
+            return await TransactionWithRetriesPolicy.Execute<Task>(async (cancellationToken) =>
             {
-                Attachment = attachment,
-                AttachmentId = attachmentId,
-                Status = AttachmentStatus.Failed,
-                StatusChanged = DateTimeOffset.UtcNow,
-                StatusText = $"Malware scan failed: {data.ScanResultType}: {data.ScanResultDetails}",
-                PartyUuid = partyUuid
-            }, cancellationToken);
-            backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.AttachmentUploadFailed, attachment.ResourceId, attachmentIdFromBlobUri, "Malware scan", attachment.Sender, CancellationToken.None));
-            logger.LogWarning("Malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
-            return Task.CompletedTask;
+                await attachmentStatusRepository.AddAttachmentStatus(new AttachmentStatusEntity()
+                {
+                    Attachment = attachment,
+                    AttachmentId = attachmentId,
+                    Status = AttachmentStatus.Failed,
+                    StatusChanged = DateTimeOffset.UtcNow,
+                    StatusText = $"Malware scan failed: {data.ScanResultType}: {data.ScanResultDetails}",
+                    PartyUuid = partyUuid
+                }, cancellationToken);
+                backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.AttachmentUploadFailed, attachment.ResourceId, attachmentIdFromBlobUri, "Malware scan", attachment.Sender, CancellationToken.None));
+                logger.LogWarning("Malicious result for {fileTransferId} with result type {scanResultType}", attachmentId, data.ScanResultType);
+                return Task.CompletedTask;
+            }, logger, cancellationToken);
         }
     }
 


### PR DESCRIPTION
## Description
Re-use same transaction pattern. Tried to use ReadUncommitted to resolve our transient issue. Instead opt for backgroundjob scheduled in same transaction which should also solve it.

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
