### PR TITLE
Added logic to stop overview when correspondence is purged

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceDeletionTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceDeletionTests.cs
@@ -121,7 +121,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 var correspondenceId = correspondence.CorrespondenceId;
                 var response = await _senderClient.DeleteAsync($"correspondence/api/v1/correspondence/{correspondenceId}/purge");
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                var overviewResponse = await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceResponse.Correspondences.FirstOrDefault().CorrespondenceId}");
+                var overviewResponse = await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}");
                 Assert.Equal(HttpStatusCode.NotFound, overviewResponse.StatusCode);
             }
 

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceDeletionTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceDeletionTests.cs
@@ -36,8 +36,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, recipientResponse.StatusCode);
             Assert.Equal(HttpStatusCode.OK, senderResponse.StatusCode);
-            var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{correspondenceResponse.Correspondences.FirstOrDefault().CorrespondenceId}", _responseSerializerOptions);
-            Assert.Equal(overview?.Status, CorrespondenceStatusExt.PurgedByAltinn);
+            var overviewResponse = await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceResponse.Correspondences.FirstOrDefault().CorrespondenceId}");
+            Assert.Equal(HttpStatusCode.NotFound, overviewResponse.StatusCode);
         }
 
         [Fact]
@@ -57,8 +57,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, senderResponse.StatusCode);
             Assert.Equal(HttpStatusCode.OK, recipientResponse.StatusCode);
-            var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{correspondenceResponse.Correspondences.FirstOrDefault().CorrespondenceId}", _responseSerializerOptions);
-            Assert.Equal(overview?.Status, CorrespondenceStatusExt.PurgedByRecipient);
+            var overviewResponse = await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceResponse.Correspondences.FirstOrDefault().CorrespondenceId}");
+            Assert.Equal(HttpStatusCode.NotFound, overviewResponse.StatusCode);
         }
 
         [Fact]
@@ -121,8 +121,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 var correspondenceId = correspondence.CorrespondenceId;
                 var response = await _senderClient.DeleteAsync($"correspondence/api/v1/correspondence/{correspondenceId}/purge");
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{correspondenceId}", _responseSerializerOptions);
-                Assert.Equal(overview?.Status, CorrespondenceStatusExt.PurgedByAltinn);
+                var overviewResponse = await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceResponse.Correspondences.FirstOrDefault().CorrespondenceId}");
+                Assert.Equal(HttpStatusCode.NotFound, overviewResponse.StatusCode);
             }
 
             // Assert

--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacyDeletionTests.cs
@@ -33,8 +33,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
-            var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{correspondence.CorrespondenceId}", _serializerOptions);
-            Assert.Equal(CorrespondenceStatusExt.PurgedByRecipient, overview.Status);
+            var overviewResponse = await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{correspondence.CorrespondenceId}");
+            Assert.Equal(HttpStatusCode.NotFound, overviewResponse.StatusCode);
         }
 
         [Fact]
@@ -50,8 +50,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
-            var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{correspondence.CorrespondenceId}", _serializerOptions);
-            Assert.Equal(CorrespondenceStatusExt.PurgedByRecipient, overview.Status);
+            var overviewResponse = await _senderClient.GetAsync($"correspondence/api/v1/correspondence/{correspondence.CorrespondenceId}");
+            Assert.Equal(HttpStatusCode.NotFound, overviewResponse.StatusCode);
         }
 
         [Fact]

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -46,8 +46,7 @@ public class GetCorrespondenceOverviewHandler(
             return CorrespondenceErrors.CorrespondenceNotFound;
         }
 
-        var purgedStatus = correspondence.GetPurgedStatus();
-        if (purgedStatus != null)
+        if (correspondence.GetPurgedStatus() != null)
         {
             logger.LogWarning("Access denied - correspondence has been purged");
             return CorrespondenceErrors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -45,6 +45,14 @@ public class GetCorrespondenceOverviewHandler(
             logger.LogWarning("Latest status not found for correspondence");
             return CorrespondenceErrors.CorrespondenceNotFound;
         }
+
+        var purgedStatus = correspondence.GetPurgedStatus();
+        if (purgedStatus != null)
+        {
+            logger.LogWarning("Access denied - correspondence has been purged");
+            return CorrespondenceErrors.CorrespondenceNotFound;
+        }
+
         var party = await altinnRegisterService.LookUpPartyById(user.GetCallerOrganizationId(), cancellationToken);
         if (party?.PartyUuid is not Guid partyUuid)
         {


### PR DESCRIPTION
## Description
Stops the overiview endpoint after a correspondence has been purged and updated tests to check for the new functionality.

## Related Issue(s)
- #990 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of purged correspondence by blocking access and displaying a "Correspondence Not Found" error when attempting to access purged items.
	- Updated deletion verification to confirm deleted correspondences are no longer accessible, showing a "Not Found" status instead of a purged status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->