### PR TITLE
Add partyid to enable migration of self-registered users' correspondences

### DIFF
--- a/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceEntity.cs
+++ b/src/Altinn.Correspondence.Core/Models/Entities/CorrespondenceEntity.cs
@@ -11,6 +11,7 @@ namespace Altinn.Correspondence.Core.Models.Entities
     [Index(nameof(Created))]
     [Index(nameof(IsMigrating))]
     [Index(nameof(Altinn2CorrespondenceId), IsUnique = true)]
+    [Index(nameof(PartyId))]
     public class CorrespondenceEntity
     {
         [Key]
@@ -70,5 +71,7 @@ namespace Altinn.Correspondence.Core.Models.Entities
         public bool IsConfirmationNeeded { get; set; }
 
         public bool IsMigrating { get; set; }
+
+        public int PartyId { get; set; } = 0;
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Migrations/20250523085516_AddPartyId.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20250523085516_AddPartyId.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Altinn.Correspondence.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250523085516_AddPartyId")]
+    partial class AddPartyId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20250523085516_AddPartyId.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20250523085516_AddPartyId.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPartyId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PartyId",
+                schema: "correspondence",
+                table: "Correspondences",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Correspondences_PartyId",
+                schema: "correspondence",
+                table: "Correspondences",
+                column: "PartyId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Correspondences_PartyId",
+                schema: "correspondence",
+                table: "Correspondences");
+
+            migrationBuilder.DropColumn(
+                name: "PartyId",
+                schema: "correspondence",
+                table: "Correspondences");
+        }
+    }
+}


### PR DESCRIPTION
## Description
Add partyid to enable migration of self-registered users' correspondences. This has the added benefit of laying the groundwork for more optimized legacy search function.

## Related Issue(s)
- #1014 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new field for Party ID to correspondence records, allowing for improved filtering and sorting.
- **Performance**
	- Introduced an index on the Party ID field to enhance query performance when accessing correspondence data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->