### PR TITLE
Added AttachmentsDownloaded status and tests

### DIFF
--- a/src/Altinn.Correspondence.API/Models/Enums/CorrespondenceStatusExt.cs
+++ b/src/Altinn.Correspondence.API/Models/Enums/CorrespondenceStatusExt.cs
@@ -62,6 +62,11 @@ namespace Altinn.Correspondence.API.Models.Enums
         /// <summary>
         /// Correspondence has failed during initialization or processing
         /// </summary>
-        Failed = 11
+        Failed = 11,
+
+        /// <summary>
+        /// Attachments have been downloaded by recipient
+        /// </summary>
+        AttachmentsDownloaded = 12
     }
 }

--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
@@ -1,10 +1,15 @@
 ﻿using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Common.Helpers;
+using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
+using Altinn.Correspondence.Integrations.Dialogporten.Models;
+using Altinn.Correspondence.Core.Models.Entities;
 using Hangfire;
 using OneOf;
 using System.Security.Claims;
+using Microsoft.Extensions.Logging;
 
 namespace Altinn.Correspondence.Application.DownloadCorrespondenceAttachment;
 
@@ -13,9 +18,11 @@ public class DownloadCorrespondenceAttachmentHandler(
     IStorageRepository storageRepository,
     IAttachmentRepository attachmentRepository,
     ICorrespondenceRepository correspondenceRepository,
-    IBackgroundJobClient backgroundJobClient) : IHandler<DownloadCorrespondenceAttachmentRequest, DownloadCorrespondenceAttachmentResponse>
+    ICorrespondenceStatusRepository correspondenceStatusRepository,
+    IAltinnRegisterService altinnRegisterService,
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<DownloadCorrespondenceAttachmentHandler> logger) : IHandler<DownloadCorrespondenceAttachmentRequest, DownloadCorrespondenceAttachmentResponse>
 {
-
     public async Task<OneOf<DownloadCorrespondenceAttachmentResponse, Error>> Process(DownloadCorrespondenceAttachmentRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         var correspondence = await correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, false, cancellationToken);
@@ -38,12 +45,40 @@ public class DownloadCorrespondenceAttachmentHandler(
         {
             return CorrespondenceErrors.CorrespondenceNotFound;
         }
-        var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, cancellationToken);
-        backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(request.CorrespondenceId, DialogportenActorType.Recipient, DialogportenTextType.DownloadStarted, attachment.DisplayName ?? attachment.FileName));
-        return new DownloadCorrespondenceAttachmentResponse()
+
+        var party = await altinnRegisterService.LookUpPartyById(user.GetCallerOrganizationId(), cancellationToken);
+        if (party?.PartyUuid is not Guid partyUuid)
         {
-            FileName = attachment.FileName,
-            Stream = attachmentStream
-        };
+            return AuthorizationErrors.CouldNotFindPartyUuid;
+        }
+
+        var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, cancellationToken);
+        
+        return await TransactionWithRetriesPolicy.Execute<DownloadCorrespondenceAttachmentResponse>(async (cancellationToken) =>
+        {
+            try
+            {
+                await correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
+                {
+                    CorrespondenceId = request.CorrespondenceId,
+                    Status = CorrespondenceStatus.AttachmentsDownloaded,
+                    StatusText = $"Attachment {attachment.Id} has been downloaded",
+                    StatusChanged = DateTimeOffset.UtcNow,
+                    PartyUuid = partyUuid
+                }, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error when adding status to correspondence");
+            }
+
+            backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(request.CorrespondenceId, DialogportenActorType.Recipient, DialogportenTextType.DownloadStarted, attachment.DisplayName ?? attachment.FileName));
+            
+            return new DownloadCorrespondenceAttachmentResponse()
+            {
+                FileName = attachment.FileName,
+                Stream = attachmentStream
+            };
+        }, logger, cancellationToken);
     }
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -33,9 +33,9 @@ public static class CorrespondenceErrors
     public static Error ArchiveBeforeConfirmed = new Error(1026, "Cannot archive or delete a correspondence which has not been confirmed when confirmation is required", HttpStatusCode.BadRequest);
     public static Error InvalidDateRange = new Error(1027, "From date cannot be after to date", HttpStatusCode.BadRequest);
     public static Error OffsetAndLimitIsNegative = new Error(1028, "Limit and offset must be greater than or equal to 0", HttpStatusCode.BadRequest);
