### PR TITLE
Filter out logs from health and migration endpoints

### DIFF
--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -34,7 +34,7 @@ static void BuildAndRun(string[] args)
         .ReadFrom.Services(services)
         .Filter.ByExcluding(logEvent =>
             logEvent.Properties.TryGetValue("RequestPath", out var requestPath) &&
-            requestPath.ToString().Equals("\"/health\"", StringComparison.OrdinalIgnoreCase))
+            requestPath.ToString().Equals("/health", StringComparison.OrdinalIgnoreCase))
         .Filter.ByExcluding(logEvent =>   
             logEvent.Properties.TryGetValue("RequestPath", out var requestPath) &&
             requestPath.ToString().Contains("/migration", StringComparison.OrdinalIgnoreCase))

--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -70,6 +70,7 @@ static void BuildAndRun(string[] args)
     app.MapControllers();
     app.UseMiddleware<SecurityHeadersMiddleware>();
     app.UseMiddleware<AcceptHeaderValidationMiddleware>();
+    app.UseSerilogRequestLogging();
 
     if (app.Environment.IsDevelopment())
     {

--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -34,7 +34,7 @@ static void BuildAndRun(string[] args)
         .ReadFrom.Services(services)
         .Filter.ByExcluding(logEvent =>
             logEvent.Properties.TryGetValue("RequestPath", out var requestPath) &&
-            requestPath.ToString().Equals("/health", StringComparison.OrdinalIgnoreCase))
+            requestPath.ToString().Contains("/health", StringComparison.OrdinalIgnoreCase))
         .Filter.ByExcluding(logEvent =>   
             logEvent.Properties.TryGetValue("RequestPath", out var requestPath) &&
             requestPath.ToString().Contains("/migration", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Description
Filter out logs from health and migration endpoints. For migration we need to do it for performance. From health check because irrelevant logs.

## Related Issue(s)
- #678

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated logging configuration to exclude health check and migration-related requests from logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->