### PR TITLE
Fixed issue where duplicate ReadyForPublish was generated locally

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -144,6 +144,7 @@ module reddis '../modules/redis/main.bicep' = {
     namePrefix: namePrefix
     keyVaultName: sourceKeyVaultName
     prodLikeEnvironment: prodLikeEnvironment
+    environment: environment
   }
 }
 

--- a/.azure/modules/redis/main.bicep
+++ b/.azure/modules/redis/main.bicep
@@ -3,6 +3,7 @@ param location string
 param namePrefix string
 @secure()
 param keyVaultName string
+param environment string
 param prodLikeEnvironment bool
 
 resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
@@ -21,7 +22,7 @@ resource redis 'Microsoft.Cache/redis@2024-11-01' = {
   name: '${namePrefix}-redis'
   properties: {
     sku: {
-      capacity: prodLikeEnvironment ? 2 : 0
+      capacity: prodLikeEnvironment ? 2 : environment == 'staging' ? 1 : 0
       family: 'C'
       name: 'Standard'
     }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -287,17 +287,6 @@ public class InitializeCorrespondencesHandler(
             }
             if (request.Correspondence.Content.Attachments.Count > 0 && await correspondenceRepository.AreAllAttachmentsPublished(correspondence.Id, cancellationToken))
             {
-                await correspondenceStatusRepository.AddCorrespondenceStatus(
-                    new CorrespondenceStatusEntity
-                    {
-                        CorrespondenceId = correspondence.Id,
-                        Status = CorrespondenceStatus.ReadyForPublish,
-                        StatusChanged = DateTime.UtcNow,
-                        StatusText = CorrespondenceStatus.ReadyForPublish.ToString(),
-                        PartyUuid = partyUuid
-                    },
-                    cancellationToken
-                );
                 await hangfireScheduleHelper.SchedulePublishAfterDialogCreated(correspondence, cancellationToken);
             }
             initializedCorrespondences.Add(new InitializedCorrespondences()


### PR DESCRIPTION
## Description
Fixed issue where duplicate ReadyForPublish was generated locally. This happened because we add the Correspondence with status set to GetHighestStatus() and when running locally, this is added synchronously during the call. 
Also fix staging deploy by setting Redis scale to C1 in Redis as we cannot downgrade past that. Some times we let consumers use staging for performance tests and hence we need to be able to scale it up to prodlike.

## Related Issue(s)
- #910

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Revised the correspondence status update process so that submissions meeting specific criteria are no longer automatically marked as ready for publishing. This ensures a more consistent and clear display of status information in the system.

- **New Features**
  - Introduced a new parameter `environment` for more granular control over Redis cache capacity based on the deployment environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->