### PR TITLE
Cancel notifications when sent instead of when correspondence cancelled

### DIFF
--- a/src/Altinn.Correspondence.Application/CancelNotification/CancelNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Application/CancelNotification/CancelNotificationHandler.cs
@@ -52,17 +52,7 @@ namespace Altinn.Correspondence.Application.CancelNotification
                     if (retryAttempts == MaxRetries) SendSlackNotificationWithMessage(error);
                     throw new Exception(error);
                 }
-                bool isCancellationSuccessful = await altinnNotificationService.CancelNotification(notificationOrderId, cancellationToken);
-                if (!isCancellationSuccessful)
-                {
-                    error += $"Cancellation unsuccessful for notificationId: {notification.Id}";
-                    if (retryAttempts == MaxRetries) SendSlackNotificationWithMessage(error);
-                    throw new Exception(error);
-                }
-                else
-                {
-                    backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(notification.CorrespondenceId, DialogportenActorType.ServiceOwner, DialogportenTextType.NotificationOrderCancelled));
-                }
+                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(notification.CorrespondenceId, DialogportenActorType.ServiceOwner, DialogportenTextType.NotificationOrderCancelled));
             }
         }
         private void SendSlackNotificationWithMessage(string message)

--- a/src/Altinn.Correspondence.Application/CheckNotification/CheckNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Application/CheckNotification/CheckNotificationHandler.cs
@@ -27,6 +27,10 @@ public class CheckNotificationHandler(ICorrespondenceRepository correspondenceRe
         {
             response.SendNotification = false;
         }
+        if (correspondence.StatusHasBeen(CorrespondenceStatus.PurgedByAltinn) || correspondence.StatusHasBeen(CorrespondenceStatus.PurgedByRecipient))
+        {
+            response.SendNotification = false;
+        }
         if (!correspondence.StatusHasBeen(CorrespondenceStatus.Published))
         {
             backgroundJobClient.Schedule<EnsureNotificationHandler>(handler => handler.Process(correspondenceId, null, CancellationToken.None), DateTimeOffset.Now.AddHours(1));


### PR DESCRIPTION
## Description
Instead of cancelling notifications directly, which is not currently supported by notifications v2, we instead fail the notification pre-condition check if a correspondence has been purged.

## Related Issue(s)
- #976

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of notification cancellations to ensure background jobs are always enqueued when appropriate.
	- Enhanced notification sending logic to prevent notifications from being sent if the correspondence has been purged by Altinn or the recipient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->