### PR TITLE
polly retries for network calls

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Common/HttpRetryPolicyTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Common/HttpRetryPolicyTests.cs
@@ -1,10 +1,8 @@
 using System.Net;
-using System.Text;
 using Altinn.Correspondence.Common.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
-using Xunit;
 
 namespace Altinn.Correspondence.Tests.Common;
 

--- a/Test/Altinn.Correspondence.Tests/Common/HttpRetryPolicyTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Common/HttpRetryPolicyTests.cs
@@ -1,0 +1,240 @@
+using System.Net;
+using System.Text;
+using Altinn.Correspondence.Common.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Altinn.Correspondence.Tests.Common;
+
+public class HttpRetryPolicyTests
+{
+    private readonly Mock<ILogger> _mockLogger;
+    private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+    private readonly HttpClient _httpClient;
+
+    public HttpRetryPolicyTests()
+    {
+        _mockLogger = new Mock<ILogger>();
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_mockHttpMessageHandler.Object)
+        {
+            BaseAddress = new Uri("https://example.com")
+        };
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldRetryOnTransientFailures()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount < 3)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(3, callCount);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldFailAfterMaxRetries()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
+        Assert.Equal(4, callCount);
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldNotRetryOnNonTransientFailures()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)); // Non-transient failure
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+        Assert.Equal(1, callCount);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task StandardRetryPolicy_ShouldRetryOnSpecificTransientFailures(HttpStatusCode statusCode)
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount < 2)
+                {
+                    return Task.FromResult(new HttpResponseMessage(statusCode));
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldRetryOnHttpRequestException()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount < 2)
+                {
+                    throw new HttpRequestException("Network error");
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldRetryOnTaskCanceledException()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount < 2)
+                {
+                    throw new TaskCanceledException("Request timeout");
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(2, callCount);
+    }
+} 

--- a/src/Altinn.Correspondence.API/Altinn.Correspondence.API.csproj
+++ b/src/Altinn.Correspondence.API/Altinn.Correspondence.API.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.10" />     
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
     <PackageReference Include="Microsoft.Identity.Web" Version="3.8.0" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />

--- a/src/Altinn.Correspondence.Application/Altinn.Correspondence.Application.csproj
+++ b/src/Altinn.Correspondence.Application/Altinn.Correspondence.Application.csproj
@@ -9,10 +9,10 @@
   <ItemGroup>
       <PackageReference Include="Hangfire.Core" Version="1.8.18" />
       <PackageReference Include="libphonenumber-csharp" Version="8.13.55" />
-      <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.2" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
       <PackageReference Include="OneOf" Version="3.0.271" />
       <PackageReference Include="Markdig" Version="0.40.0" />
       <PackageReference Include="Polly" Version="8.6.0" />

--- a/src/Altinn.Correspondence.Application/Altinn.Correspondence.Application.csproj
+++ b/src/Altinn.Correspondence.Application/Altinn.Correspondence.Application.csproj
@@ -15,7 +15,7 @@
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
       <PackageReference Include="OneOf" Version="3.0.271" />
       <PackageReference Include="Markdig" Version="0.40.0" />
-      <PackageReference Include="Polly" Version="8.5.2" />
+      <PackageReference Include="Polly" Version="8.6.0" />
       <PackageReference Include="ReverseMarkdown" Version="4.6.0" />
       <PackageReference Include="Slack.Webhooks" Version="1.1.5" />
     </ItemGroup>

--- a/src/Altinn.Correspondence.Common/Altinn.Correspondence.Common.csproj
+++ b/src/Altinn.Correspondence.Common/Altinn.Correspondence.Common.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
     <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
+    <PackageReference Include="Polly" Version="8.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Altinn.Correspondence.Common/Altinn.Correspondence.Common.csproj
+++ b/src/Altinn.Correspondence.Common/Altinn.Correspondence.Common.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
     <PackageReference Include="Polly" Version="8.6.0" />

