### PR TITLE
859 kun første event skal sendes til dp

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -18,9 +18,9 @@ using Hangfire.States;
 using Microsoft.AspNetCore.Http;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Persistence;
-using System.Text.Json.Nodes;
 using System.Text;
 using Altinn.Correspondence.Tests.TestingFeature;
+using Altinn.Correspondence.Core.Models.Enums;
 
 namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 {
@@ -801,6 +801,85 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 
             // Tear down
             memoryStream.Dispose();
+        }
+
+        [Fact]
+        public async Task InitializeCorrespondence_WithMultipleAttachments_CreatesIdempotencyKeys()
+        {
+            // Arrange
+            var attachmentId1 = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions);
+            var attachmentId2 = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions);
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithExistingAttachments([attachmentId1, attachmentId2])
+                .WithConfirmationNeeded(true)
+                .WithDueDateTime(DateTimeOffset.UtcNow.AddDays(7))
+                .Build();
+
+            // Act
+            var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+            Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
+            var responseObject = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+            Assert.NotNull(responseObject);
+            Assert.NotEmpty(responseObject.Correspondences);
+            Assert.Single(responseObject.Correspondences); // Single correspondence for one recipient
+
+            // Assert
+            using var scope = _factory.Services.CreateScope();
+            var idempotencyKeyRepository = scope.ServiceProvider.GetRequiredService<IIdempotencyKeyRepository>();
+            var correspondenceRepository = scope.ServiceProvider.GetRequiredService<ICorrespondenceRepository>();
+            
+            var correspondence = responseObject.Correspondences.First();
+            
+            // First verify the correspondence exists in the database
+            var dbCorrespondence = await correspondenceRepository.GetCorrespondenceById(
+                correspondence.CorrespondenceId, 
+                true, 
+                true, 
+                false, 
+                CancellationToken.None);
+            Assert.NotNull(dbCorrespondence);
+
+            // Check opened/fetched key
+            var openedKey = await idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
+                correspondence.CorrespondenceId, 
+                null, 
+                StatusAction.Read, 
+                CancellationToken.None);
+            Assert.NotNull(openedKey);
+            Assert.Equal(correspondence.CorrespondenceId, openedKey.CorrespondenceId);
+            Assert.Equal(StatusAction.Read, openedKey.StatusAction);
+
+            // Check confirm key
+            var confirmKey = await idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
+                correspondence.CorrespondenceId, 
+                null, 
+                StatusAction.Confirm, 
+                CancellationToken.None);
+            Assert.NotNull(confirmKey);
+            Assert.Equal(correspondence.CorrespondenceId, confirmKey.CorrespondenceId);
+            Assert.Equal(StatusAction.Confirm, confirmKey.StatusAction);
+
+            // Check download keys for each attachment
+            var downloadKey1 = await idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
+                correspondence.CorrespondenceId, 
+                attachmentId1, 
+                StatusAction.DownloadStarted, 
+                CancellationToken.None);
+            Assert.NotNull(downloadKey1);
+            Assert.Equal(correspondence.CorrespondenceId, downloadKey1.CorrespondenceId);
+            Assert.Equal(attachmentId1, downloadKey1.AttachmentId);
+            Assert.Equal(StatusAction.DownloadStarted, downloadKey1.StatusAction);
+
+            var downloadKey2 = await idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
+                correspondence.CorrespondenceId, 
+                attachmentId2, 
+                StatusAction.DownloadStarted, 
+                CancellationToken.None);
+            Assert.NotNull(downloadKey2);
+            Assert.Equal(correspondence.CorrespondenceId, downloadKey2.CorrespondenceId);
+            Assert.Equal(attachmentId2, downloadKey2.AttachmentId);
+            Assert.Equal(StatusAction.DownloadStarted, downloadKey2.StatusAction);
         }
     }
 }

--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
@@ -1,15 +1,14 @@
 ﻿using Altinn.Correspondence.Application.Helpers;
-using Altinn.Correspondence.Common.Helpers;
+using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
-using Altinn.Correspondence.Integrations.Dialogporten.Models;
-using Altinn.Correspondence.Core.Models.Entities;
 using Hangfire;
