### PR TITLE
Increase max individual attachment size to 2GB

### DIFF
--- a/src/Altinn.Correspondence.Application/ApplicationConstants.cs
+++ b/src/Altinn.Correspondence.Application/ApplicationConstants.cs
@@ -2,7 +2,7 @@ namespace Altinn.Correspondence.Application.Settings;
 
 public static class ApplicationConstants
 {
-    public const long MaxFileUploadSize = 250 * 1024 * 1024;
+    public const long MaxFileUploadSize = 2 * 1024 * 1024 * 1024L;
     public static readonly List<string> AllowedFileTypes =
     [
         ".doc",


### PR DESCRIPTION
## Description
Increase max individual attachment size to 2GB

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the maximum allowed file upload size from 250 MB to 2 GB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->