### PR TITLE
Trim search tags

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -100,14 +100,14 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
         private static List<SearchTag> AddSearchTagIfValid(List<SearchTag> list, string? searchTag)
         {
-            if (string.IsNullOrWhiteSpace(searchTag) || searchTag.Length < 3)
+            if (string.IsNullOrWhiteSpace(searchTag) || searchTag.Trim().Length < 3)
             {
                 return list;
             }
             list.Add(
                 new SearchTag()
                 {
-                    Value = searchTag
+                    Value = searchTag.Trim()
                 }
             );
             return list;


### PR DESCRIPTION
## Description
Bug fix: the code did not trim whitespace from search tags

## Related Issue(s)
- #931 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for search tags by ensuring tags with fewer than three non-whitespace characters are excluded.
  - Search tags are now stored without leading or trailing spaces, providing more consistent and accurate tag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->