+using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Security.Claims;
-using Microsoft.Extensions.Logging;
 
 namespace Altinn.Correspondence.Application.DownloadCorrespondenceAttachment;
 
@@ -18,21 +17,31 @@ public class DownloadCorrespondenceAttachmentHandler(
     IStorageRepository storageRepository,
     IAttachmentRepository attachmentRepository,
     ICorrespondenceRepository correspondenceRepository,
-    ICorrespondenceStatusRepository correspondenceStatusRepository,
-    IAltinnRegisterService altinnRegisterService,
     IBackgroundJobClient backgroundJobClient,
+    IIdempotencyKeyRepository idempotencyKeyRepository,
+    IAltinnRegisterService altinnRegisterService,
+    ICorrespondenceStatusRepository correspondenceStatusRepository,
     ILogger<DownloadCorrespondenceAttachmentHandler> logger) : IHandler<DownloadCorrespondenceAttachmentRequest, DownloadCorrespondenceAttachmentResponse>
 {
+    private readonly ICorrespondenceRepository _correspondenceRepository = correspondenceRepository;
+    private readonly IBackgroundJobClient _backgroundJobClient = backgroundJobClient;
+    private readonly ILogger<DownloadCorrespondenceAttachmentHandler> _logger = logger;
+    private readonly IIdempotencyKeyRepository _idempotencyKeyRepository = idempotencyKeyRepository;
+
     public async Task<OneOf<DownloadCorrespondenceAttachmentResponse, Error>> Process(DownloadCorrespondenceAttachmentRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
-        var correspondence = await correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, false, cancellationToken);
+        _logger.LogInformation("Processing download for correspondence {correspondenceId} and attachment {attachmentId}", request.CorrespondenceId, request.AttachmentId);
+
+        var correspondence = await _correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, true, false, cancellationToken);
         if (correspondence is null)
         {
+            _logger.LogError("Correspondence with id {correspondenceId} not found", request.CorrespondenceId);
             return CorrespondenceErrors.CorrespondenceNotFound;
         }
         var attachment = await attachmentRepository.GetAttachmentByCorrespondenceIdAndAttachmentId(request.CorrespondenceId, request.AttachmentId, cancellationToken);
         if (attachment is null)
         {
+            _logger.LogError("Attachment with id {attachmentId} not found in correspondence {correspondenceId}", request.AttachmentId, request.CorrespondenceId);
             return AttachmentErrors.AttachmentNotFound;
         }
         var hasAccess = await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken);
@@ -46,6 +55,34 @@ public class DownloadCorrespondenceAttachmentHandler(
             return CorrespondenceErrors.CorrespondenceNotFound;
         }
 
+        // Check for existing idempotency key
+        var existingKey = await _idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
+            request.CorrespondenceId, 
+            request.AttachmentId, 
+            StatusAction.DownloadStarted, 
+            cancellationToken);
+
+        string activityId;
+        if (existingKey != null)
+        {
+            // Use existing activity ID
+            activityId = existingKey.Id.ToString();
+        }
+        else
+        {
+            // Create new idempotency key
+            activityId = Guid.NewGuid().ToString();
+            var idempotencyKey = new IdempotencyKeyEntity
+            {
+                Id = Guid.Parse(activityId),
+                CorrespondenceId = request.CorrespondenceId,
+                AttachmentId = request.AttachmentId,
+                StatusAction = StatusAction.DownloadStarted
+            };
+            await _idempotencyKeyRepository.CreateAsync(idempotencyKey, cancellationToken);
+        }
+
+
         var party = await altinnRegisterService.LookUpPartyById(user.GetCallerOrganizationId(), cancellationToken);
         if (party?.PartyUuid is not Guid partyUuid)
         {
@@ -53,6 +90,7 @@ public class DownloadCorrespondenceAttachmentHandler(
         }
 
         var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, cancellationToken);
