### PR TITLE
Add instance id property to log event in addition to log context so t…

### DIFF
--- a/src/Altinn.Correspondence.API/Helpers/PropertyPropagationEnricher.cs
+++ b/src/Altinn.Correspondence.API/Helpers/PropertyPropagationEnricher.cs
@@ -24,13 +24,13 @@ public class PropertyPropagationEnricher : ILogEventEnricher
                 if (logEvent.Properties.TryGetValue(propertyToken.PropertyName, out var value))
                 {
                     LogContext.PushProperty(propertyToken.PropertyName, value);
+                    if (propertyToken.PropertyName == "correspondenceId") // For queries that work across multiple API's.
+                    {
+                        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("instanceId", value));
+                        LogContext.PushProperty("instanceId", value);
+                    }
                 }
             }
-        }
-
-        if (logEvent.Properties.TryGetValue("correspondenceId", out var correspondenceIdValue))
-        {
-            LogContext.PushProperty("instanceId", correspondenceIdValue);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The instanceId wouldn't always be added to properties for logs that have a correspondenceId property. This PR adds instanceId to the log event in addition to the log context, this fixes that issue.

Before:
![image](https://github.com/user-attachments/assets/c2cd8579-097a-4b7c-8d50-8736baac166d)

After adding instanceId to the log event:
![image](https://github.com/user-attachments/assets/7a67c464-b629-42d6-a8d4-68f4d2d24add)

## Related Issue(s)
- #866 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced internal log enrichment to conditionally propagate an additional identifier only when necessary. This improvement minimizes redundant log entries and ensures more accurate logging data without impacting any public interfaces or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->