### PR TITLE
Make Altinn2attachmentid a string so that we can prefix it

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -331,7 +331,7 @@ public class MigrationControllerTests
     public async Task InitializeMigrateAttachment_DuplicateAltinn2AttachmentId_FailsWithConflict()
     {
         MigrateInitializeAttachmentExt migrateAttachmentExt = new MigrateAttachmentBuilder().CreateAttachment().Build();
-        migrateAttachmentExt.Altinn2AttachmentId = (new Random()).Next();
+        migrateAttachmentExt.Altinn2AttachmentId = (new Random()).Next().ToString();
         byte[] file = Encoding.UTF8.GetBytes("Test av fil opplasting");
         MemoryStream memoryStream = new(file);
         StreamContent content = new(memoryStream);

--- a/src/Altinn.Correspondence.API/Models/MigrateInitializeAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/MigrateInitializeAttachmentExt.cs
@@ -13,5 +13,5 @@ public class MigrateInitializeAttachmentExt : InitializeAttachmentExt
     public required Guid SenderPartyUuid { get; set; }
 
     [JsonPropertyName("altinn2AttachmentId")]
-    public int? Altinn2AttachmentId { get; set; }
+    public string? Altinn2AttachmentId { get; set; }
 }

--- a/src/Altinn.Correspondence.Core/Models/Entities/AttachmentEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/AttachmentEntity.cs
@@ -50,6 +50,6 @@ namespace Altinn.Correspondence.Core.Models.Entities
 
         public StorageProviderEntity? StorageProvider { get; set; }
 
-        public int? Altinn2AttachmentId { get; set; }
+        public string? Altinn2AttachmentId { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Migrations/20250515073353_Altinn2AttachmentIdToString.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20250515073353_Altinn2AttachmentIdToString.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Altinn.Correspondence.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250515073353_Altinn2AttachmentIdToString")]
+    partial class Altinn2AttachmentIdToString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20250515073353_Altinn2AttachmentIdToString.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20250515073353_Altinn2AttachmentIdToString.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Altinn2AttachmentIdToString : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Altinn2AttachmentId",
+                schema: "correspondence",
+                table: "Attachments",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Altinn2AttachmentId",
+                schema: "correspondence",
+                table: "Attachments",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Make Altinn2attachmentid a string so that we can prefix it

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- None.
- **Refactor**
	- Updated the type of the Altinn2AttachmentId property from integer to string across the application and database schema.
- **Tests**
	- Adjusted tests to use string values for Altinn2AttachmentId, ensuring compatibility with the updated property type.
- **Chores**
	- Added a database migration to change the Altinn2AttachmentId column type to string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->