### PR TITLE
If no idempotency key exists, create one

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -260,7 +260,15 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
 
         if (idempotencyKey == null)
         {
-            throw new InvalidOperationException($"No idempotency key found for open dialog activity on correspondence {correspondenceId}");
+            idempotencyKey = await _idempotencyKeyRepository.CreateAsync(
+                new IdempotencyKeyEntity
+                {
+                    Id = Uuid.NewDatabaseFriendly(Database.PostgreSql),
+                    CorrespondenceId = correspondence.Id,
+                    AttachmentId = null, // No attachment for opened activity
+                    StatusAction = StatusAction.Fetched
+                },
+                cancellationToken);
         }
 
         var createDialogActivityRequest = CreateDialogActivityRequestMapper.CreateDialogActivityRequest(correspondence, actorType, null, Models.ActivityType.DialogOpened);


### PR DESCRIPTION
## Description
If no idempotency key exists, create one. This occurs with all correspondences created before we added the Idempotency code.

## Related Issue(s)
- #993 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when an idempotency key is missing during activity creation, ensuring the process completes successfully without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->