### PR TITLE
Fix flaky tests caused by failure to get distributed lock

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
 using System.Net.Http.Headers;
 using System.Security.Claims;
@@ -41,6 +42,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             services.AddHangfire(config =>
                            config.UseMemoryStorage()
                        );
+            services.RemoveAll<IRecurringJobManager>();
+            services.AddSingleton(new Mock<IRecurringJobManager>().Object);
             HangfireBackgroundJobClient = new Mock<IBackgroundJobClient>();
             HangfireBackgroundJobClient.Setup(x => x.Create(
                 It.IsAny<Job>(),


### PR DESCRIPTION
## Description
Our tests frequently fail with an error like:
`Hangfire.Storage.DistributedLockTimeoutException : Timeout expired. The timeout elapsed prior to obtaining a distributed lock on the 'lock:recurring-job:Update IP restrictions to apimIp and current EventGrid IPs' resource.`

We do not need Hangfire's recurring job manager, hence I replace it with a no-op mock.

## Related Issue(s)
- #1053

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
