### PR TITLE
Need correct role assignment to enable malware scan

### DIFF
--- a/.azure/modules/identity/create.bicep
+++ b/.azure/modules/identity/create.bicep
@@ -9,7 +9,7 @@ resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@
 
 var storageBlobDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource storageBlobDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(subscription().id, userAssignedIdentity.id, storageBlobDataContributorRoleId)
   properties: {
     roleDefinitionId: storageBlobDataContributorRoleId
@@ -18,6 +18,15 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
+var azureDefenderForStorageScannerOperatorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f641de8-0b88-4198-bdef-bd8b45ceba96')
+resource azureDefenderForStorageScannerOperatorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, userAssignedIdentity.id, azureDefenderForStorageScannerOperatorRoleId)
+  properties: {
+    roleDefinitionId: azureDefenderForStorageScannerOperatorRoleId
+    principalId: userAssignedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
 output id string = userAssignedIdentity.id
 output clientId string = userAssignedIdentity.properties.clientId
 output principalId string = userAssignedIdentity.properties.principalId

--- a/.azure/modules/identity/create.bicep
+++ b/.azure/modules/identity/create.bicep
@@ -8,7 +8,6 @@ resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@
 }
 
 var storageBlobDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
-
 resource storageBlobDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(subscription().id, userAssignedIdentity.id, storageBlobDataContributorRoleId)
   properties: {


### PR DESCRIPTION
## Description
Need correct role assignment to enable malware scan. This is the job role Azure Defender For Storage Scanner Operator

## Related Issue(s)
- #754

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added assignment of the "Azure Defender for Storage Scanner Operator" role to the managed identity.

- **Refactor**
  - Improved naming for the existing storage role assignment for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->