+        
         
         return await TransactionWithRetriesPolicy.Execute<DownloadCorrespondenceAttachmentResponse>(async (cancellationToken) =>
         {
@@ -72,8 +110,13 @@ public class DownloadCorrespondenceAttachmentHandler(
                 logger.LogError(e, "Error when adding status to correspondence");
             }
 
-            backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(request.CorrespondenceId, DialogportenActorType.Recipient, DialogportenTextType.DownloadStarted, attachment.DisplayName ?? attachment.FileName));
-            
+            _backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => 
+            dialogportenService.CreateInformationActivity(
+                request.CorrespondenceId, 
+                DialogportenActorType.ServiceOwner, 
+                DialogportenTextType.DownloadStarted,  
+                attachment.DisplayName ?? attachment.FileName,
+                request.AttachmentId.ToString()));
             return new DownloadCorrespondenceAttachmentResponse()
             {
                 FileName = attachment.FileName,

--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
@@ -59,7 +59,7 @@ public class DownloadCorrespondenceAttachmentHandler(
         var existingKey = await _idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
             request.CorrespondenceId, 
             request.AttachmentId, 
-            StatusAction.DownloadStarted, 
+            StatusAction.AttachmentDownloaded, 
             cancellationToken);
 
         string activityId;
@@ -77,7 +77,7 @@ public class DownloadCorrespondenceAttachmentHandler(
                 Id = Guid.Parse(activityId),
                 CorrespondenceId = request.CorrespondenceId,
                 AttachmentId = request.AttachmentId,
-                StatusAction = StatusAction.DownloadStarted
+                StatusAction = StatusAction.AttachmentDownloaded
             };
             await _idempotencyKeyRepository.CreateAsync(idempotencyKey, cancellationToken);
         }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -9,7 +9,6 @@ using Hangfire;
 using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Security.Claims;
-using System.Linq;
 
 namespace Altinn.Correspondence.Application.GetCorrespondenceOverview;
 

--- a/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceEntity.cs
@@ -54,8 +54,9 @@ namespace Altinn.Correspondence.Core.Models.Entities
 
         public required List<CorrespondenceStatusEntity> Statuses { get; set; }
 
-        public List <CorrespondenceForwardingEventEntity>? ForwardingEvents { get; set; }
+        public List<CorrespondenceForwardingEventEntity>? ForwardingEvents { get; set; }
 
+        public List<IdempotencyKeyEntity> IdempotencyKeys { get; set; } = [];
 
         [Required]
         public required DateTimeOffset Created { get; set; }

--- a/src/Altinn.Correspondence.Core/Models/Entities/IdempotencyKeyEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/IdempotencyKeyEntity.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Altinn.Correspondence.Core.Models.Enums;
+
+
+namespace Altinn.Correspondence.Core.Models.Entities;
+
+public class IdempotencyKeyEntity
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    public Guid CorrespondenceId { get; set; }
+
+    [ForeignKey(nameof(CorrespondenceId))]
+    public CorrespondenceEntity? Correspondence { get; set; } = null!;
+
+    public Guid? AttachmentId { get; set; }
+
+    [ForeignKey(nameof(AttachmentId))]
+    public AttachmentEntity? Attachment { get; set; }
+
+    [Required]
+    public StatusAction StatusAction { get; set; }
+} 

--- a/src/Altinn.Correspondence.Core/Models/Entities/IdempotencyKeyEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/IdempotencyKeyEntity.cs
@@ -14,7 +14,7 @@ public class IdempotencyKeyEntity
     public Guid CorrespondenceId { get; set; }
 
     [ForeignKey(nameof(CorrespondenceId))]
-    public CorrespondenceEntity? Correspondence { get; set; } = null!;
+    public CorrespondenceEntity Correspondence { get; set; } = null!;
 
     public Guid? AttachmentId { get; set; }
 

--- a/src/Altinn.Correspondence.Core/Models/Enums/ReferenceType.cs
+++ b/src/Altinn.Correspondence.Core/Models/Enums/ReferenceType.cs
@@ -30,9 +30,5 @@ namespace Altinn.Correspondence.Core.Models.Enums
         /// </summary>
         DialogportenProcessId = 4,
 
-        /// <summary>
-        /// Specifies that the reference is a Dialogporten Fetch Activity ID
-        /// </summary>
-        DialogPortenOpenedActivityId = 5,
     }
 }

--- a/src/Altinn.Correspondence.Core/Models/Enums/ReferenceType.cs
+++ b/src/Altinn.Correspondence.Core/Models/Enums/ReferenceType.cs
@@ -29,5 +29,10 @@ namespace Altinn.Correspondence.Core.Models.Enums
         /// Specifies that the reference is a Dialogporten Process ID
         /// </summary>
         DialogportenProcessId = 4,
