### PR TITLE
Remove service owner access to content post-publish

### DIFF
--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceContentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceContentMapper.cs
@@ -6,8 +6,19 @@ namespace Altinn.Correspondence.Mappers;
 
 internal static class CorrespondenceContentMapper
 {
-    internal static CorrespondenceContentExt MapToExternal(CorrespondenceContentEntity correspondenceContent)
+    internal static CorrespondenceContentExt MapToExternal(CorrespondenceContentEntity? correspondenceContent)
     {
+        if (correspondenceContent is null)
+        {
+            return new CorrespondenceContentExt
+            {
+                Language = "no",
+                MessageSummary = string.Empty,
+                MessageTitle = string.Empty,
+                MessageBody = string.Empty,
+                Attachments = new List<CorrespondenceAttachmentExt>(),
+            };
+        }
         var content = new CorrespondenceContentExt
         {
             Language = correspondenceContent.Language,

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -99,7 +99,7 @@ public class GetCorrespondenceDetailsHandler(
                 MessageSender = correspondence.MessageSender ?? string.Empty,
                 Created = correspondence.Created,
                 Recipient = correspondence.Recipient,
-                Content = correspondence.Content!,
+                Content = hasAccessAsRecipient || !correspondence.StatusHasBeen(CorrespondenceStatus.Published) ? correspondence.Content : null,
                 ReplyOptions = correspondence.ReplyOptions ?? new List<CorrespondenceReplyOptionEntity>(),
                 Notifications = notificationStatus,
                 StatusHistory = correspondence.Statuses

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
@@ -24,7 +24,7 @@ public class GetCorrespondenceDetailsResponse
 
     public string Recipient { get; set; } = string.Empty;
 
-    public required CorrespondenceContentEntity Content { get; set; }
+    public CorrespondenceContentEntity? Content { get; set; }
 
     public List<CorrespondenceReplyOptionEntity> ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionEntity>();
 

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -90,7 +90,7 @@ public class GetCorrespondenceOverviewHandler(
             var response = new GetCorrespondenceOverviewResponse
             {
                 CorrespondenceId = correspondence.Id,
-                Content = correspondence.Content,
+                Content = hasAccessAsRecipient || !correspondence.StatusHasBeen(CorrespondenceStatus.Published) ? correspondence.Content : null,
                 Status = latestStatus.Status,
                 StatusText = latestStatus.StatusText,
                 StatusChanged = latestStatus.StatusChanged,

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
@@ -25,7 +25,7 @@ public class GetCorrespondenceOverviewResponse
 
     public string Recipient { get; set; } = string.Empty;
 
-    public required CorrespondenceContentEntity Content { get; set; }
+    public CorrespondenceContentEntity? Content { get; set; }
 
     public List<CorrespondenceReplyOptionEntity> ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionEntity>();
 


### PR DESCRIPTION
## Description
After publish the correspondence belongs to the recipient and its contents should no longer be available to the service owner.

## Related Issue(s)
- #559 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
