### PR TITLE
Set storage provider on attachment during migrate

### DIFF
--- a/src/Altinn.Correspondence.Application/MigrateCorrespondenceAttachment/MigrateAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondenceAttachment/MigrateAttachmentHandler.cs
@@ -41,6 +41,7 @@ public class MigrateAttachmentHandler(
                 request.Attachment.DataLocationUrl = uploadResult.AsT0.DataLocationUrl;
                 request.Attachment.Checksum = uploadResult.AsT0.Checksum;
                 request.Attachment.AttachmentSize = uploadResult.AsT0.Size;
+                request.Attachment.StorageProvider = uploadResult.AsT0.StorageProviderEntity;
             }
             try
             {

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondenceAttachment/MigrateAttachmentHelper.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondenceAttachment/MigrateAttachmentHelper.cs
@@ -39,7 +39,7 @@ namespace Altinn.Correspondence.Application.MigrateCorrespondenceAttachment
             return storageProvider;
         }
 
-        public async Task<OneOf<(string DataLocationUrl, string? Checksum, long Size), Error>> UploadAttachment(MigrateAttachmentRequest request, Guid partyUuid, CancellationToken cancellationToken)
+        public async Task<OneOf<(string DataLocationUrl, string? Checksum, long Size, StorageProviderEntity StorageProviderEntity), Error>> UploadAttachment(MigrateAttachmentRequest request, Guid partyUuid, CancellationToken cancellationToken)
         {
             logger.LogInformation("Start upload of attachment {AttachmentId} for party {PartyUuid}", request.Attachment.Id, partyUuid);
             try
@@ -48,7 +48,7 @@ namespace Altinn.Correspondence.Application.MigrateCorrespondenceAttachment
                 var (dataLocationUrl, checksum, size) = await storageRepository.UploadAttachment(request.Attachment, request.UploadStream, provider, cancellationToken);
                 logger.LogInformation("Finished uploaded {AttachmentId} to Azure Storage", request.Attachment.Id);
 
-                return (dataLocationUrl, checksum, size);
+                return (dataLocationUrl, checksum, size, provider);
             }
             catch (DataLocationUrlException)
             {


### PR DESCRIPTION
## Description
Set storage provider when attachment is created in database

- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking the storage provider information for migrated attachments. This information is now included with each attachment after a successful upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->