+
+        /// <summary>
+        /// Specifies that the reference is a Dialogporten Fetch Activity ID
+        /// </summary>
+        DialogPortenOpenedActivityId = 5,
     }
 }

--- a/src/Altinn.Correspondence.Core/Models/Enums/StatusAction.cs
+++ b/src/Altinn.Correspondence.Core/Models/Enums/StatusAction.cs
@@ -1,22 +1,30 @@
 namespace Altinn.Correspondence.Core.Models.Enums;
 
 /// <summary>
-/// Represents different types of status actions that can be performed on a correspondence or its attachments
+/// Represents different types of status actions that can be performed on a correspondence or its attachments.
+/// This enum is used to support creating idempotent requests to Dialogporten to avoid duplicate activities being created.
+/// <para>
+/// The numeric values correspond to the related <see cref="CorrespondenceStatus"/> values in Dialogporten.
+/// For example, Fetched (3) corresponds to <see cref="CorrespondenceStatus.Fetched"/>.
+/// </para>
+/// <para>
+/// These values align with the corresponding status values in CorrespondenceStatusExt in the API layer for consistency across the application.
+/// </para>
 /// </summary>
 public enum StatusAction
 {
     /// <summary>
-    /// Indicates that a correspondence has been read
+    /// Indicates that a correspondence has been fetched
     /// </summary>
-    Read,
+    Fetched = 3,
 
     /// <summary>
     /// Indicates that a correspondence has been confirmed
     /// </summary>
-    Confirm,
+    Confirmed = 6,
 
     /// <summary>
     /// Indicates that an attachment download has started
     /// </summary>
-    DownloadStarted,
+    AttachmentDownloaded = 9,
 } 

--- a/src/Altinn.Correspondence.Core/Models/Enums/StatusAction.cs
+++ b/src/Altinn.Correspondence.Core/Models/Enums/StatusAction.cs
@@ -1,0 +1,22 @@
+namespace Altinn.Correspondence.Core.Models.Enums;
+
+/// <summary>
+/// Represents different types of status actions that can be performed on a correspondence or its attachments
+/// </summary>
+public enum StatusAction
+{
+    /// <summary>
+    /// Indicates that a correspondence has been read
+    /// </summary>
+    Read,
+
+    /// <summary>
+    /// Indicates that a correspondence has been confirmed
+    /// </summary>
+    Confirm,
+
+    /// <summary>
+    /// Indicates that an attachment download has started
+    /// </summary>
+    DownloadStarted,
+} 

--- a/src/Altinn.Correspondence.Core/Repositories/IIdempotencyKeyRepository.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IIdempotencyKeyRepository.cs
@@ -7,5 +7,5 @@ public interface IIdempotencyKeyRepository
 {
     Task<IdempotencyKeyEntity?> GetByCorrespondenceAndAttachmentAndActionAsync(Guid correspondenceId, Guid? attachmentId, StatusAction action, CancellationToken cancellationToken);
     Task<IdempotencyKeyEntity> CreateAsync(IdempotencyKeyEntity idempotencyKey, CancellationToken cancellationToken);
-    Task CreateRangeAsync(IEnumerable<IdempotencyKeyEntity> idempotencyKeys, CancellationToken cancellationToken);
+    Task<IEnumerable<IdempotencyKeyEntity>> CreateRangeAsync(IEnumerable<IdempotencyKeyEntity> idempotencyKeys, CancellationToken cancellationToken);
 } 

--- a/src/Altinn.Correspondence.Core/Repositories/IIdempotencyKeyRepository.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IIdempotencyKeyRepository.cs
@@ -1,0 +1,11 @@
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+
+namespace Altinn.Correspondence.Core.Repositories;
+
+public interface IIdempotencyKeyRepository
+{
+    Task<IdempotencyKeyEntity?> GetByCorrespondenceAndAttachmentAndActionAsync(Guid correspondenceId, Guid? attachmentId, StatusAction action, CancellationToken cancellationToken);
+    Task<IdempotencyKeyEntity> CreateAsync(IdempotencyKeyEntity idempotencyKey, CancellationToken cancellationToken);
+    Task CreateRangeAsync(IEnumerable<IdempotencyKeyEntity> idempotencyKeys, CancellationToken cancellationToken);
+} 

