### PR TITLE
Fix timing issue

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -683,7 +683,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
-
             hangfireBackgroundJobClient.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == "SchedulePublishAtPublishTime"),
                 It.IsAny<IState>()), Times.Once);

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -683,8 +683,9 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
+
             hangfireBackgroundJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Method.Name == "Process"),
+                It.Is<Job>(job => job.Method.Name == "SchedulePublishAtPublishTime"),
                 It.IsAny<IState>()), Times.Once);
         }
 
@@ -717,7 +718,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Assert
             Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
             hangfireBackgroundJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Method.Name == "Process"),
+                It.Is<Job>(job => job.Method.Name == "SchedulePublishAtPublishTime"),
                 It.IsAny<IState>()), Times.Once);
         }
     }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -684,7 +684,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Assert
             Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
             hangfireBackgroundJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Method.Name == "SchedulePublish"),
+                It.Is<Job>(job => job.Method.Name == "Process"),
                 It.IsAny<IState>()), Times.Once);
         }
 
@@ -717,7 +717,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Assert
             Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
             hangfireBackgroundJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Method.Name == "SchedulePublish"),
+                It.Is<Job>(job => job.Method.Name == "Process"),
                 It.IsAny<IState>()), Times.Once);
         }
     }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
@@ -8,6 +8,8 @@ using Altinn.Correspondence.Tests.TestingController.Correspondence.Base;
 using System.Net;
 using System.Net.Http.Json;
 using Altinn.Correspondence.Tests.Fixtures;
+using Altinn.Correspondence.Application.PublishCorrespondence;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 {
@@ -67,7 +69,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var initializeCorrespondenceResponse2 = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payloadResourceB);
             Assert.True(initializeCorrespondenceResponse2.IsSuccessStatusCode, await initializeCorrespondenceResponse2.Content.ReadAsStringAsync());
 
-            int status = (int)CorrespondenceStatusExt.Published;
+            int status = (int)CorrespondenceStatusExt.ReadyForPublish;
             var correspondenceList = await _senderClient.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resourceA}&status={status}&role={"recipientandsender"}");
             Assert.Equal(payloadResourceA.Recipients.Count, correspondenceList?.Ids.Count);
         }
@@ -193,6 +195,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Act
             var responsePublished = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payloadPublished);
             Assert.True(responsePublished.IsSuccessStatusCode, await responsePublished.Content.ReadAsStringAsync());
+            var responsePublishedContent = await responsePublished.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
             var responseReadyForPublish = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payloadReadyForPublish);
             Assert.True(responseReadyForPublish.IsSuccessStatusCode, await responseReadyForPublish.Content.ReadAsStringAsync());
             var correspondenceList = await recipientClient.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resource}&role={"recipient"}");

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
@@ -69,7 +69,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var initializeCorrespondenceResponse2 = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payloadResourceB);
             Assert.True(initializeCorrespondenceResponse2.IsSuccessStatusCode, await initializeCorrespondenceResponse2.Content.ReadAsStringAsync());
 
-            int status = (int)CorrespondenceStatusExt.ReadyForPublish;
+            int status = (int)CorrespondenceStatusExt.Published;
             var correspondenceList = await _senderClient.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resourceA}&status={status}&role={"recipientandsender"}");
             Assert.Equal(payloadResourceA.Recipients.Count, correspondenceList?.Ids.Count);
         }

--- a/Test/Altinn.Correspondence.Tests/TestingFeature/MalwareScanResultControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/MalwareScanResultControllerTests.cs
@@ -63,7 +63,7 @@ public class MalwareScanResultControllerTests : IClassFixture<CustomWebApplicati
         Assert.Equal("{\"validationResponse\":\"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\"}", rs);
     }
 
