### PR TITLE
Update GetCorrespondenceDetails to show Notification History for Altinn 2 Correspondences

### DIFF
--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -80,17 +80,23 @@ public class GetCorrespondenceDetailsHandler(
                     notificationDetails.IsReminder = notification.IsReminder;
                     notificationStatus.Add(notificationDetails);
                 }
+                // If notification does not have a shipmentId, and also has no NotificationOrderId, it's probably an Altinn2Notification.
+                else if (notification.ShipmentId == null && notification.Altinn2NotificationId != null)
+                {
+                    notificationStatus.Add(await notificationMapper.MapAltinn2NotificationToAltinn3NotificationStatus(notification));
+                }
                 // If the notification has a shipmentId, it is a version 2 notification
                 else if (notification.ShipmentId is not null)
                 {
                     var notificationDetails = await altinnNotificationService.GetNotificationDetailsV2(notification.ShipmentId.ToString(), cancellationToken);
                     notificationStatus.Add(await notificationMapper.MapNotificationV2ToV1Async(notificationDetails, notification));
-                } 
+                }
             }
 
             var response = new GetCorrespondenceDetailsResponse
             {
                 CorrespondenceId = correspondence.Id,
+                Altinn2CorrespondenceId = correspondence.Altinn2CorrespondenceId,
                 Status = latestStatus.Status,
                 StatusText = latestStatus.StatusText,
                 StatusChanged = latestStatus.StatusChanged,

--- a/src/Altinn.Correspondence.Application/Helpers/NotificationMapper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/NotificationMapper.cs
@@ -13,6 +13,28 @@ public class NotificationMapper
         _resourceRegistryService = resourceRegistryService;
     }
 
+    public async Task<NotificationStatusResponse> MapAltinn2NotificationToAltinn3NotificationStatus(CorrespondenceNotificationEntity notification)
+    {
+        var correspondence = notification.Correspondence ?? throw new ArgumentException($"Correspondence with id {notification.CorrespondenceId} not found when mapping notification", nameof(notification));
+
+        return new NotificationStatusResponse
+        {
+            SendersReference = null,
+            RequestedSendTime = notification.RequestedSendTime.DateTime,
+            Created = notification.Created.DateTime,
+            Creator = correspondence?.ResourceId != null ? await _resourceRegistryService.GetServiceOwnerOrgCode(correspondence.ResourceId) : "Not found",
+            IsReminder = notification.IsReminder,
+            NotificationChannel = notification.NotificationChannel,
+            ResourceId = correspondence.ResourceId,
+            IgnoreReservation = correspondence.IgnoreReservation ?? false,
+            ProcessingStatus = new StatusExt
+            {
+                Status = "Completed",
+                LastUpdate = notification.NotificationSent.Value.UtcDateTime
+            }
+        };
+    }
+
     public async Task<NotificationStatusResponse> MapNotificationV2ToV1Async(NotificationStatusResponseV2 notificationDetails, CorrespondenceNotificationEntity notification)
     {
         var correspondence = notification.Correspondence ?? throw new ArgumentException($"Correspondence with id {notification.CorrespondenceId} not found when mapping notification", nameof(notification));
@@ -80,7 +102,7 @@ public class NotificationMapper
                     },
                     Succeeded = latestSmsRecipient?.Status == "SMS_Delivered"
                 } : null,
-                Emails = emailRecipients!= null && emailRecipients.Count != 0 ? [.. emailRecipients.Select(r => new EmailNotificationWithResult
+                Emails = emailRecipients != null && emailRecipients.Count != 0 ? [.. emailRecipients.Select(r => new EmailNotificationWithResult
                 {
                     Recipient = new Recipient
                     {
@@ -92,8 +114,8 @@ public class NotificationMapper
                         LastUpdate = r.LastUpdate.DateTime
                     },
                     Succeeded = r.Status == "Email_Delivered"
-                })]: null,
-                Smses = smsRecipients!= null && smsRecipients.Count != 0 ? [.. smsRecipients.Select(r => new SmsNotificationWithResult
+                })] : null,
+                Smses = smsRecipients != null && smsRecipients.Count != 0 ? [.. smsRecipients.Select(r => new SmsNotificationWithResult
                 {
                     Recipient = new Recipient
                     {
@@ -105,7 +127,7 @@ public class NotificationMapper
                         LastUpdate = r.LastUpdate.DateTime
                     },
                     Succeeded = r.Status == "SMS_Delivered"
-                })]: null,
+                })] : null,
             }
         };
     }


### PR DESCRIPTION
Altinn 2 Correspondences did not show Altinn 2 NotificationHistory.
Changed GetcorrespondenceDetails to show them.

## Description
Updated GetCorrespondenceDetails with a new If test when testing what kind of Notifications are connected to correspondences.
If they are Altinn 2 Correspondences, created a new Mapping function to map Altinn 2 Notifications to the external status object.
Altinn2CorrespondenceId Property existed in the GetCorrespondenceDetails result object, but was never populated.
Changed code to also populate this value.

## Related Issue(s)
- #1030 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying notifications originating from Altinn 2 when viewing correspondence details.
  - The correspondence details view now includes the Altinn2 correspondence ID, if available.

- **Bug Fixes**
  - Improved formatting and readability in some areas of the notification mapping logic.

- **Tests**
  - Introduced new tests to verify that Altinn 2 notifications are correctly included and displayed in correspondence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->