### PR TITLE
Fixed bug where storage provider was not used with batch attachment download

### DIFF
--- a/src/Altinn.Correspondence.Core/Repositories/IAttachmentRepository.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IAttachmentRepository.cs
@@ -7,7 +7,6 @@ namespace Altinn.Correspondence.Core.Repositories
     {
         Task<AttachmentEntity> InitializeAttachment(AttachmentEntity attachment, CancellationToken cancellationToken);
         Task<List<Guid>> InitializeMultipleAttachments(List<AttachmentEntity> attachments, CancellationToken cancellationToken);
-        Task<AttachmentEntity?> GetAttachmentByUrl(string url, CancellationToken cancellationToken);
         Task<AttachmentEntity?> GetAttachmentById(Guid attachmentId, bool includeStatus = false, CancellationToken cancellationToken = default);
         Task<bool> SetDataLocationUrl(AttachmentEntity attachmentEntity, AttachmentDataLocationType attachmentDataLocationType, string dataLocationUrl, StorageProviderEntity? storageProvider, CancellationToken cancellationToken);
         Task<AttachmentEntity> GetAttachmentByAltinn2Id(string altinn2Id, CancellationToken cancellationToken);

--- a/src/Altinn.Correspondence.Persistence/Repositories/AttachmentRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/AttachmentRepository.cs
@@ -23,11 +23,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
             return attachments.Select(a => a.Id).ToList();
         }
 
-        public async Task<AttachmentEntity?> GetAttachmentByUrl(string url, CancellationToken cancellationToken)
-        {
-            return await _context.Attachments.SingleOrDefaultAsync(a => a.DataLocationUrl == url, cancellationToken);
-        }
-
         public async Task<AttachmentEntity> GetAttachmentByAltinn2Id(string altinn2Id, CancellationToken cancellationToken)
         {
             return await _context.Attachments.SingleAsync(a => a.Altinn2AttachmentId == altinn2Id, cancellationToken);
@@ -40,6 +35,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
             {
                 attachments = attachments.Include(a => a.Statuses);
             }
+            attachments = attachments.Include(a => a.StorageProvider);
             return await attachments.SingleOrDefaultAsync(a => a.Id == guid, cancellationToken);
         }
 


### PR DESCRIPTION
## Description
Fixed bug where storage provider was not used with batch attachment download. It used a different repository function to retrieve correspondence. 
Also removed unused function.

## Related Issue(s)
- #1032 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
