### PR TITLE
Bug in service owner lookup from resource registry

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/ResourceRegistryService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/ResourceRegistry/ResourceRegistryService.cs
@@ -102,7 +102,7 @@ public class ResourceRegistryService : IResourceRegistryService
 
     private string GetNameOfResourceResponse(GetResourceResponse resourceResponse)
     {
-        var nameAttributes = new List<string> { "en", "nb-no", "nn-no" };
+        var nameAttributes = new List<string> { "en", "nb", "nn" };
         string? name = null;
         foreach (var nameAttribute in nameAttributes)
         {


### PR DESCRIPTION
## Description
Make language nameAttributes consistent with values in the resource registry. Without this bugfix it's impossible to authorize for services without an English entry in the hasCompetentAuthority record in the resource definition.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
