### PR TITLE
Added altinn 2 notificationinfo to LegacyGetCorrespondenceHistory

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/Base/MigrationTestBase.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/Base/MigrationTestBase.cs
@@ -9,12 +9,18 @@ public class MigrationTestBase
 {
     internal readonly CustomWebApplicationFactory _factory;
     internal readonly HttpClient _migrationClient;
+    internal readonly HttpClient _legacyClient;
+    public readonly string _partyIdClaim = "urn:altinn:partyid";
+    public readonly int _digdirPartyId = 50952483;
     internal readonly JsonSerializerOptions _responseSerializerOptions;
 
     public MigrationTestBase(CustomWebApplicationFactory factory)
     {
         _factory = factory;
         _migrationClient = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.MigrateScope));
+        _legacyClient = _factory.CreateClientWithAddedClaims(
+                ("scope", AuthorizationConstants.LegacyScope),
+                (_partyIdClaim, _digdirPartyId.ToString()));
         _responseSerializerOptions = new JsonSerializerOptions(new JsonSerializerOptions()
         {
             PropertyNameCaseInsensitive = true


### PR DESCRIPTION
Added Altinn 2 migrated notifications to LegacyGetCorrespondenceHistory.

## Description
Previous changes only added Altinn 2 notifications to GetcorrespondenceDetails.
It should also be added to LegacyGetcorrespondenceHistory.
Added code that converts each Altinn 2 Notification History object to a CorrespondenceHistory object.

## Related Issue(s)
- #1030 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for legacy notifications, ensuring notifications identified by a new property are now included in correspondence history.
- **Tests**
  - Added new tests to verify that legacy notifications are correctly included in correspondence details and history.
  - Refactored test setup for notification history to reduce code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->