### PR TITLE
Corrected so that Legacy implementation can perform all actions on mi…

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
@@ -32,86 +32,7 @@ public class MigrationAccessTests : MigrationTestBase
     }
 
     [Fact]
-    public async Task LegacyGetCorrespondences_IsMigratingTrue_WithFilterEnabled__NoCorrespondenceFoundInList_OverviewFound()
-    {
-        // Arrange
-        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
-            .CreateMigrateCorrespondence()
-            .Build();
-
-        // Act
-        var initializeCorrespondenceResponse = await _migrationClient.PostAsJsonAsync("correspondence/api/v1/migration/correspondence", migrateCorrespondenceExt);
-        Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
-
-        CorrespondenceMigrationStatusExt? result = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<CorrespondenceMigrationStatusExt>(_responseSerializerOptions);
-        var createdCorrespondenceId = result.CorrespondenceId;
-
-        var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", GetBasicLegacyGetCorrespondenceRequestExt());
-        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
-
-        var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
-        Assert.False(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
-
-        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
-        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
-    }
-
-    [Fact]
-    public async Task LegacyGetCorrespondences_IsMigratingFalse_WithFilterEnabled__NoCorrespondenceFoundInList_OverviewFound()
-    {
-        // Arrange
-        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
-            .CreateMigrateCorrespondence()
-            .WithIsMigrating(false)
-            .Build();
-
-        // Act
-        var initializeCorrespondenceResponse = await _migrationClient.PostAsJsonAsync("correspondence/api/v1/migration/correspondence", migrateCorrespondenceExt);
-        Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
-
-        CorrespondenceMigrationStatusExt? result = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<CorrespondenceMigrationStatusExt>(_responseSerializerOptions);
-        var createdCorrespondenceId = result.CorrespondenceId;
-
-        var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", GetBasicLegacyGetCorrespondenceRequestExt());
-        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
-
-        var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
-        Assert.False(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
-
-        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
-        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
-    }
-
-    [Fact]
-    public async Task LegacyGetCorrespondences_IsMigratingTrue_WithFilterDisabled__CorrespondenceFoundInList_OverviewFound()
-    {
-        // Arrange
-        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
-            .CreateMigrateCorrespondence()
-            .Build();
-
-        // Act
-        var initializeCorrespondenceResponse = await _migrationClient.PostAsJsonAsync("correspondence/api/v1/migration/correspondence", migrateCorrespondenceExt);
-        Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
-
-        CorrespondenceMigrationStatusExt? result = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<CorrespondenceMigrationStatusExt>(_responseSerializerOptions);
-        var createdCorrespondenceId = result.CorrespondenceId;
-
-        var request = GetBasicLegacyGetCorrespondenceRequestExt();
-        request.FilterMigrated = false;
-
-        var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", request);
-        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
-
-        var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
-        Assert.True(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
-
-        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
-        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
-    }
-
-    [Fact]
-    public async Task LegacyGetCorrespondences_IsMigratingFalse_WithFilterDisabled__CorrespondenceFoundInList_OverviewFound()
+    public async Task LegacyLifeCycle_IsMigratingFalse_WithFilterDisabled__OK()
     {
         // Arrange
         MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
@@ -137,6 +58,153 @@ public class MigrationAccessTests : MigrationTestBase
 
         var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
         Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
+
+        var correspondenceHistory = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/history");
+        Assert.True(correspondenceHistory.IsSuccessStatusCode, await correspondenceHistory.Content.ReadAsStringAsync());
+
+        var markAsReadResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/markasread", null);
+        Assert.True(markAsReadResponse.IsSuccessStatusCode, await markAsReadResponse.Content.ReadAsStringAsync());
+
+        var confirmResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/confirm", null);
+        Assert.True(confirmResponse.IsSuccessStatusCode, await confirmResponse.Content.ReadAsStringAsync());
+
+        var archiveResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/archive", null);
+        Assert.True(archiveResponse.IsSuccessStatusCode, await archiveResponse.Content.ReadAsStringAsync());
+
+        var purgeResponse = await _legacyClient.DeleteAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/purge");
+        Assert.True(purgeResponse.IsSuccessStatusCode, await purgeResponse.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task LegacyLifeCycle_IsMigratingFalse_WithFilterEnabled__NotFoundInList_RestOK()
+    {
+        // Arrange
+        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
+            .CreateMigrateCorrespondence()
+            .WithIsMigrating(false)
+            .Build();
+
+        // Act
+        var initializeCorrespondenceResponse = await _migrationClient.PostAsJsonAsync("correspondence/api/v1/migration/correspondence", migrateCorrespondenceExt);
+        Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
+
+        CorrespondenceMigrationStatusExt? result = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<CorrespondenceMigrationStatusExt>(_responseSerializerOptions);
+        var createdCorrespondenceId = result.CorrespondenceId;
+
+        var correspondenceListRequest = GetBasicLegacyGetCorrespondenceRequestExt();
+        correspondenceListRequest.FilterMigrated = true;
+
+        var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", correspondenceListRequest);
+        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
+
+        var correspondenceListResponse = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);        
+        Assert.False(correspondenceListResponse?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
+
+        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
+        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
+
+        var correspondenceHistory = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/history");
+        Assert.True(correspondenceHistory.IsSuccessStatusCode, await correspondenceHistory.Content.ReadAsStringAsync());
+
+        var markAsReadResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/markasread", null);
+        Assert.True(markAsReadResponse.IsSuccessStatusCode, await markAsReadResponse.Content.ReadAsStringAsync());
+
+        var confirmResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/confirm", null);
+        Assert.True(confirmResponse.IsSuccessStatusCode, await confirmResponse.Content.ReadAsStringAsync());
+
+        var archiveResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/archive", null);
+        Assert.True(archiveResponse.IsSuccessStatusCode, await archiveResponse.Content.ReadAsStringAsync());
+
+        var purgeResponse = await _legacyClient.DeleteAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/purge");
+        Assert.True(purgeResponse.IsSuccessStatusCode, await purgeResponse.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task LegacyLifeCycle_IsMigratingTrue_WithFilterDisabled__OK()
+    {
+        // Arrange
+        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
+            .CreateMigrateCorrespondence()
+            .WithIsMigrating(true)
+            .Build();
+
+        // Act
+        var initializeCorrespondenceResponse = await _migrationClient.PostAsJsonAsync("correspondence/api/v1/migration/correspondence", migrateCorrespondenceExt);
+        Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
+
+        CorrespondenceMigrationStatusExt? result = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<CorrespondenceMigrationStatusExt>(_responseSerializerOptions);
+        var createdCorrespondenceId = result.CorrespondenceId;
+
+        var request = GetBasicLegacyGetCorrespondenceRequestExt();
+        request.FilterMigrated = false;
+
+        var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", request);
+        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
+
+        var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
+        Assert.True(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
+
+        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
+        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
+
+        var correspondenceHistory = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/history");
+        Assert.True(correspondenceHistory.IsSuccessStatusCode, await correspondenceHistory.Content.ReadAsStringAsync());
+
+        var markAsReadResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/markasread", null);
+        Assert.True(markAsReadResponse.IsSuccessStatusCode, await markAsReadResponse.Content.ReadAsStringAsync());
+
+        var confirmResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/confirm", null);
+        Assert.True(confirmResponse.IsSuccessStatusCode, await confirmResponse.Content.ReadAsStringAsync());
+
+        var archiveResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/archive", null);
+        Assert.True(archiveResponse.IsSuccessStatusCode, await archiveResponse.Content.ReadAsStringAsync());
+
+        var purgeResponse = await _legacyClient.DeleteAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/purge");
+        Assert.True(purgeResponse.IsSuccessStatusCode, await purgeResponse.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task LegacyLifeCycle_IsMigratingTrue_WithFilterEnabled__NotFoundInList_RestOK()
+    {
+        // Arrange
+        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
+            .CreateMigrateCorrespondence()
+            .WithIsMigrating(true)
+            .Build();
+
+        // Act
+        var initializeCorrespondenceResponse = await _migrationClient.PostAsJsonAsync("correspondence/api/v1/migration/correspondence", migrateCorrespondenceExt);
+        Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
+
+        CorrespondenceMigrationStatusExt? result = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<CorrespondenceMigrationStatusExt>(_responseSerializerOptions);
+        var createdCorrespondenceId = result.CorrespondenceId;
+
+        var request = GetBasicLegacyGetCorrespondenceRequestExt();
+        request.FilterMigrated = true;
+
+        var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", request);
+        Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
+
+        var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
+        Assert.False(response?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
+
+        var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
+        Assert.True(correspondenceOverview.IsSuccessStatusCode, await correspondenceOverview.Content.ReadAsStringAsync());
+
+        var correspondenceHistory = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/history");
+        Assert.True(correspondenceHistory.IsSuccessStatusCode, await correspondenceHistory.Content.ReadAsStringAsync());
+
+        var markAsReadResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/markasread", null);
+        Assert.True(markAsReadResponse.IsSuccessStatusCode, await markAsReadResponse.Content.ReadAsStringAsync());
+
+        var confirmResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/confirm", null);
+        Assert.True(confirmResponse.IsSuccessStatusCode, await confirmResponse.Content.ReadAsStringAsync());
+
+        var archiveResponse = await _legacyClient.PostAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/archive", null);
+        Assert.True(archiveResponse.IsSuccessStatusCode, await archiveResponse.Content.ReadAsStringAsync());
+
+        var purgeResponse = await _legacyClient.DeleteAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/purge");
+        Assert.True(purgeResponse.IsSuccessStatusCode, await purgeResponse.Content.ReadAsStringAsync());
     }
 
     [Fact]

--- a/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadCorrespondenceAttachment/LegacyDownloadCorrespondenceAttachmentHandler.cs
@@ -30,7 +30,7 @@ public class LegacyDownloadCorrespondenceAttachmentHandler(
             return AuthorizationErrors.CouldNotFindOrgNo;
         }
         // TODO: Authorize party
-        var correspondence = await correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, false, cancellationToken);
+        var correspondence = await correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, false, cancellationToken, true);
         if (correspondence is null)
         {
             return CorrespondenceErrors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceHistory/LegacyGetCorrespondenceHistoryHandler.cs
@@ -26,7 +26,7 @@ public class LegacyGetCorrespondenceHistoryHandler(
         {
             return AuthorizationErrors.CouldNotFindOrgNo;
         }
-        var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, true, cancellationToken);
+        var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, true, cancellationToken, true);
         if (correspondence is null)
         {
             return CorrespondenceErrors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/LegacyPurgeCorrespondenceHandler.cs
@@ -29,7 +29,7 @@ public class LegacyPurgeCorrespondenceHandler(
         {
             return AuthorizationErrors.CouldNotFindOrgNo;
         }
-        var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, false, false, cancellationToken);
+        var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, false, false, cancellationToken, true);
         if (correspondence == null)
         {
             return CorrespondenceErrors.CorrespondenceNotFound;

--- a/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateCorrespondenceStatus/LegacyUpdateCorrespondenceStatusHandler.cs
@@ -26,7 +26,7 @@ public class LegacyUpdateCorrespondenceStatusHandler(
         {
             return AuthorizationErrors.CouldNotFindOrgNo;
         }
-        var correspondence = await correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, false, cancellationToken);
+        var correspondence = await correspondenceRepository.GetCorrespondenceById(request.CorrespondenceId, true, false, false, cancellationToken, true);
         if (correspondence == null)
         {
             return CorrespondenceErrors.CorrespondenceNotFound;


### PR DESCRIPTION
Corrected so that Legacy implementation can perform all actions on migrated correspondences despite IsMigrating status, not just Overview.

Re-wrote MigrationAccessTests to contain lifecycle-tests for Legacy to confirm.

## Related Issue(s)
- #753 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
