### PR TITLE
Give Legacy.GetOverview Access to IsMigrating correspondences

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
@@ -135,8 +135,8 @@ public class MigrationAccessTests : MigrationTestBase
         var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
         Assert.True(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
 
-        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}");
-        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
+        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
+        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
     }
 
     [Fact]

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
@@ -32,7 +32,7 @@ public class MigrationAccessTests : MigrationTestBase
     }
 
     [Fact]
-    public async Task LegacyGetCorrespondences_IsMigratingTrue_WithFilterEnabled__NoCorrespondenceFound()
+    public async Task LegacyGetCorrespondences_IsMigratingTrue_WithFilterEnabled__NoCorrespondenceFoundInList_OverviewFound()
     {
         // Arrange
         MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
@@ -47,14 +47,17 @@ public class MigrationAccessTests : MigrationTestBase
         var createdCorrespondenceId = result.CorrespondenceId;
 
         var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", GetBasicLegacyGetCorrespondenceRequestExt());
-        Assert.True(correspondenceList.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
+        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
 
         var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
         Assert.False(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
+
+        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
+        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
     }
 
     [Fact]
-    public async Task LegacyGetCorrespondences_IsMigratingFalse_WithFilterEnabled__NoCorrespondenceFound()
+    public async Task LegacyGetCorrespondences_IsMigratingFalse_WithFilterEnabled__NoCorrespondenceFoundInList_OverviewFound()
     {
         // Arrange
         MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
@@ -70,14 +73,17 @@ public class MigrationAccessTests : MigrationTestBase
         var createdCorrespondenceId = result.CorrespondenceId;
 
         var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", GetBasicLegacyGetCorrespondenceRequestExt());
-        Assert.True(correspondenceList.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
+        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
 
         var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
         Assert.False(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
+
+        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
+        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
     }
 
     [Fact]
-    public async Task LegacyGetCorrespondences_IsMigratingTrue_WithFilterDisabled__CorrespondenceFound()
+    public async Task LegacyGetCorrespondences_IsMigratingTrue_WithFilterDisabled__CorrespondenceFoundInList_OverviewFound()
     {
         // Arrange
         MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
@@ -95,14 +101,17 @@ public class MigrationAccessTests : MigrationTestBase
         request.FilterMigrated = false;
 
         var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", request);
-        Assert.True(correspondenceList.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
+        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
 
         var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
         Assert.True(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
+
+        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
+        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
     }
 
     [Fact]
-    public async Task LegacyGetCorrespondences_IsMigratingFalse_WithFilterDisabled__CorrespondenceFound()
+    public async Task LegacyGetCorrespondences_IsMigratingFalse_WithFilterDisabled__CorrespondenceFoundInList_OverviewFound()
     {
         // Arrange
         MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
@@ -121,10 +130,13 @@ public class MigrationAccessTests : MigrationTestBase
         request.FilterMigrated = false;
 
         var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", request);
-        Assert.True(correspondenceList.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
+        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
 
         var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
         Assert.True(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
+
+        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}");
+        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
     }
 
     [Fact]

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -33,7 +33,7 @@ public class LegacyGetCorrespondenceOverviewHandler(
         {
             return AuthorizationErrors.CouldNotFindOrgNo;
         }
-        var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, false, cancellationToken);
+        var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, false, cancellationToken, true);
         if (correspondence == null)
         {
             return CorrespondenceErrors.CorrespondenceNotFound;


### PR DESCRIPTION
Changed filtering behavior of IsMigrating for LegacyController.GetOverview so that it always returns an Correspondence, despite the IsMigrating value.

Toggable filtering is already handled in the GetFiles call, an so adding another parameter to the Overrview seemed redundant. Also fixed some minor mistakes in MigrationAccessTests.

In any case, this filtering is for testing purposes only,.

## Related Issue(s)
- #753 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved test coverage by adding validation to ensure the correspondence overview is accessible immediately after creation in various migration scenarios.
	- Corrected test assertions to accurately check for successful responses from the overview endpoint.

- **Tests**
	- Enhanced test methods with additional steps to verify the existence and accessibility of correspondence overviews, improving reliability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->