--- a/src/Altinn.Correspondence.Core/Repositories/IIdempotencyKeyRepository.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IIdempotencyKeyRepository.cs
@@ -7,5 +7,5 @@ public interface IIdempotencyKeyRepository
 {
     Task<IdempotencyKeyEntity?> GetByCorrespondenceAndAttachmentAndActionAsync(Guid correspondenceId, Guid? attachmentId, StatusAction action, CancellationToken cancellationToken);
     Task<IdempotencyKeyEntity> CreateAsync(IdempotencyKeyEntity idempotencyKey, CancellationToken cancellationToken);
-    Task<IEnumerable<IdempotencyKeyEntity>> CreateRangeAsync(IEnumerable<IdempotencyKeyEntity> idempotencyKeys, CancellationToken cancellationToken);
+    Task CreateRangeAsync(IEnumerable<IdempotencyKeyEntity> idempotencyKeys, CancellationToken cancellationToken);
 } 

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Correspondence.Core.Models.Enums;
+﻿using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Options;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
@@ -8,10 +9,11 @@ using Altinn.Correspondence.Integrations.Dialogporten.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Net.Http.Json;
+using UUIDNext;
 
 namespace Altinn.Correspondence.Integrations.Dialogporten;
 
-public class DialogportenService(HttpClient _httpClient, ICorrespondenceRepository _correspondenceRepository, IOptions<GeneralSettings> generalSettings, ILogger<DialogportenService> logger) : IDialogportenService
+public class DialogportenService(HttpClient _httpClient, ICorrespondenceRepository _correspondenceRepository, IOptions<GeneralSettings> generalSettings, ILogger<DialogportenService> logger, IIdempotencyKeyRepository _idempotencyKeyRepository) : IDialogportenService
 {
     public async Task<string> CreateCorrespondenceDialog(Guid correspondenceId)
     {
@@ -24,12 +26,42 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
         }
 
+        logger.LogInformation("CreateCorrespondenceDialog for correspondence {correspondenceId}", correspondence.Id);
+
+        // Create idempotency key for open dialog activity
+        var openActivityId = Uuid.NewDatabaseFriendly(Database.PostgreSql);
+        var openIdempotencyKey = new IdempotencyKeyEntity
+        {
+            Id = openActivityId,
+            CorrespondenceId = correspondence.Id,
+            AttachmentId = null, // No attachment for opened activity
+            StatusAction = StatusAction.Read
+        };
+        await _idempotencyKeyRepository.CreateAsync(openIdempotencyKey, cancellationToken);
+
+        // Create idempotency keys for each attachment's download activity
+        var attachmentIdempotencyKeys = new List<IdempotencyKeyEntity>();
+        foreach (var attachment in correspondence.Content?.Attachments ?? Enumerable.Empty<CorrespondenceAttachmentEntity>())
+        {
+            var downloadActivityId = Uuid.NewDatabaseFriendly(UUIDNext.Database.PostgreSql);
+            var downloadIdempotencyKey = new IdempotencyKeyEntity
+            {
+                Id = downloadActivityId,
+                CorrespondenceId = correspondence.Id,
+                AttachmentId = attachment.AttachmentId,
+                StatusAction = StatusAction.DownloadStarted
+            };
+            attachmentIdempotencyKeys.Add(downloadIdempotencyKey);
+        }
+        await _idempotencyKeyRepository.CreateRangeAsync(attachmentIdempotencyKeys, cancellationToken);
+
         var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, generalSettings.Value.CorrespondenceBaseUrl);
         var response = await _httpClient.PostAsJsonAsync("dialogporten/api/v1/serviceowner/dialogs", createDialogRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
             throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
         }
+
         var dialogResponse = await response.Content.ReadFromJsonAsync<string>(cancellationToken);
         if (dialogResponse is null)
         {
@@ -97,13 +129,44 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
-            throw new ArgumentException($"No dialog found on on correspondence with id {correspondenceId}");
+            throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
         }
 
         var createDialogActivityRequest = CreateDialogActivityRequestMapper.CreateDialogActivityRequest(correspondence, actorType, textType, Models.ActivityType.Information, tokens);
