### PR TITLE
updated unit tests to account for updates to correspondence ID and at…

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/MigrateAttachmentBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/MigrateAttachmentBuilder.cs
@@ -23,7 +23,7 @@ namespace Altinn.Correspondence.Tests.Factories
                 DisplayName = "Test file",
                 IsEncrypted = false,
                 SenderPartyUuid = new Guid("EBF0DA78-DB7C-4087-9711-2C64DB201EB1"),
-                Altinn2AttachmentId = "R1",
+                Altinn2AttachmentId = "SS" + new Random().Next().ToString(),
                 Created = new DateTimeOffset(new DateTime(2025, 5, 1))
             };
             return this;

--- a/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
@@ -22,7 +22,7 @@ namespace Altinn.Correspondence.Tests.Factories
             _migratedCorrespondence = new()
             {
                 CorrespondenceData = basicCorrespondence,
-                Altinn2CorrespondenceId = 99911,
+                Altinn2CorrespondenceId = (new Random().Next()),
                 EventHistory =
             [
                 new MigrateCorrespondenceStatusEventExt()


### PR DESCRIPTION
Updated unit tests to account for updated code related to correspondence ID and attachment Id.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated CorrespondenceBuilder to always generate a random correspondence Id.
Update AttachmentBuilder to always generate a random attachment Id.
Updated Attachment Unittests to account for change in attachment handling.

## Related Issue(s)
- #123 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test logic to ensure that submitting the same attachment twice with the same identifier now returns a successful response and the same attachment ID, instead of a conflict error.
  - Removed a redundant test for consecutive attachment submissions without an identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->