### PR TITLE
Removed Dependencies to ResourceRegister from Migration Controller

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Helpers/ServiceCollectionExtensions.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/ServiceCollectionExtensions.cs
@@ -79,16 +79,6 @@ public static class ServiceCollectionExtensions
             });
 
         altinnAuthorizationService
-            .Setup(x => x.CheckMigrationAccess(
-                It.IsAny<string>(),
-                It.IsAny<List<ResourceAccessLevel>>(),
-                It.IsAny<CancellationToken>()))
-            .Returns((string resourceId, IEnumerable<ResourceAccessLevel> levels, CancellationToken token) =>
-            {
-                return Task.FromResult(true);
-            });
-
-        altinnAuthorizationService
             .Setup(x => x.CheckUserAccessAndGetMinimumAuthLevel(
                 It.IsAny<ClaimsPrincipal>(),
                 It.IsAny<string>(),

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -10,18 +10,11 @@ namespace Altinn.Correspondence.Application.InitializeCorrespondence;
 
 public class MigrateCorrespondenceHandler(
     InitializeCorrespondenceHelper initializeCorrespondenceHelper,
-    IAltinnAuthorizationService altinnAuthorizationService,
     ICorrespondenceRepository correspondenceRepository,
     ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRequest, MigrateCorrespondenceResponse>
 {
     public async Task<OneOf<MigrateCorrespondenceResponse, Error>> Process(MigrateCorrespondenceRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
-        var hasAccess = await altinnAuthorizationService.CheckMigrationAccess(request.CorrespondenceEntity.ResourceId, [ResourceAccessLevel.Write], cancellationToken);
-        if (!hasAccess)
-        {
-            return AuthorizationErrors.NoAccessToResource;
-        }
-
         var contentError = MigrationValidateCorrespondenceContent(request.CorrespondenceEntity.Content);
         if (contentError != null)
         {

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondenceAttachment/MigrateInitializeAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondenceAttachment/MigrateInitializeAttachmentHandler.cs
@@ -13,16 +13,10 @@ public class MigrateInitializeAttachmentHandler(
     IAttachmentRepository attachmentRepository,
     IAltinnRegisterService altinnRegisterService,
     IAttachmentStatusRepository attachmentStatusRepository,
-    IAltinnAuthorizationService altinnAuthorizationService,
     ILogger<MigrateInitializeAttachmentHandler> logger) : IHandler<InitializeAttachmentRequest, Guid>
 {
     public async Task<OneOf<Guid, Error>> Process(InitializeAttachmentRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
-        var hasAccess = await altinnAuthorizationService.CheckMigrationAccess(request.Attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, cancellationToken);
-        if (!hasAccess)
-        {
-            return AuthorizationErrors.NoAccessToResource;
-        }
         var party = await altinnRegisterService.LookUpPartyById(request.Attachment.Sender, cancellationToken);
         if (party?.PartyUuid is not Guid partyUuid)
         {

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondenceAttachment/MigrateUploadAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondenceAttachment/MigrateUploadAttachmentHandler.cs
@@ -10,7 +10,6 @@ using System.Security.Claims;
 namespace Altinn.Correspondence.Application.UploadAttachment;
 
 public class MigrateUploadAttachmentHandler(
-    IAltinnAuthorizationService altinnAuthorizationService,
     IAltinnRegisterService altinnRegisterService,
     IAttachmentRepository attachmentRepository,
     AttachmentHelper attachmentHelper,
@@ -22,11 +21,6 @@ public class MigrateUploadAttachmentHandler(
         if (attachment == null)
         {
             return AttachmentErrors.AttachmentNotFound;
-        }
-        var hasAccess = await altinnAuthorizationService.CheckMigrationAccess(attachment.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, cancellationToken);
-        if (!hasAccess)
-        {
-            return AuthorizationErrors.NoAccessToResource;
         }
         var maxUploadSize = long.Parse(int.MaxValue.ToString());
         if (request.ContentLength > maxUploadSize || request.ContentLength == 0)

--- a/src/Altinn.Correspondence.Core/Repositories/IAltinnAuthorizationService.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IAltinnAuthorizationService.cs
@@ -11,5 +11,4 @@ public interface IAltinnAuthorizationService
     Task<bool> CheckAccessAsRecipient(ClaimsPrincipal? user, CorrespondenceEntity correspondence, CancellationToken cancellationToken = default);
     Task<bool> CheckAccessAsAny(ClaimsPrincipal? user, string resource, string party, CancellationToken cancellationToken);
     Task<int?> CheckUserAccessAndGetMinimumAuthLevel(ClaimsPrincipal? user, string ssn, string resourceId, List<ResourceAccessLevel> rights, string recipientOrgNo, CancellationToken cancellationToken = default);
-    Task<bool> CheckMigrationAccess(string resourceId, List<ResourceAccessLevel> rights, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationDevService.cs
@@ -27,11 +27,6 @@ namespace Altinn.Correspondence.Integrations.Altinn.Authorization
             return Task.FromResult(true);
         }
 
-        public Task<bool> CheckMigrationAccess(string resourceId, List<ResourceAccessLevel> rights, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult(true);
-        }
-
         public Task<int?> CheckUserAccessAndGetMinimumAuthLevel(ClaimsPrincipal? user, string ssn, string resourceId, List<ResourceAccessLevel> rights, string recipientOrgNo, CancellationToken cancellationToken = default)
         {
             return Task.FromResult((int?)3);

--- a/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
@@ -101,16 +101,6 @@ public class AltinnAuthorizationService : IAltinnAuthorizationService
         return minLevel;
     }
 
-    public async Task<bool> CheckMigrationAccess(string resourceId, List<ResourceAccessLevel> rights, CancellationToken cancellationToken = default)
-    {
-        if (_hostEnvironment.IsDevelopment())
-        {
-            return true;
-        }
-
-        return true;
-    }
-
     private async Task<bool> CheckUserAccess(ClaimsPrincipal? user, string resourceId, string party, string? correspondenceId, List<ResourceAccessLevel> rights, CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Checking access for organization {org} with resource {resourceId}", user?.GetCallerOrganizationId(), resourceId);

--- a/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
@@ -107,11 +107,6 @@ public class AltinnAuthorizationService : IAltinnAuthorizationService
         {
             return true;
         }
-        var serviceOwnerId = await _resourceRepository.GetServiceOwnerOfResource(resourceId, cancellationToken);
-        if (string.IsNullOrWhiteSpace(serviceOwnerId))
-        {
-            return false;
-        }
 
         return true;
     }


### PR DESCRIPTION
Removed dependencies to ResourceRegister for migration, so that we may begin migrating data without this dependency, as well as reducing our performance impact.

Setup in ResourceRegistry of appropriate Resources is only required once migration of correspondences is complete, and we need to set up Autorization to allow access to the migrated elements via APIs.

## Related Issue(s)
- #860 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined migration workflows for correspondence and attachments by removing redundant access validations, enabling direct processing.
  
- **Tests**
  - Cleaned up outdated test configurations by removing obsolete mock setups for migration access checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->