### PR TITLE
Legacy download should use same tokens as normal for Dialogporten

### DIFF
--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/DownloadCorrespondenceAttachmentHandler.cs
@@ -116,7 +116,8 @@ public class DownloadCorrespondenceAttachmentHandler(
                 DialogportenActorType.ServiceOwner, 
                 DialogportenTextType.DownloadStarted,  
                 attachment.DisplayName ?? attachment.FileName,
-                request.AttachmentId.ToString()));
+                request.AttachmentId.ToString(),
+                DateTime.Now.ToString()));
             return new DownloadCorrespondenceAttachmentResponse()
             {
                 FileName = attachment.FileName,

--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
@@ -46,7 +46,7 @@ public class LegacyDownloadCorrespondenceAttachmentHandler(
             return CorrespondenceErrors.CorrespondenceNotFound;
         }
         var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, attachment.StorageProvider, cancellationToken);
-        backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(request.CorrespondenceId, DialogportenActorType.Recipient, DialogportenTextType.DownloadStarted, attachment.DisplayName ?? attachment.FileName));
+        backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(request.CorrespondenceId, DialogportenActorType.Recipient, DialogportenTextType.DownloadStarted, attachment.Id.ToString()));
         return new DownloadCorrespondenceAttachmentResponse()
         {
             FileName = attachment.FileName,

--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
@@ -46,7 +46,7 @@ public class LegacyDownloadCorrespondenceAttachmentHandler(
             return CorrespondenceErrors.CorrespondenceNotFound;
         }
         var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, attachment.StorageProvider, cancellationToken);
-        backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(request.CorrespondenceId, DialogportenActorType.Recipient, DialogportenTextType.DownloadStarted, attachment.Id.ToString()));
+        backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateInformationActivity(request.CorrespondenceId, DialogportenActorType.Recipient, DialogportenTextType.DownloadStarted, attachment.DisplayName ?? attachment.FileName, attachment.Id.ToString(), DateTime.Now.ToString()));
         return new DownloadCorrespondenceAttachmentResponse()
         {
             FileName = attachment.FileName,

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -177,6 +177,11 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
                 logger.LogError("Invalid attachment ID token for download activity on correspondence {correspondenceId}", correspondenceId);
                 throw new ArgumentException("Invalid attachment ID token", nameof(tokens));
             }
+
+            if (tokens[2] is not null)
+            {
+                createDialogActivityRequest.CreatedAt = DateTime.Parse(tokens[2]);
+            }
             
             if (correspondence.Statuses.Count(s => s.Status == CorrespondenceStatus.AttachmentsDownloaded && s.StatusText.Contains(attachmentId.ToString())) >= 2)
             {

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -177,10 +177,17 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
                 logger.LogError("Invalid attachment ID token for download activity on correspondence {correspondenceId}", correspondenceId);
                 throw new ArgumentException("Invalid attachment ID token", nameof(tokens));
             }
-
-            if (tokens[2] is not null)
+            
+            if (tokens.Length > 2 && tokens[2] is not null)
             {
-                createDialogActivityRequest.CreatedAt = DateTime.Parse(tokens[2]);
+                if (DateTime.TryParse(tokens[2], out DateTime createdAt))
+                {
+                    createDialogActivityRequest.CreatedAt = createdAt;
+                }
+                else
+                {
+                    logger.LogWarning("Invalid timestamp format in token[2] for correspondence {correspondenceId}: {timestamp}", correspondenceId, tokens[2]);
+                }
             }
             
             if (correspondence.Statuses.Count(s => s.Status == CorrespondenceStatus.AttachmentsDownloaded && s.StatusText.Contains(attachmentId.ToString())) >= 2)


### PR DESCRIPTION
## Description
Legacy download needs to pass in the same tokens to ensure same behaviour

## Related Issue(s)
- #993 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced activity logging to include timestamps when downloading attachments.
  - Improved tracking details for correspondence attachment downloads by adding creation date information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->