+
+        // Only set activity ID for download events using the stored idempotency key
+        if (textType == DialogportenTextType.DownloadStarted)
+        {
+            if (tokens.Length < 2 || !Guid.TryParse(tokens[1], out var attachmentId))
+            {
+                logger.LogError("Invalid attachment ID token for download activity on correspondence {correspondenceId}", correspondenceId);
+                throw new ArgumentException("Invalid attachment ID token", nameof(tokens));
+            }
+
+            var idempotencyKey = await _idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
+                correspondenceId,
+                attachmentId,
+                StatusAction.DownloadStarted,
+                cancellationToken);
+
+            if (idempotencyKey != null)
+            {
+                createDialogActivityRequest.Id = idempotencyKey.Id.ToString();
+            }
+        }
+
         var response = await _httpClient.PostAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}/activities", createDialogActivityRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
+            if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync();
+                if (errorContent.Contains("already exists"))
+                {
+                    logger.LogInformation("Activity already exists for correspondence {correspondenceId} and dialog {dialogId}", correspondenceId, dialogId);
+                    return; // Skip if the activity already exists
+                }
+            }
             throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
         }
     }
@@ -128,15 +191,20 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
         }
 
-        // Get the dedicated fetch activity ID from external references
-        var dialogOpenedActivityId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogPortenOpenedActivityId)?.ReferenceValue;
-        if (dialogOpenedActivityId is null)
+        // Get the pre-created idempotency key for open dialog activity
+        var idempotencyKey = await _idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
+            correspondenceId,
+            null, // No attachment for opened activity
+            StatusAction.Read,
+            cancellationToken);
+
+        if (idempotencyKey == null)
         {
-            throw new ArgumentException($"No fetch activity ID found on correspondence with id {correspondenceId}");
+            throw new InvalidOperationException($"No idempotency key found for open dialog activity on correspondence {correspondenceId}");
         }
 
         var createDialogActivityRequest = CreateDialogActivityRequestMapper.CreateDialogActivityRequest(correspondence, actorType, null, Models.ActivityType.DialogOpened);
-        createDialogActivityRequest.Id = dialogOpenedActivityId; // Use the dedicated fetch activity ID
+        createDialogActivityRequest.Id = idempotencyKey.Id.ToString(); // Use the pre-created activity ID
         var response = await _httpClient.PostAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}/activities", createDialogActivityRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
@@ -152,6 +220,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
         }
     }
+
     public async Task PurgeCorrespondenceDialog(Guid correspondenceId)
     {
         var cancellationTokenSource = new CancellationTokenSource();
@@ -165,7 +234,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
-            throw new ArgumentException($"No dialog found on on correspondence with id {correspondenceId}");
+            throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
         }
 
         var response = await _httpClient.PostAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}/actions/purge", null, cancellationToken);

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -35,7 +35,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             Id = openActivityId,
             CorrespondenceId = correspondence.Id,
             AttachmentId = null, // No attachment for opened activity
-            StatusAction = StatusAction.Read
+            StatusAction = StatusAction.Fetched
         };
         await _idempotencyKeyRepository.CreateAsync(openIdempotencyKey, cancellationToken);
 
@@ -48,7 +48,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
                 Id = confirmActivityId,
                 CorrespondenceId = correspondence.Id,
                 AttachmentId = null, // No attachment for confirm activity
-                StatusAction = StatusAction.Confirm
+                StatusAction = StatusAction.Confirmed
             };
             await _idempotencyKeyRepository.CreateAsync(confirmIdempotencyKey, cancellationToken);
         }
@@ -63,7 +63,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
                 Id = downloadActivityId,
                 CorrespondenceId = correspondence.Id,
                 AttachmentId = attachment.AttachmentId,
-                StatusAction = StatusAction.DownloadStarted
+                StatusAction = StatusAction.AttachmentDownloaded
             };
             attachmentIdempotencyKeys.Add(downloadIdempotencyKey);
         }
@@ -160,7 +160,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             var idempotencyKey = await _idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
                 correspondenceId,
                 null, // No attachment for confirm activity