-    public static Error AttachmentNotAvailableForRecipient = new(1029, "Attachment is not available for recipient, latest status of correspondence is not in [Published, Fetched, Read, Replied, Confirmed, Archived, Reserved]", HttpStatusCode.BadRequest);
     public static Error RecipientLookupFailed(List<string> recipients) { return new Error(1029, $"Could not find partyId for the following recipients: {string.Join(", ", recipients)}", HttpStatusCode.NotFound); }
     public static Error RecipientReserved(string recipientId) => new Error(1030, $"Recipient {recipientId} has reserved themselves from public correspondences. Can be overridden using the 'IgnoreReservation' flag.", HttpStatusCode.UnprocessableEntity);
+    public static Error AttachmentNotAvailableForRecipient = new(1031, "Attachment is not available for recipient, latest status of correspondence is not in [Published, Fetched, Read, Replied, Confirmed, Archived, Reserved, AttachmentsDownloaded]", HttpStatusCode.BadRequest);
 }
 public static class AttachmentErrors
 {

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -33,6 +33,7 @@ public static class CorrespondenceErrors
     public static Error ArchiveBeforeConfirmed = new Error(1026, "Cannot archive or delete a correspondence which has not been confirmed when confirmation is required", HttpStatusCode.BadRequest);
     public static Error InvalidDateRange = new Error(1027, "From date cannot be after to date", HttpStatusCode.BadRequest);
     public static Error OffsetAndLimitIsNegative = new Error(1028, "Limit and offset must be greater than or equal to 0", HttpStatusCode.BadRequest);
+    public static Error AttachmentNotAvailableForRecipient = new(1029, "Attachment is not available for recipient, latest status of correspondence is not in [Published, Fetched, Read, Replied, Confirmed, Archived, Reserved]", HttpStatusCode.BadRequest);
     public static Error RecipientLookupFailed(List<string> recipients) { return new Error(1029, $"Could not find partyId for the following recipients: {string.Join(", ", recipients)}", HttpStatusCode.NotFound); }
     public static Error RecipientReserved(string recipientId) => new Error(1030, $"Recipient {recipientId} has reserved themselves from public correspondences. Can be overridden using the 'IgnoreReservation' flag.", HttpStatusCode.UnprocessableEntity);
 }

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -35,7 +35,8 @@ public static class CorrespondenceStatusExtensions
         [
             CorrespondenceStatus.Initialized, CorrespondenceStatus.ReadyForPublish, CorrespondenceStatus.Failed,
             CorrespondenceStatus.Published, CorrespondenceStatus.Fetched, CorrespondenceStatus.Read, 
-            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Replied, CorrespondenceStatus.Reserved
+            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Replied, CorrespondenceStatus.Reserved,
+            CorrespondenceStatus.AttachmentsDownloaded
         ];
         return validStatuses.Contains(correspondenceStatus);
     }
@@ -45,7 +46,7 @@ public static class CorrespondenceStatusExtensions
         List<CorrespondenceStatus> validStatuses =
         [
             CorrespondenceStatus.Published, CorrespondenceStatus.Fetched, CorrespondenceStatus.Read, CorrespondenceStatus.Replied,
-            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved
+            CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived, CorrespondenceStatus.Reserved, CorrespondenceStatus.AttachmentsDownloaded
         ];
         return validStatuses.Contains(correspondenceStatus);
     }

--- a/src/Altinn.Correspondence.Core/Models/Enums/CorrespondenceStatus.cs
+++ b/src/Altinn.Correspondence.Core/Models/Enums/CorrespondenceStatus.cs
@@ -63,6 +63,11 @@ namespace Altinn.Correspondence.Core.Models.Enums
         /// <summary>
         /// Message has Failed
         /// </summary>
-        Failed = 11
+        Failed = 11,
+
+        /// <summary>
+        /// Attachments have been downloaded by recipient
+        /// </summary>
+        AttachmentsDownloaded = 12
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We store the attachment downloaded status in our system in the similar way to status we send to DP.
Two tests has been added as well.

## Related Issue(s)
- #883 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The attachment download process now provides clear status updates, indicating when attachments have been downloaded.
  - The sequence of status notifications has been refined so that users see events in the correct order.
  - Enhanced validations now deliver more precise feedback if an attachment isn’t available—ensuring a smoother user experience.
  - Introduced a new status, "AttachmentsDownloaded," to improve tracking of correspondence states.

- **Bug Fixes**
  - Fixed issues related to status history not reflecting the correct chronological order of events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->