### PR TITLE
Migration: Nullable strings should be accepted and mapped to empty string

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyRetrievalTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyRetrievalTests.cs
@@ -193,9 +193,11 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
             basicCorrespondence.Correspondence.Content.MessageBody = "<html><header>test header</header><body>test body</body></html>";
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
+            var basicCorrespondenceJson = JsonSerializer.Serialize(basicCorrespondence);
+            var basicMigrateCorrespondence = JsonSerializer.Deserialize<MigrateInitializeCorrespondencesExt>(basicCorrespondenceJson);
             MigrateCorrespondenceExt migrateCorrespondenceExt = new()
             {
-                CorrespondenceData = basicCorrespondence,
+                CorrespondenceData = basicMigrateCorrespondence,
                 Altinn2CorrespondenceId = 12345,
                 EventHistory =
                 [

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -39,9 +39,11 @@ public class MigrationControllerTests
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
         basicCorrespondence.Correspondence.Content.MessageBody = "<html><header>test header</header><body>test body</body></html>";
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
+        var basicCorrespondenceJson = JsonSerializer.Serialize(basicCorrespondence);
+        var basicMigrateCorrespondence = JsonSerializer.Deserialize<MigrateInitializeCorrespondencesExt>(basicCorrespondenceJson);
         MigrateCorrespondenceExt migrateCorrespondenceExt = new()
         {
-            CorrespondenceData = basicCorrespondence,
+            CorrespondenceData = basicMigrateCorrespondence,
             Altinn2CorrespondenceId = 12345,
             EventHistory =
         [
@@ -137,9 +139,11 @@ public class MigrationControllerTests
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
         basicCorrespondence.Correspondence.Content.MessageBody = "<html><header>test header</header><body>test body</body></html>";
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
+        var basicCorrespondenceJson = JsonSerializer.Serialize(basicCorrespondence);
+        var basicMigrateCorrespondence = JsonSerializer.Deserialize<MigrateInitializeCorrespondencesExt>(basicCorrespondenceJson);
         MigrateCorrespondenceExt migrateCorrespondenceExt = new()
         {
-            CorrespondenceData = basicCorrespondence,
+            CorrespondenceData = basicMigrateCorrespondence,
             Altinn2CorrespondenceId = 12345,
             EventHistory =
         [
@@ -267,9 +271,11 @@ public class MigrationControllerTests
         var basicCorrespondence = new CorrespondenceBuilder()
             .CreateCorrespondence()
             .Build();
+        var basicCorrespondenceJson = JsonSerializer.Serialize(basicCorrespondence);
+        var basicMigrateCorrespondence = JsonSerializer.Deserialize<MigrateInitializeCorrespondencesExt>(basicCorrespondenceJson);
         MigrateCorrespondenceExt migrateCorrespondenceExt = new()
         {
-            CorrespondenceData = basicCorrespondence,
+            CorrespondenceData = basicMigrateCorrespondence,
             Altinn2CorrespondenceId = 12345,
             EventHistory =
         [
@@ -329,9 +335,11 @@ public class MigrationControllerTests
 
         InitializeCorrespondencesExt initializeCorrespondencesExt = new CorrespondenceBuilder().CreateCorrespondence().WithExistingAttachments([attachmentId, attachmentId2]).Build();
         initializeCorrespondencesExt.Correspondence.SendersReference = "test 2024 10 09 09 45";
+        var basicCorrespondenceJson = JsonSerializer.Serialize(initializeCorrespondencesExt);
+        var basicMigrateCorrespondence = JsonSerializer.Deserialize<MigrateInitializeCorrespondencesExt>(basicCorrespondenceJson);
         MigrateCorrespondenceExt migrateCorrespondenceExt = new()
         {
-            CorrespondenceData = initializeCorrespondencesExt,
+            CorrespondenceData = basicMigrateCorrespondence,
             Altinn2CorrespondenceId = 12345,
             EventHistory = [ new CorrespondenceStatusEventExt()
             {
@@ -354,9 +362,11 @@ public class MigrationControllerTests
         var basicCorrespondence = new CorrespondenceBuilder()
             .CreateCorrespondence()
             .Build();
+        var basicCorrespondenceJson = JsonSerializer.Serialize(basicCorrespondence);
+        var basicMigrateCorrespondence = JsonSerializer.Deserialize<MigrateInitializeCorrespondencesExt>(basicCorrespondenceJson);
         MigrateCorrespondenceExt migrateCorrespondenceExt = new()
         {
-            CorrespondenceData = basicCorrespondence,
+            CorrespondenceData = basicMigrateCorrespondence,
             Altinn2CorrespondenceId = 12345,
             EventHistory =
             [

--- a/src/Altinn.Correspondence.API/Mappers/MigrateCorrespondenceMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/MigrateCorrespondenceMapper.cs
@@ -57,9 +57,9 @@ internal static class MigrateCorrespondenceMapper
             Content = migrateCorrespondenceExt.CorrespondenceData.Correspondence.Content != null ? new CorrespondenceContentEntity
             {
                 Language = migrateCorrespondenceExt.CorrespondenceData.Correspondence.Content.Language,
-                MessageTitle = migrateCorrespondenceExt.CorrespondenceData.Correspondence.Content.MessageTitle,
-                MessageSummary = migrateCorrespondenceExt.CorrespondenceData.Correspondence.Content.MessageSummary,
-                MessageBody = migrateCorrespondenceExt.CorrespondenceData.Correspondence.Content.MessageBody,
+                MessageTitle = migrateCorrespondenceExt.CorrespondenceData.Correspondence.Content.MessageTitle ?? "",
+                MessageSummary = migrateCorrespondenceExt.CorrespondenceData.Correspondence.Content.MessageSummary ?? "",
+                MessageBody = migrateCorrespondenceExt.CorrespondenceData.Correspondence.Content.MessageBody ?? "",
                 Attachments = []
             } : null,
             IsConfirmationNeeded = migrateCorrespondenceExt.CorrespondenceData.Correspondence.IsConfirmationNeeded,

--- a/src/Altinn.Correspondence.API/Models/MigrateBaseCorrespondenceExt.cs
+++ b/src/Altinn.Correspondence.API/Models/MigrateBaseCorrespondenceExt.cs
@@ -1,0 +1,115 @@
+﻿using Altinn.Correspondence.Common.Constants;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Altinn.Correspondence.API.Models
+{
+    /// <summary>
+    /// Represents a request object for the operation, InitializeCorrespondence, that can create a correspondence in Altinn.    
+    /// </summary>
+    public class MigrateBaseCorrespondenceExt
+    {
+        /// <summary>
+        /// The Resource Id associated with the correspondence service.
+        /// </summary>
+        [JsonPropertyName("resourceId")]
+        [StringLength(255, MinimumLength = 1)]
+        [Required]
+        public required string ResourceId { get; set; }
+
+        /// <summary>
+        /// The Sending organization of the correspondence. 
+        /// </summary>
+        /// <remarks>
+        /// Organization number must be formatted as countrycode:organizationnumber.
+        /// </remarks>
+        [JsonPropertyName("sender")]
+        [OrganizationNumber(ErrorMessage = $"Organization numbers should be on the format '{UrnConstants.OrganizationNumberAttribute}:organizationnumber' or the format countrycode:organizationnumber, for instance 0192:910753614")]
+        [Required]
+        public required string Sender { get; set; }
+
+        /// <summary>
+        /// A reference used by senders and receivers to identify a specific Correspondence using external identification methods.
+        /// </summary>
+        [JsonPropertyName("sendersReference")]
+        [StringLength(4096, MinimumLength = 1)]
+        [Required]
+        public required string SendersReference { get; set; }
+
+        /// <summary>
+        /// An alternative name for the sender of the correspondence. The name will be displayed instead of the organization name.
+        ///  </summary>
+        [JsonPropertyName("messageSender")]
+        [StringLength(256, MinimumLength = 0)]
+        public string? MessageSender { get; set; }
+
+        /// <summary>
+        /// The correspondence content. Contains information about the Correspondence body, subject etc.
+        /// </summary>
+        [JsonPropertyName("content")]
+        public MigrateCorrespondenceContentExt? Content { get; set; }
+
+        /// <summary>
+        /// When the correspondence should become visible to the recipient.
+        /// </summary>
+        [JsonPropertyName("requestedPublishTime")]
+        public DateTimeOffset? RequestedPublishTime { get; set; }
+
+        /// <summary>
+        /// When Altinn can remove the correspondence from its database.
+        /// </summary>
+        [JsonPropertyName("allowSystemDeleteAfter")]
+        public DateTimeOffset? AllowSystemDeleteAfter { get; set; }
+
+        /// <summary>
+        /// When the recipient must reply to the correspondence
+        /// </summary>
+        [JsonPropertyName("dueDateTime")]
+        public DateTimeOffset? DueDateTime { get; set; }
+
+        /// <summary>
+        /// A list of references Senders can use to tell the recipient that the correspondence is related to the referenced item(s)
+        /// Examples include Altinn App instances, Altinn Broker File Transfers
+        /// </summary>
+        [JsonPropertyName("externalReferences")]
+        [ExternalReferences]
+        public List<ExternalReferenceExt>? ExternalReferences { get; set; }
+
+        /// <summary>
+        /// User-defined properties related to the Correspondence
+        /// </summary>
+        [JsonPropertyName("propertyList")]
+        [PropertyList]
+        public Dictionary<string, string> PropertyList { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Options for how the recipient can reply to the Correspondence
+        /// </summary>
+        [JsonPropertyName("replyOptions")]
+        public List<CorrespondenceReplyOptionExt> ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionExt>();
+
+        /// <summary>
+        /// Notifications related to the Correspondence.
+        /// </summary>
+        [JsonPropertyName("notification")]
+        public InitializeCorrespondenceNotificationExt? Notification { get; set; }
+
+        /// <summary>
+        /// Specifies whether the correspondence can override reservation against digital communication in KRR
+        /// </summary>
+        [JsonPropertyName("ignoreReservation")]
+        public bool? IgnoreReservation { get; set; }
+
+        /// <summary>
+        /// Is null until the correspondence is published.
+        /// </summary>
+        [JsonPropertyName("published")]
+        public DateTimeOffset? Published { get; set; }
+
+        /// <summary>
+        /// Specifies whether reading the correspondence needs to be confirmed by the recipient
+        /// </summary>
+        [JsonPropertyName("isConfirmationNeeded")]
+        public bool IsConfirmationNeeded { get; set; }
+    }
+}

--- a/src/Altinn.Correspondence.API/Models/MigrateCorrespondenceExt.cs
+++ b/src/Altinn.Correspondence.API/Models/MigrateCorrespondenceExt.cs
@@ -5,7 +5,7 @@ namespace Altinn.Correspondence.API.Models
     public class MigrateCorrespondenceExt
     {
         [JsonPropertyName("correspondenceData")]
-        public required InitializeCorrespondencesExt CorrespondenceData { get; set; }
+        public required MigrateInitializeCorrespondencesExt CorrespondenceData { get; set; }
         
         [JsonPropertyName("altinn2CorrespondenceId")]
         public required int Altinn2CorrespondenceId { get; set; }

--- a/src/Altinn.Correspondence.API/Models/MigrateCorrespondencesContentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/MigrateCorrespondencesContentExt.cs
@@ -1,0 +1,40 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.Correspondence.API.Models
+{
+    /// <summary>
+    /// Represents the content of a Correspondence.
+    /// </summary>
+    public class MigrateCorrespondenceContentExt
+    {
+        /// <summary>
+        /// Gets or sets the language of the correspondence, specified according to ISO 639-1 
+        /// </summary>
+        [JsonPropertyName("language")]
+        [ISO6391]
+        public required string Language { get; set; }
+
+        /// <summary>
+        /// Gets or sets the correspondence message title. Subject.
+        /// </summary>
+        [JsonPropertyName("messageTitle")]
+        public string? MessageTitle { get; set; }
+
+        /// <summary>
+        /// Gets or sets a summary text of the correspondence.
+        /// </summary>
+        [JsonPropertyName("messageSummary")]
+        public string? MessageSummary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the main body of the correspondence.
+        /// </summary>
+        public string? MessageBody { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of attachments.
+        /// </summary>
+        [JsonPropertyName("attachments")]
+        public List<InitializeCorrespondenceAttachmentExt> Attachments { get; set; } = new List<InitializeCorrespondenceAttachmentExt>();
+    }
+}

--- a/src/Altinn.Correspondence.API/Models/MigrateInitializeCorrespondencesExt.cs
+++ b/src/Altinn.Correspondence.API/Models/MigrateInitializeCorrespondencesExt.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Altinn.Correspondence.API.Models
+{
+
+    public class MigrateInitializeCorrespondencesExt
+    {
+        /// <summary>
+        /// The correspondence object that should be created
+        /// </summary>
+        [JsonPropertyName("correspondence")]
+        public required MigrateBaseCorrespondenceExt Correspondence { get; set; }
+
+        /// <summary>
+        /// List of recipients for the correspondence, either as organization(urn:altinn:organization:identifier-no:ORGNR) or national identity number(urn:altinn:person:identifier-no:SSN)
+        /// </summary>
+        [JsonPropertyName("recipients")]
+        [Required]
+        [RecipientList]
+        public required List<string> Recipients { get; set; }
+
+        /// <summary>
+        /// Existing attachments that should be added to the correspondence
+        /// </summary>
+        [JsonPropertyName("existingAttachments")]
+        public List<Guid> ExistingAttachments { get; set; } = new List<Guid>();
+    }
+}


### PR DESCRIPTION
## Description
Nullable strings should be accepted and mapped to empty string. Big change because migration re-used existing models. Hack-ish way to make tests work, but they will only exist for the migration.

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new request and content models for migrating correspondences, supporting enhanced validation and structured data for correspondence creation, recipients, and attachments.
- **Bug Fixes**
	- Improved handling of message content fields to ensure empty strings are used instead of null values, increasing stability during correspondence migration.
- **Refactor**
	- Updated property types in existing models to align with the new migration structure.
	- Adjusted test data handling to support new correspondence migration data structures via serialization and deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->