### PR TITLE
Add specific ID's to ensure attachment ordering is preserved.

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -290,8 +290,9 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
         private static List<Attachment> GetAttachmentsForCorrespondence(string baseUrl, CorrespondenceEntity correspondence)
         {
-            return correspondence.Content?.Attachments.Select(attachment => new Attachment
+            return correspondence.Content?.Attachments.Select((attachment, index) => new Attachment
             {
+                Id = index.ToString(),
                 DisplayName = new List<DisplayName>
                 {
                     new DisplayName

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Models/CreateDialogRequest.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Models/CreateDialogRequest.cs
@@ -106,6 +106,8 @@ public class ApiAction
 
 public class Attachment
 {
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
     [JsonPropertyName("displayName")]
     public List<DisplayName> DisplayName { get; set; }
 


### PR DESCRIPTION
## Description
Add specific ID's to ensure attachment ordering is preserved.

## Related Issue(s)
- #940 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Each attachment now includes a unique identifier, making it easier to reference specific attachments in correspondence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->