### PR TITLE
Moved validation of reply options into application code to enable migration of old correspondences

### DIFF
--- a/src/Altinn.Correspondence.API/Models/BaseCorrespondenceExt.cs
+++ b/src/Altinn.Correspondence.API/Models/BaseCorrespondenceExt.cs
@@ -86,7 +86,7 @@ namespace Altinn.Correspondence.API.Models
         /// Options for how the recipient can reply to the Correspondence
         /// </summary>
         [JsonPropertyName("replyOptions")]
-        public List<CorrespondenceReplyOptionExt> ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionExt>();
+        public List<CorrespondenceReplyOptionExt>? ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionExt>();
 
         /// <summary>
         /// Notifications related to the Correspondence.

--- a/src/Altinn.Correspondence.API/Models/CorrespondenceReplyOptionExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceReplyOptionExt.cs
@@ -21,42 +21,5 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("linkText")]
         public string? LinkText { get; set; }
-
-        [AttributeUsage(AttributeTargets.Property)]
-        internal class IsLinkAttribute : ValidationAttribute
-        {
-            private const int maxLength = 255;
-            private const string httpsPrefix = "https://";
-            private const string httpPrefix = "http://";
-            public IsLinkAttribute()
-            {
-
-            }
-
-            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
-            {
-                if (value is not string strValue)
-                {
-                    return new ValidationResult("LinkURL is not of type string");
-                }
-                if (strValue.Length > maxLength)
-                {
-                    return new ValidationResult($"LinkURL  must not exceed {maxLength} characters");
-                }
-                if (!Uri.IsWellFormedUriString((string)value, UriKind.Absolute))
-                {
-                    return new ValidationResult("LinkURL is not a valid URL");
-                }
-                if (strValue.StartsWith(httpPrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    return new ValidationResult("LinkURL must use HTTPS");
-                }
-                if (!strValue.StartsWith(httpsPrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    return new ValidationResult($"LinkURL must start with {httpsPrefix}");
-                }
-                return ValidationResult.Success;
-            }
-        }
     }
 }

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -37,6 +37,7 @@ public static class CorrespondenceErrors
     public static Error RecipientReserved(string recipientId) => new Error(1030, $"Recipient {recipientId} has reserved themselves from public correspondences. Can be overridden using the 'IgnoreReservation' flag.", HttpStatusCode.UnprocessableEntity);
     public static Error AttachmentNotAvailableForRecipient = new(1031, "Attachment is not available for recipient, latest status of correspondence is not in [Published, Fetched, Read, Replied, Confirmed, Archived, Reserved, AttachmentsDownloaded]", HttpStatusCode.BadRequest);
     public static Error ContactReservationRegistryFailed = new Error(1032, "Contact reservation registry lookup failed", HttpStatusCode.InternalServerError);
+    public static Error InvalidReplyOptions = new Error(1033, "Reply options must be well-formed URIs and HTTPS with a max length of 255 characters", HttpStatusCode.BadRequest);
 }
 
 public static class AttachmentErrors

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -464,5 +464,25 @@ namespace Altinn.Correspondence.Application.Helpers
             }
             return await attachmentRepository.InitializeAttachment(attachment, cancellationToken);
         }
+
+        public Error? ValidateReplyOptions(List<CorrespondenceReplyOptionEntity> replyOptions)
+        {
+            foreach(var replyOption in replyOptions)
+            {
+                if (replyOption.LinkURL.Length > 255)
+                {
+                    return CorrespondenceErrors.InvalidReplyOptions;
+                }
+                if (!Uri.IsWellFormedUriString((string)replyOption.LinkURL, UriKind.Absolute))
+                {
+                    return CorrespondenceErrors.InvalidReplyOptions;
+                }
+                if (!replyOption.LinkURL.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                {
+                    return CorrespondenceErrors.InvalidReplyOptions;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -123,6 +123,13 @@ public class InitializeCorrespondencesHandler(
             return attachmentMetaDataError;
         }
 
+        // Validate reply options
+        var replyOptionsError = initializeCorrespondenceHelper.ValidateReplyOptions(request.Correspondence.ReplyOptions);
+        if (attachmentMetaDataError != null && !)
+        {
+            return replyOptionsError;
+        }
+
         // Gather attachments for the correspondence
         var attachmentsToBeUploaded = new List<AttachmentEntity>();
         if (uploadAttachmentMetadata.Count > 0)


### PR DESCRIPTION
## Description
Moved validation of reply options into application code to enable migration of old correspondences. This is not an ideal solution. We should use separate API models for all migration endpoints. We should look into doing such a re-factor if more problems like this occur.

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