-    private string GetMalwareScanResultJson(string filePath, string fileId)
+    public static string GetMalwareScanResultJson(string filePath, string fileId)
     {
         string jsonBody = File.ReadAllText(filePath);
         var randomizedEtagId = Guid.NewGuid().ToString();

--- a/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
@@ -1,26 +1,40 @@
 ﻿using Altinn.Correspondence.Application.PublishCorrespondence;
 using Altinn.Correspondence.Common.Caching;
 using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Repositories;
 using Hangfire;
 using Microsoft.Extensions.Logging;
 
 namespace Altinn.Correspondence.Application.Helpers
 {
-    public class HangfireScheduleHelper(IBackgroundJobClient backgroundJobClient, IHybridCacheWrapper hybridCacheWrapper, ILogger<HangfireScheduleHelper> logger)
+    public class HangfireScheduleHelper(IBackgroundJobClient backgroundJobClient,
+                                        IHybridCacheWrapper hybridCacheWrapper,
+                                        ICorrespondenceRepository correspondenceRepository,
+                                        ILogger<HangfireScheduleHelper> logger)
     {
 
-        public async Task PrepareForPublish(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
+        public async Task SchedulePublishAfterDialogCreated(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
         {
             var dialogJobId = await hybridCacheWrapper.GetAsync<string?>("dialogJobId_" + correspondence.Id);
             if (dialogJobId is null)
             {
                 logger.LogError("Could not find dialogJobId for correspondence {correspondenceId} in cache. More than 24 hours delayed?", correspondence.Id);
-                backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), GetActualPublishTime(correspondence.RequestedPublishTime));
+                await SchedulePublishAtPublishTime(correspondence.Id, cancellationToken);
             }
             else
             {
-                backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), GetActualPublishTime(correspondence.RequestedPublishTime));
+                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(dialogJobId, (helper) => helper.SchedulePublishAtPublishTime(correspondence.Id, cancellationToken));
             }
+        }
+
+        public async Task SchedulePublishAtPublishTime(Guid correspondenceId, CancellationToken cancellationToken)
+        {
+            var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, false, cancellationToken);
+            if (correspondence is null)
+            {
+                throw new Exception($"Correspondence with id {correspondenceId} not found when scheduling publish");
+            }
+            backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), GetActualPublishTime(correspondence.RequestedPublishTime));
         }
 
         private static DateTimeOffset GetActualPublishTime(DateTimeOffset publishTime) => publishTime < DateTimeOffset.UtcNow ? DateTimeOffset.UtcNow : publishTime; // If in past, do now

--- a/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
@@ -1,15 +1,33 @@
 ﻿using Altinn.Correspondence.Application.PublishCorrespondence;
+using Altinn.Correspondence.Common.Caching;
+using Altinn.Correspondence.Core.Models.Entities;
 using Hangfire;
+using Microsoft.Extensions.Logging;
 
 namespace Altinn.Correspondence.Application.Helpers
 {
-    public class HangfireScheduleHelper(IBackgroundJobClient backgroundJobClient)
+    public class HangfireScheduleHelper(IBackgroundJobClient backgroundJobClient, IHybridCacheWrapper hybridCacheWrapper, ILogger<HangfireScheduleHelper> logger)
     {
 
         public void SchedulePublish(Guid correspondenceId, DateTimeOffset publishTime, CancellationToken cancellationToken)
         {
-            var actualPublishTime = publishTime < DateTimeOffset.UtcNow ? DateTimeOffset.UtcNow : publishTime; // If in past, do now
-            backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondenceId, null, cancellationToken), actualPublishTime);
+            backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondenceId, null, cancellationToken), GetActualPublishTime(publishTime));
         }
+
+        public async Task PrepareForPublish(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
+        {
+            var dialogJobId = await hybridCacheWrapper.GetAsync<string?>("dialogJobId_" + correspondence.Id);
+            if (dialogJobId is null)
+            {
+                logger.LogError("Could not find dialogJobId for correspondence {correspondenceId} in cache. More than 24 hours delayed?", correspondence.Id);
+                backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), GetActualPublishTime(publishTime));
+            }
+            else
+            {
+                backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), GetActualPublishTime(publishTime));
+            }
+        }
+
+        private static DateTimeOffset GetActualPublishTime(DateTimeOffset publishTime) => publishTime < DateTimeOffset.UtcNow ? DateTimeOffset.UtcNow : publishTime; // If in past, do now
     }
 }