--- a/src/Altinn.Correspondence.Common/Helpers/HttpClientBuilderExtensions.cs
+++ b/src/Altinn.Correspondence.Common/Helpers/HttpClientBuilderExtensions.cs
@@ -1,0 +1,72 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Polly;
+
+namespace Altinn.Correspondence.Common.Helpers;
+
+/// <summary>
+/// Extension methods for configuring HttpClient with retry policies
+/// </summary>
+public static class HttpClientBuilderExtensions
+{
+    /// <summary>
+    /// Adds standard retry policy to HttpClient
+    /// </summary>
+    public static IHttpClientBuilder AddStandardRetryPolicy(this IHttpClientBuilder builder)
+    {
+        return builder.AddPolicyHandler((services, request) =>
+        {
+            var loggerFactory = services.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("HttpRetryPolicies");
+            return GetStandardRetryPolicy(logger);
+        });
+    }
+
+    /// <summary>
+    /// A standard retry policy for HTTP operations; 3 retry attempts with 100ms delay between attempts
+    /// </summary>
+    public static IAsyncPolicy<HttpResponseMessage> GetStandardRetryPolicy(ILogger logger)
+    {
+        return Policy
+            .HandleResult<HttpResponseMessage>(r => !r.IsSuccessStatusCode && IsTransientFailure(r.StatusCode))
+            .Or<HttpRequestException>()
+            .Or<TaskCanceledException>()
+            .WaitAndRetryAsync(
+                retryCount: 3,
+                sleepDurationProvider: retryAttempt => TimeSpan.FromMilliseconds(100),
+                onRetry: (outcome, timespan, retryCount, context) =>
+                {
+                    var exception = outcome.Exception;
+                    var result = outcome.Result;
+                    
+                    if (exception != null)
+                    {
+                        logger.LogWarning("HTTP request attempt {RetryCount} failed with exception: {Exception}. Retrying in {Delay}ms", 
+                            retryCount, exception.Message, timespan.TotalMilliseconds);
+                    }
+                    else if (result != null)
+                    {
+                        logger.LogWarning("HTTP request attempt {RetryCount} failed with status {StatusCode}. Retrying in {Delay}ms", 
+                            retryCount, result.StatusCode, timespan.TotalMilliseconds);
+                    }
+                });
+    }
+
+    /// <summary>
+    /// Determines if an HTTP status code indicates a transient failure
+    /// </summary>
+    private static bool IsTransientFailure(HttpStatusCode statusCode)
+    {
+        return statusCode switch
+        {
+            HttpStatusCode.RequestTimeout => true,
+            HttpStatusCode.TooManyRequests => true,
+            HttpStatusCode.InternalServerError => true,
+            HttpStatusCode.BadGateway => true,
+            HttpStatusCode.ServiceUnavailable => true,
+            HttpStatusCode.GatewayTimeout => true,
+            _ => false
+        };
+    }
+} 

--- a/src/Altinn.Correspondence.Common/Helpers/HttpClientBuilderExtensions.cs
+++ b/src/Altinn.Correspondence.Common/Helpers/HttpClientBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class HttpClientBuilderExtensions
     }
 
     /// <summary>
-    /// A standard retry policy for HTTP operations; 3 retry attempts with 100ms delay between attempts
+    /// A standard retry policy for HTTP operations; 3 retry attempts with exponential backoff (50ms, 100ms, 200ms)
     /// </summary>
     public static IAsyncPolicy<HttpResponseMessage> GetStandardRetryPolicy(ILogger logger)
     {
@@ -34,7 +34,7 @@ public static class HttpClientBuilderExtensions
             .Or<TaskCanceledException>()
             .WaitAndRetryAsync(
                 retryCount: 3,
-                sleepDurationProvider: retryAttempt => TimeSpan.FromMilliseconds(100),
+                sleepDurationProvider: retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(2, retryAttempt) * 50),
                 onRetry: (outcome, timespan, retryCount, context) =>
                 {
                     var exception = outcome.Exception;

--- a/src/Altinn.Correspondence.Core/Altinn.Correspondence.Core.csproj
+++ b/src/Altinn.Correspondence.Core/Altinn.Correspondence.Core.csproj
@@ -13,10 +13,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.Correspondence.Integrations/Altinn.Correspondence.Integrations.csproj
+++ b/src/Altinn.Correspondence.Integrations/Altinn.Correspondence.Integrations.csproj
@@ -20,12 +20,12 @@
     <PackageReference Include="Hangfire.Core" Version="1.8.18" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.10" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
     <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />

--- a/src/Altinn.Correspondence.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Integrations/DependencyInjection.cs
@@ -70,7 +70,7 @@ public static class DependencyInjection
         }
         else
         {
-            services.AddHttpClient<SlackClient>()
+            services.AddHttpClient(nameof(SlackClient))
                 .AddStandardRetryPolicy();
             services.AddSingleton<ISlackClient>(serviceProvider =>
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Httpclient calls might occationaly fail from transient issues. This PR adds a extension method to httpClientBuilder which adds a retry policy for transient failures. Currently it is set to retry up to 3 times with a backoff (50ms, 100ms, 200ms). The httpClients in the integration project are registered to use the retrypolicy in the dependencyInjection.

## Related Issue(s)
- #700 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a standard retry policy for HTTP clients, improving resilience against transient network errors.
  - Added a new extension to easily apply retry policies to HTTP client registrations.

- **Bug Fixes**
  - Enhanced error handling for HTTP requests by automatically retrying on specific transient failures.

- **Chores**
  - Upgraded several third-party dependencies to the latest patch versions.
  - Added and updated package references to support improved HTTP resilience.

- **Tests**
  - Added comprehensive unit tests to verify HTTP retry policy behavior under various failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->