### PR TITLE
Set maximum 100 attachments

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -802,5 +802,101 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Tear down
             memoryStream.Dispose();
         }
+
+        [Fact]
+        public async Task InitializeCorrespondence_WithMoreThan100Attachments_ReturnsBadRequest()
+        {
+            // Arrange
+            var hangfireBackgroundJobClient = new Mock<IBackgroundJobClient>();
+            hangfireBackgroundJobClient
+            .Setup(x => x.Create(
+                It.IsAny<Job>(),
+                It.IsAny<IState>()))
+            .Returns<Job, IState>((job, state) =>
+            {
+                // Apply 5-second delay only for CreateDialogportenDialog to give us time to poll for attachments
+                if (job.Method.Name == "CreateDialogportenDialog")
+                {
+                    Task.Delay(5000).Wait();
+                    return "dialog-job-id-123";
+                }
+
+                // For other jobs, return immediately
+                return "123456";
+            });
+
+            var attachments = new List<InitializeCorrespondenceAttachmentExt>();
+            for (int i = 0; i < 101; i++)
+            {
+                var attachment = AttachmentHelper.GetAttachmentMetaData($"file{i}.txt");
+                attachment.DataLocationType = API.Models.Enums.InitializeAttachmentDataLocationTypeExt.NewCorrespondenceAttachment;
+                attachment.ExpirationTime = DateTimeOffset.UtcNow.AddDays(1);
+                attachments.Add(attachment);
+            }
+            
+            Assert.Equal(101, attachments.Count);
+            
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithAttachments(attachments)
+                .Build();
+
+            var formData = CorrespondenceHelper.CorrespondenceToFormData(payload.Correspondence);
+            formData.Add(new StringContent($"{UrnConstants.OrganizationNumberAttribute}:986252932"), "recipients[0]");
+
+            foreach (var attachment in attachments)
+            {
+                var memoryStream = new MemoryStream();
+                memoryStream.Write(Encoding.UTF8.GetBytes("test content"));
+                memoryStream.Position = 0;
+                
+                var streamContent = new StreamContent(memoryStream);
+                formData.Add(streamContent, "attachments", attachment.FileName);
+            }
+
+            // Act
+            var response = await _senderClient.PostAsync("correspondence/api/v1/correspondence/upload", formData);
+            
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task InitializeCorrespondence_With100Attachments_ReturnsOk()
+        {
+            // Arrange
+            var attachments = new List<InitializeCorrespondenceAttachmentExt>();
+            for (int i = 0; i < 100; i++)
+            {
+                var attachment = AttachmentHelper.GetAttachmentMetaData($"file{i}.txt");
+                attachment.DataLocationType = Altinn.Correspondence.API.Models.Enums.InitializeAttachmentDataLocationTypeExt.NewCorrespondenceAttachment;
+                attachment.ExpirationTime = DateTimeOffset.UtcNow.AddDays(1);
+                attachments.Add(attachment);
+            }
+            
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithAttachments(attachments)
+                .Build();
+
+            var formData = CorrespondenceHelper.CorrespondenceToFormData(payload.Correspondence);
+            formData.Add(new StringContent($"{UrnConstants.OrganizationNumberAttribute}:986252932"), "recipients[0]");
+
+            foreach (var attachment in attachments)
+            {
+                var memoryStream = new MemoryStream();
+                memoryStream.Write(Encoding.UTF8.GetBytes("test content"));
+                memoryStream.Position = 0;
+                
+                var streamContent = new StreamContent(memoryStream);
+                formData.Add(streamContent, "attachments", attachment.FileName);
+            }
+
+            // Act
+            var response = await _senderClient.PostAsync("correspondence/api/v1/correspondence/upload", formData);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
     }
 }

--- a/src/Altinn.Correspondence.API/Models/CorrespondenceContentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceContentExt.cs
@@ -1,5 +1,4 @@
-﻿using Altinn.Correspondence.API.Models.Enums;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Altinn.Correspondence.API.Models
 {
@@ -11,9 +10,6 @@ namespace Altinn.Correspondence.API.Models
         /// <summary>
         /// Gets or sets a list of attachments.
         /// </summary>
-        /// <remarks>
-        /// TODO: Number restriction?
-        /// </remarks>
         [JsonPropertyName("attachments")]
         public required new List<CorrespondenceAttachmentExt> Attachments { get; set; }
     }

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceContentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceContentExt.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Text.Json.Serialization;
 
@@ -36,7 +37,11 @@ namespace Altinn.Correspondence.API.Models
         /// <summary>
         /// Gets or sets a list of attachments.
         /// </summary>
+        /// <remarks>
+        /// Maximum of 100 attachments allowed.
+        /// </remarks>
         [JsonPropertyName("attachments")]
+        [MaxListCount(100, "attachments")]
         public List<InitializeCorrespondenceAttachmentExt> Attachments { get; set; } = new List<InitializeCorrespondenceAttachmentExt>();
     }
 
@@ -61,6 +66,25 @@ namespace Altinn.Correspondence.API.Models
             if (CultureInfo.InvariantCulture.TwoLetterISOLanguageName.Contains(stringValue))
             {
                 return new ValidationResult("The language code must be ISO6391 compliant!");
+            }
+            return ValidationResult.Success;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    internal class MaxListCountAttribute(int maxCount, string? propertyName = null) : ValidationAttribute
+    {
+        public int MaxCount { get; } = maxCount;
+        public string PropertyName { get; } = propertyName ?? "items";
+
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+        {
+            if (value is ICollection collection)
+            {
+                if (collection.Count > MaxCount)
+                {
+                    return new ValidationResult($"Maximum of {MaxCount} {PropertyName} allowed.");
+                }
             }
             return ValidationResult.Success;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the max ammount of attachment for a correspondence is unlimited. This PR validates the amount of attachments and limits it to 100.

## Related Issue(s)
- #979 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a validation rule to limit the number of attachments to 100 when initializing correspondence.
- **Bug Fixes**
  - Improved error handling for cases where the attachment limit is exceeded.
- **Tests**
  - Introduced tests to verify correct responses when the number of attachments is at or above the allowed limit.
- **Style**
  - Cleaned up unused imports and removed obsolete comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->