-                StatusAction.Confirm,
+                StatusAction.Confirmed,
                 cancellationToken);
 
             if (idempotencyKey != null)
@@ -187,7 +187,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             var idempotencyKey = await _idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
                 correspondenceId,
                 attachmentId,
-                StatusAction.DownloadStarted,
+                StatusAction.AttachmentDownloaded,
                 cancellationToken);
 
             if (idempotencyKey != null)
@@ -243,7 +243,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var idempotencyKey = await _idempotencyKeyRepository.GetByCorrespondenceAndAttachmentAndActionAsync(
             correspondenceId,
             null, // No attachment for opened activity
-            StatusAction.Read,
+            StatusAction.Fetched,
             cancellationToken);
 
         if (idempotencyKey == null)

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -9,14 +9,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
         internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl)
         {
             var dialogId = Guid.CreateVersion7().ToString(); // Dialogporten requires time-stamped GUIDs
-            var fetchActivityId = Guid.CreateVersion7().ToString(); // Generate dedicated GUID for Fetch activity
-            
-            // Add the fetch activity ID to external references
-            correspondence.ExternalReferences.Add(new ExternalReferenceEntity
-            {
-                ReferenceType = ReferenceType.DialogPortenOpenedActivityId,
-                ReferenceValue = fetchActivityId
-            });
 
             return new CreateDialogRequest
             {

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -1,7 +1,6 @@
 ﻿using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Integrations.Dialogporten.Models;
-using UUIDNext;
 
 namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 {
@@ -9,7 +8,16 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
     {
         internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl)
         {
-            var dialogId = Uuid.NewDatabaseFriendly(Database.PostgreSql).ToString(); // Dialogporten requires time-stamped GUIDs, not supported natively until .NET 9.0
+            var dialogId = Guid.CreateVersion7().ToString(); // Dialogporten requires time-stamped GUIDs
+            var fetchActivityId = Guid.CreateVersion7().ToString(); // Generate dedicated GUID for Fetch activity
+            
+            // Add the fetch activity ID to external references
+            correspondence.ExternalReferences.Add(new ExternalReferenceEntity
+            {
+                ReferenceType = ReferenceType.DialogPortenOpenedActivityId,
+                ReferenceValue = fetchActivityId
+            });
+
             return new CreateDialogRequest
             {
                 Id = dialogId,

--- a/src/Altinn.Correspondence.Integrations/Slack/SlackNotificationService.cs
+++ b/src/Altinn.Correspondence.Integrations/Slack/SlackNotificationService.cs
@@ -1,7 +1,5 @@
-using System.Net.Http;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 

--- a/src/Altinn.Correspondence.Persistence/Configurations/IdempotencyKeyConfiguration.cs
+++ b/src/Altinn.Correspondence.Persistence/Configurations/IdempotencyKeyConfiguration.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+
+namespace Altinn.Correspondence.Persistence.Configurations;
+
+public class IdempotencyKeyConfiguration : IEntityTypeConfiguration<IdempotencyKeyEntity>
+{
+    public void Configure(EntityTypeBuilder<IdempotencyKeyEntity> builder)
+    {
+        builder.ToTable("IdempotencyKeys");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.CorrespondenceId)
+            .IsRequired();
+
+        builder.Property(x => x.AttachmentId)
+            .IsRequired(false);
+
+        builder.Property(x => x.StatusAction)
+            .IsRequired()
+            .HasConversion<string>();
+
+        // Create a unique index on the combination of CorrespondenceId, AttachmentId, and Action
+        builder.HasIndex(x => new { x.CorrespondenceId, x.AttachmentId, x.StatusAction })
+            .IsUnique();
+    }
+} 

--- a/src/Altinn.Correspondence.Persistence/Data/ApplicationDbContext.cs
+++ b/src/Altinn.Correspondence.Persistence/Data/ApplicationDbContext.cs
@@ -41,6 +41,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<ExternalReferenceEntity> ExternalReferences { get; set; }
     public DbSet<NotificationTemplateEntity> NotificationTemplates { get; set; }
     public DbSet<LegacyPartyEntity> LegacyParties { get; set; }
+    public DbSet<IdempotencyKeyEntity> IdempotencyKeys { get; set; } = null!;
 
     private bool IsAccessTokenValid()
     {

--- a/src/Altinn.Correspondence.Persistence/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Persistence/DependencyInjection.cs
@@ -26,6 +26,7 @@ public static class DependencyInjection
         services.AddScoped<IStorageRepository, StorageRepository>();
         services.AddScoped<INotificationTemplateRepository, NotificationTemplateRepository>();
         services.AddScoped<ILegacyPartyRepository, LegacyPartyRepository>();
+        services.AddScoped<IIdempotencyKeyRepository, IdempotencyKeyRepository>();
     }
 
     private static NpgsqlDataSource BuildAzureNpgsqlDataSource(IConfiguration config)

--- a/src/Altinn.Correspondence.Persistence/Migrations/20250408123318_IdempotencyKeyEntity.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20250408123318_IdempotencyKeyEntity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Altinn.Correspondence.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250408123318_IdempotencyKeyEntity")]
+    partial class IdempotencyKeyEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20250408123318_IdempotencyKeyEntity.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20250408123318_IdempotencyKeyEntity.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class IdempotencyKeyEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "IdempotencyKeys",
+                schema: "correspondence",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CorrespondenceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AttachmentId = table.Column<Guid>(type: "uuid", nullable: true),
+                    StatusAction = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IdempotencyKeys", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_IdempotencyKeys_Attachments_AttachmentId",
+                        column: x => x.AttachmentId,
+                        principalSchema: "correspondence",
+                        principalTable: "Attachments",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_IdempotencyKeys_Correspondences_CorrespondenceId",
+                        column: x => x.CorrespondenceId,
+                        principalSchema: "correspondence",
+                        principalTable: "Correspondences",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IdempotencyKeys_AttachmentId",
+                schema: "correspondence",
+                table: "IdempotencyKeys",
+                column: "AttachmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IdempotencyKeys_CorrespondenceId",
+                schema: "correspondence",
+                table: "IdempotencyKeys",
+                column: "CorrespondenceId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "IdempotencyKeys",
+                schema: "correspondence");
+        }
+    }
+}