--- a/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
@@ -29,7 +29,7 @@ namespace Altinn.Correspondence.Application.Helpers
 
         public async Task SchedulePublishAtPublishTime(Guid correspondenceId, CancellationToken cancellationToken)
         {
-            var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, false, cancellationToken);
+            var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, false, false, cancellationToken);
             if (correspondence is null)
             {
                 throw new Exception($"Correspondence with id {correspondenceId} not found when scheduling publish");

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -463,19 +463,5 @@ namespace Altinn.Correspondence.Application.Helpers
             }
             return await attachmentRepository.InitializeAttachment(attachment, cancellationToken);
         }
-
-        public async Task PrepareForPublish(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
-        {
-            var dialogJobId = await hybridCacheWrapper.GetAsync<string?>("dialogJobId_" + correspondence.Id);
-            if (dialogJobId is null)
-            {
-                logger.LogError("Could not find dialogJobId for correspondence {correspondenceId} in cache. More than 24 hours delayed?", correspondence.Id);
-                backgroundJobClient.Enqueue<HangfireScheduleHelper>((hangfireScheduleHelper) => hangfireScheduleHelper.SchedulePublish(correspondence.Id, correspondence.RequestedPublishTime, cancellationToken));
-            }
-            else
-            {
-                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(dialogJobId, (hangfireScheduleHelper) => hangfireScheduleHelper.SchedulePublish(correspondence.Id, correspondence.RequestedPublishTime, cancellationToken), JobContinuationOptions.OnAnyFinishedState);
-            }
-        }
     }
 }

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -299,6 +299,16 @@ namespace Altinn.Correspondence.Application.Helpers
                     PartyUuid = partyUuid
                 });
             }
+            if (hostEnvironment.IsDevelopment() && currentStatus == CorrespondenceStatus.ReadyForPublish)
+            {
+                statuses.Add(new CorrespondenceStatusEntity
+                {
+                    Status = CorrespondenceStatus.Published,
+                    StatusChanged = DateTimeOffset.UtcNow,
+                    StatusText = currentStatus.ToString(),
+                    PartyUuid = partyUuid
+                });
+            }
             string sender = request.Correspondence.Sender;
             if (sender.StartsWith("0192:"))
             {
@@ -410,8 +420,6 @@ namespace Altinn.Correspondence.Application.Helpers
             var status = correspondence.Statuses.LastOrDefault()?.Status ?? CorrespondenceStatus.Initialized;
             if (correspondence.Content.Attachments.All(c => c.Attachment?.Statuses != null && c.Attachment.StatusHasBeen(AttachmentStatus.Published)))
             {
-                if (hostEnvironment.IsDevelopment() && correspondence.RequestedPublishTime < DateTimeOffset.UtcNow) status = CorrespondenceStatus.Published; // used to test on published correspondences in development
-                else 
                 status = CorrespondenceStatus.ReadyForPublish;
             }
             return status;

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -299,7 +299,9 @@ namespace Altinn.Correspondence.Application.Helpers
                     PartyUuid = partyUuid
                 });
             }
-            if (hostEnvironment.IsDevelopment() && currentStatus == CorrespondenceStatus.ReadyForPublish)
+            if (hostEnvironment.IsDevelopment()
+                && currentStatus == CorrespondenceStatus.ReadyForPublish
+                && request.Correspondence.RequestedPublishTime < DateTime.UtcNow)
             {
                 statuses.Add(new CorrespondenceStatusEntity
                 {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -1,7 +1,6 @@
 using Altinn.Correspondence.Application.InitializeCorrespondences;
 using Altinn.Correspondence.Application.Settings;
 using Altinn.Correspondence.Application.UploadAttachment;
-using Altinn.Correspondence.Common.Caching;
 using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
@@ -9,7 +8,6 @@ using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Models.Notifications;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Notifications.Core.Helpers;
-using Hangfire;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -23,9 +21,6 @@ namespace Altinn.Correspondence.Application.Helpers
         IHostEnvironment hostEnvironment,
         AttachmentHelper attachmentHelper,
         MobileNumberHelper mobileNumberHelper,
-        IBackgroundJobClient backgroundJobClient,
-        ICorrespondenceStatusRepository correspondenceStatusRepository,
-        IHybridCacheWrapper hybridCacheWrapper,
         ILogger<InitializeCorrespondenceHelper> logger)
     {
         private static readonly Regex emailRegex = new Regex(@"((""[^\\""]+"")|(([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))");

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -305,7 +305,7 @@ namespace Altinn.Correspondence.Application.Helpers
                 {
                     Status = CorrespondenceStatus.Published,
                     StatusChanged = DateTimeOffset.UtcNow,
-                    StatusText = currentStatus.ToString(),
+                    StatusText = CorrespondenceStatus.Published.ToString(),
                     PartyUuid = partyUuid
                 });
             }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -317,7 +317,6 @@ public class InitializeCorrespondencesHandler(
                 Notifications = notificationDetails
             });
         }
