### PR TITLE
Make Altinn 2 id for migrated correspondences available in Altinn 3 correspondence

### DIFF
--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceDetailsMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceDetailsMapper.cs
@@ -32,6 +32,7 @@ internal static class CorrespondenceDetailsMapper
             PropertyList = correspondenceDetails.PropertyList,
             Published = correspondenceDetails.Published,
             IsConfirmationNeeded = correspondenceDetails.IsConfirmationNeeded,
+            Altinn2CorrespondenceId = correspondenceDetails.Altinn2CorrespondenceId
         };
         return Correspondence;
     }

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceOverviewMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceOverviewMapper.cs
@@ -31,6 +31,7 @@ internal static class CorrespondenceOverviewMapper
             IgnoreReservation = correspondenceOverview.IgnoreReservation,
             Published = correspondenceOverview.Published,
             IsConfirmationNeeded = correspondenceOverview.IsConfirmationNeeded,
+            Altinn2CorrespondenceId = correspondenceOverview.Altinn2CorrespondenceId
         };
         return Correspondence;
     }

--- a/src/Altinn.Correspondence.API/Models/CorrespondenceOverviewExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceOverviewExt.cs
@@ -56,5 +56,11 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("notifications")]
         public List<CorrespondenceNotificationOverview> Notifications { get; set; } = new List<CorrespondenceNotificationOverview>();
+
+        /// <summary>
+        /// The identifier/reference from Altinn 2 for migrated correspondence. Will be null for correspondence created in Altinn 3.
+        /// </summary>
+        [JsonPropertyName("altinn2CorrespondenceId")]
+        public int? Altinn2CorrespondenceId { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
@@ -49,4 +49,6 @@ public class GetCorrespondenceDetailsResponse
     public DateTimeOffset? Published { get; internal set; }
 
     public bool IsConfirmationNeeded { get; set; }
+
+    public int? Altinn2CorrespondenceId { get; set; }
 }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
@@ -48,6 +48,8 @@ public class GetCorrespondenceOverviewResponse
     public DateTimeOffset? Published { get; set; }
 
     public bool IsConfirmationNeeded { get; set; }
+
+    public int? Altinn2CorrespondenceId { get; set; }
 }
 
 public class CorrespondenceNotificationOverview {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added Altinn2CorrespondenceId to CorrespondenceOverviewExt and updated related mappers.

## Related Issue(s)
- #548 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