--- a/src/Altinn.Correspondence.Persistence/Repositories/IdempotencyKeyRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/IdempotencyKeyRepository.cs
@@ -1,0 +1,39 @@
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Altinn.Correspondence.Persistence.Repositories;
+
+public class IdempotencyKeyRepository : IIdempotencyKeyRepository
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public IdempotencyKeyRepository(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IdempotencyKeyEntity?> GetByCorrespondenceAndAttachmentAndActionAsync(Guid correspondenceId, Guid? attachmentId, StatusAction action, CancellationToken cancellationToken)
+    {
+        return await _dbContext.IdempotencyKeys
+            .FirstOrDefaultAsync(k => 
+                k.CorrespondenceId == correspondenceId && 
+                k.AttachmentId == attachmentId && 
+                k.StatusAction == action,
+                cancellationToken);
+    }
+
+    public async Task<IdempotencyKeyEntity> CreateAsync(IdempotencyKeyEntity idempotencyKey, CancellationToken cancellationToken)
+    {
+        await _dbContext.IdempotencyKeys.AddAsync(idempotencyKey, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return idempotencyKey;
+    }
+
+    public async Task CreateRangeAsync(IEnumerable<IdempotencyKeyEntity> idempotencyKeys, CancellationToken cancellationToken)
+    {
+        await _dbContext.IdempotencyKeys.AddRangeAsync(idempotencyKeys, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+} 


### PR DESCRIPTION
Kun første event skal sendes til DP ved bruk av idenpotent mechanism

## Description
- IdempotencyKeyEntity has been added in EM, migration script has ran.
- Updated DialogPortenService and more.

## Related Issue(s)
- #859 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out) <- ongoing work
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a mechanism to prevent duplicate processing of downloads and correspondence actions, enhancing overall reliability.
  - Implemented time-stamped identifier generation for dialog creation, ensuring more accurate tracking and smoother operations.

- **Refactor**
  - Enhanced error reporting and logging for clearer, more actionable feedback during processing.

These improvements aim to provide a more robust and consistent user experience when interacting with correspondence activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->