-        // Her må vi schedule publish et sted
         return new InitializeCorrespondencesResponse()
         {
             Correspondences = initializedCorrespondences,

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -234,7 +234,7 @@ public class InitializeCorrespondencesHandler(
             {
                 if (request.Correspondence.Content.Attachments.Count == 0) 
                 {
-                    backgroundJobClient.ContinueJobWith(dialogJob, () => hangfireScheduleHelper.SchedulePublish(correspondence.Id, correspondence.RequestedPublishTime, cancellationToken), JobContinuationOptions.OnlyOnSucceededState);
+                    await hangfireScheduleHelper.PrepareForPublish(correspondence, cancellationToken);
                 }
                 else
                 {
@@ -294,7 +294,7 @@ public class InitializeCorrespondencesHandler(
                     }
                 }
             }
-            if (await correspondenceRepository.AreAllAttachmentsPublished(correspondence.Id, cancellationToken))
+            if (request.Correspondence.Content.Attachments.Count > 0 && await correspondenceRepository.AreAllAttachmentsPublished(correspondence.Id, cancellationToken))
             {
                 await correspondenceStatusRepository.AddCorrespondenceStatus(
                     new CorrespondenceStatusEntity
@@ -307,7 +307,7 @@ public class InitializeCorrespondencesHandler(
                     },
                     cancellationToken
                 );
-                await initializeCorrespondenceHelper.PrepareForPublish(correspondence, cancellationToken);
+                await hangfireScheduleHelper.PrepareForPublish(correspondence, cancellationToken);
             }
             initializedCorrespondences.Add(new InitializedCorrespondences()
             {

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -238,7 +238,7 @@ public class InitializeCorrespondencesHandler(
                 }
                 else
                 {
-                    // Will be published by MalwarescanResultHandler
+                    // Will be used to ensure publish always occurs after dialog has been successfully created
                     await hybridCacheWrapper.SetAsync("dialogJobId_" + correspondence.Id, dialogJob, new HybridCacheEntryOptions
                     {
                         Expiration = TimeSpan.FromHours(24)
@@ -307,6 +307,7 @@ public class InitializeCorrespondencesHandler(
                     },
                     cancellationToken
                 );
+                await initializeCorrespondenceHelper.PrepareForPublish(correspondence, cancellationToken);
             }
             initializedCorrespondences.Add(new InitializedCorrespondences()
             {
@@ -316,8 +317,7 @@ public class InitializeCorrespondencesHandler(
                 Notifications = notificationDetails
             });
         }
-        logger.LogInformation("Initialized {correspondenceCount} correspondences for {resourceId}", request.Recipients.Count, request.Correspondence.ResourceId);
-
+        // Her må vi schedule publish et sted
         return new InitializeCorrespondencesResponse()
         {
             Correspondences = initializedCorrespondences,

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -23,6 +23,7 @@ public class MalwareScanResultHandler(
     IBackgroundJobClient backgroundJobClient,
     IHybridCacheWrapper hybridCacheWrapper,
     InitializeCorrespondenceHelper initializeCorrespondenceHelper,
+    HangfireScheduleHelper hangfireScheduleHelper,
     ILogger<MalwareScanResultHandler> logger) : IHandler<ScanResultData, Task>
 {
     public async Task<OneOf<Task, Error>> Process(ScanResultData data, ClaimsPrincipal? user, CancellationToken cancellationToken)
@@ -114,7 +115,7 @@ public class MalwareScanResultHandler(
                     PartyUuid = partyUuid
                 }
             );
-            await initializeCorrespondenceHelper.PrepareForPublish(correspondence, cancellationToken);
+            await hangfireScheduleHelper.PrepareForPublish(correspondence, cancellationToken);
         }
         await correspondenceStatusRepository.AddCorrespondenceStatuses(list, cancellationToken);
         return;

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Application.MalwareScanResult.Models;
+using Altinn.Correspondence.Application.PublishCorrespondence;
 using Altinn.Correspondence.Common.Caching;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
@@ -7,6 +8,7 @@ using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
 using Hangfire;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Security.Claims;
@@ -22,7 +24,6 @@ public class MalwareScanResultHandler(
     UserClaimsHelper userClaimsHelper,
     IBackgroundJobClient backgroundJobClient,
     IHybridCacheWrapper hybridCacheWrapper,
-    InitializeCorrespondenceHelper initializeCorrespondenceHelper,
     HangfireScheduleHelper hangfireScheduleHelper,
     ILogger<MalwareScanResultHandler> logger) : IHandler<ScanResultData, Task>
 {

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -116,7 +116,7 @@ public class MalwareScanResultHandler(
                     PartyUuid = partyUuid
                 }
             );
-            await hangfireScheduleHelper.PrepareForPublish(correspondence, cancellationToken);
+            await hangfireScheduleHelper.SchedulePublishAfterDialogCreated(correspondence, cancellationToken);
         }
         await correspondenceStatusRepository.AddCorrespondenceStatuses(list, cancellationToken);
         return;

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -10,7 +10,6 @@ using Hangfire;
 using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Security.Claims;
-using System.Transactions;
 
 namespace Altinn.Correspondence.Application;
 
@@ -23,6 +22,7 @@ public class MalwareScanResultHandler(
     UserClaimsHelper userClaimsHelper,
     IBackgroundJobClient backgroundJobClient,
     IHybridCacheWrapper hybridCacheWrapper,
+    InitializeCorrespondenceHelper initializeCorrespondenceHelper,
     ILogger<MalwareScanResultHandler> logger) : IHandler<ScanResultData, Task>
 {
     public async Task<OneOf<Task, Error>> Process(ScanResultData data, ClaimsPrincipal? user, CancellationToken cancellationToken)
@@ -114,16 +114,7 @@ public class MalwareScanResultHandler(
                     PartyUuid = partyUuid
                 }
             );
-            var dialogJobId = await hybridCacheWrapper.GetAsync<string?>("dialogJobId_" + correspondence.Id);
-            if (dialogJobId is null)
-            {
-                logger.LogError("Could not find dialogJobId for correspondence {correspondenceId} in cache. More than 24 hours delayed?", correspondence.Id);
-                backgroundJobClient.Enqueue<HangfireScheduleHelper>((hangfireScheduleHelper) => hangfireScheduleHelper.SchedulePublish(correspondence.Id, correspondence.RequestedPublishTime, cancellationToken));
-            }
-            else
-            {
-                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(dialogJobId, (hangfireScheduleHelper) => hangfireScheduleHelper.SchedulePublish(correspondence.Id, correspondence.RequestedPublishTime, cancellationToken), JobContinuationOptions.OnAnyFinishedState);
-            }
+            await initializeCorrespondenceHelper.PrepareForPublish(correspondence, cancellationToken);
         }
         await correspondenceStatusRepository.AddCorrespondenceStatuses(list, cancellationToken);
         return;


### PR DESCRIPTION
## Description
The malware scan can occur both before correspondences are created and thus the logic to publish the correspondence did not run in those cases. We end up having to duplicate the logic for the two different cases; whether attachment is published first or correspondence is initialized first. Extended HangfireScheduleHelper to do this without duplicating.

## Related Issue(s)
- #895

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced the correspondence publication process to ensure that publication occurs only when all attachments are confirmed.
  - Introduced a method for preparing correspondences for publishing, improving background job handling and caching.
  - Added new dependencies to support enhanced functionality in correspondence management.
  - Added a new test for scheduling correspondence jobs based on malware scan results.

- **Refactor**
  - Streamlined the workflow by removing the scheduling capability, simplifying the update of correspondence publication statuses.
  - Updated method signatures to improve dependency injection and error handling in the publishing process.
  - Changed access modifier for a method to allow broader access and potential reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->