### PR TITLE
Return errorCode in problemDetails

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
@@ -29,17 +29,15 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// Only required if the attachment is to be shared, otherwise this is done as part of the Initialize Correspondence operation
     /// </remarks>
     /// <response code="200">Returns the attachment id</response>
-    /// <response code="400">
-    /// <ul>
-    /// <li>Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService. </li>
-    /// <li>Could not retrieve party uuid from lookup in Altinn Register </li>
-    /// <li>Filename is missing</li>
-    /// <li>Filename is too long</li>
-    /// <li>Filename contains invalid characters</li>
-    /// <li>Filetype not allowed</li>
-    /// </ul>
-    /// </response>
-    /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+    /// <response code="400"><ul>
+    /// <li>2010: Filename is missing</li>
+    /// <li>2011: Filename is too long</li>
+    /// <li>2012: Filename contains invalid characters</li>
+    /// <li>2013: Filetype not allowed</li>
+    /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register </li>
+    /// <li>4009: Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService. </li>
+    /// </ul></response>
+    /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
     [HttpPost]
     [Consumes("application/json")]
     [Produces("application/json")]
@@ -70,19 +68,17 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <response code="200">Returns attachment metadata</response>
-    /// <response code="400">
-    /// <ul>
-    /// <li>File must have content and has a max file size of 250 MB</li>
-    /// <li>File has already been or is being uploaded</li>
-    /// <li>Cannot upload attachment to a correspondence that has been created</li>
-    /// <li>Could not retrieve party uuid from lookup in Altinn Register</li>
-    /// <li>Could not get data location url</li>  
-    /// <li>Checksum mismatch</li>
-    /// </ul>
-    /// </response>
-    /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-    /// <response code="404">The requested attachment was not found</response>
-    /// <response code="502">Error occurred during upload</response>
+    /// <response code="400"><ul>
+    /// <li>2003: Cannot upload attachment to a correspondence that has been created</li>
+    /// <li>2004: File must have content and has a max file size of 250 MB</li>
+    /// <li>2005: File has already been or is being uploaded</li>
+    /// <li>2008: Checksum mismatch</li>
+    /// <li>2009: Could not get data location url</li>
+    /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li>
+    /// </ul></response>
+    /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+    /// <response code="404">2001: The requested attachment was not found</response>
+    /// <response code="502">2002: Error occurred during upload</response>
     [HttpPost]
     [Produces("application/json")]
     [Route("{attachmentId}/upload")]
@@ -128,8 +124,8 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <response code="200">Returns attachment metadata</response>
-    /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-    /// <response code="404">The requested attachment was not found</response>
+    /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+    /// <response code="404">2001: The requested attachment was not found</response>
     [HttpGet]
     [Route("{attachmentId}")]
     [Produces("application/json")]
@@ -160,8 +156,8 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <response code="200">Returns attachment metadata</response>
-    /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-    /// <response code="404">The requested attachment was not found</response>
+    /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+    /// <response code="404">2001: The requested attachment was not found</response>
     [HttpGet]
     [Produces("application/json")]
     [ProducesResponseType(typeof(AttachmentDetailsExt), StatusCodes.Status200OK)]
@@ -193,15 +189,13 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <response code="200">Returns no data</response>
-    /// <response code="400">
-    /// <ul> 
-    /// <li>File has already been purged</li>
-    /// <li>Attachment cannot be purged as it is linked to at least one existing correspondence</li>
-    /// <li>Could not retrieve party uuid from lookup in Altinn Register</li>
-    /// </ul>
-    /// </response>
-    /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-    /// <response code="404">The requested attachment was not found</response>
+    /// <response code="400"><ul> 
+    /// <li>2006: File has already been purged</li>
+    /// <li>2007: Attachment cannot be purged as it is linked to at least one existing correspondence</li>
+    /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li>
+    /// </ul></response>
+    /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+    /// <response code="404">2001: The requested attachment was not found</response>
     [HttpDelete]
     [Route("{attachmentId}")]
     [Produces("application/json")]
@@ -232,8 +226,8 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// - altinn:correspondence.write <br/>
     /// </remarks>
     /// <response code="200">Returns the attachment</response>
-    /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-    /// <response code="404">The requested attachment was not found</response>
+    /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+    /// <response code="404">2001: The requested attachment was not found</response>
     [HttpGet]
     [Produces("application/octet-stream")]
     [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK)]
@@ -255,5 +249,8 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
             Problem
         );
     }
-    private ActionResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
+    private ActionResult Problem(Error error) => Problem(
+        detail: error.Message, 
+        statusCode: (int)error.StatusCode, 
+        extensions: new Dictionary<string, object?> { { "errorCode", error.ErrorCode } });
 }

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -33,53 +33,67 @@ namespace Altinn.Correspondence.API.Controllers
         }
 
         /// <summary>
-        /// Initialize Correspondences
+        /// Initialize Correspondences and uploads attachments in the same request
         /// </summary>
         /// <remarks>
-        /// One of the scopes: <br/>/>
+        /// One of the scopes: <br/>
         /// - altinn:correspondence.write <br />
         /// Requires uploads of specified attachments if any before it can be Published
         /// </remarks>
         /// <response code="200">Returns metadata about the initialized correspondence</response>
         /// <response code="400"><ul>
-        /// <li>Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService</li>
-        /// <li>Could not retrieve party uuid from lookup in Altinn Register</li>
-        /// <li>Recipients must be unique</li>
-        /// <li>DueDateTime is required when confirmation is needed</li>
-        /// <li>DueDateTime cannot be prior to today</li>
-        /// <li>DueDateTime cannot be prior to RequestedPublishTime</li>
-        /// <li>AllowSystemDelete cannot be prior to today</li>
-        /// <li>AllowSystemDelete cannot be prior to RequestedPublishTime</li>
-        /// <li>The Content field must be provided for the correspondence</li>
-        /// <li>Message title cannot be empty</li>
-        /// <li>Message title must be plain text</li>
-        /// <li>Message body cannot be empty</li>
-        /// <li>Message body must be markdown</li>
-        /// <li>Message summary cannot be empty</li>
-        /// <li>Message summary must be markdown</li>
-        /// <li>Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)</li>
-        /// <li>Recipient overrides with email or mobile number are not allowed when using notification recipient name because of name lookup</li>
-        /// <li>Could not find recipient with id: {id} to override</li>
-        /// <li>No recipients provided for one or more recipient overrides</li>
-        /// <li>Missing email information for custom recipient. Add email or use the OrganizationNumber or NationalIdentityNumber fields for contact information</li>
-        /// <li>Missing mobile number for custom recipient. Add mobile number or use the OrganizationNumber or NationalIdentityNumber fields for contact information</li>
-        /// <li>Organization number cannot be combined with email address, mobile number, or national identity number</li>
-        /// <li>National identity number cannot be combined with email address, mobile number, or organization number.</li>
-        /// <li>Invalid email provided for custom recipient</li>
-        /// <li>Invalid mobile number provided. Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard</li>
-        /// <li>Mismatch between uploaded files and attachment metadata</li>
-        /// <li>File must have content and has a max file size of 250 MB</li>
-        /// <li>The sender of the correspondence must be equal the sender of existing attachments</li>
-        /// <li>Existing attachment not found</li>
-        /// <li>Attachment is not published</li>
+        /// <li>1002: Message title must be plain text</li>
+        /// <li>1003: Message body must be markdown</li>
+        /// <li>1004: Message summary must be markdown</li>
+        /// <li>1006: Recipients must be unique</li>
+        /// <li>1007: Existing attachment not found</li>
+        /// <li>1008: DueDateTime cannot be prior to today</li>
+        /// <li>1009: DueDateTime cannot be prior to RequestedPublishTime</li>
+        /// <li>1010: AllowSystemDelete cannot be prior to today</li>
+        /// <li>1011: AllowSystemDelete cannot be prior to RequestedPublishTime</li>
+        /// <li>1012: AllowSystemDelete cannot be prior to DueDateTime</li>
+        /// <li>1013: Sender cannot delete correspondence that has been published</li>
+        /// <li>1016: DueDateTime is required when confirmation is needed</li>
+        /// <li>1017: The sender of the correspondence must be equal the sender of existing attachments</li>
+        /// <li>1018: Attachment is not published</li>
+        /// <li>1019: The Content field must be provided for the correspondence</li>
+        /// <li>1020: Message title cannot be empty</li>
+        /// <li>1021: Message body cannot be empty</li>
+        /// <li>1023: Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)</li>
+        /// <li>1033: The idempotency key must be a valid non-empty GUID</li>
+        /// <li>1035: Reply options must be well-formed URIs and HTTPS with a max length of 255 characters</li>
+        /// <li>3001: The requested notification template with the given language was not found</li>
+        /// <li>3002: Email body and subject must be provided when sending email notifications</li>
+        /// <li>3003: Reminder email body and subject must be provided when sending reminder email notifications</li>
+        /// <li>3004: SMS body must be provided when sending SMS notifications</li>
+        /// <li>3005: Reminder SMS body must be provided when sending reminder SMS notifications</li>
+        /// <li>3006: Email body, subject and SMS body must be provided when sending preferred notifications</li>
+        /// <li>3007: Reminder email body, subject and SMS body must be provided when sending reminder preferred notifications</li>
+        /// <li>3011: Invalid email provided for custom recipient</li>
+        /// <li>3012: Invalid mobile number provided. Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard</li>
+        /// <li>3015: Recipient overrides with email or mobile number are not allowed when using notification recipient name because of name lookup</li>
+        /// <li>3017: Custom recipient with multiple recipients is not allowed</li>
+        /// <li>3018: Custom recipient with multiple identifiers is not allowed</li>
+        /// <li>3019: Custom recipient without identifier is not allowed</li>
+        /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li>
+        /// <li>4009: Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService</li>
         /// </ul></response>
-        /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-        /// <response code="403">Resource not whitelisted. Contact us on Slack or servicedesk@altinn.no</response>
+        /// <response code="401"><ul>
+        /// <li>4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</li>
+        /// </ul></response>
+        /// <response code="403"><ul>
+        /// <li>4008: Resource not whitelisted. Contact us on Slack or servicedesk@altinn.no</li>
+        /// </ul></response>
         /// <response code="404"><ul>
-        /// <li>Could not find partyId for the following recipients: {recipients}</li> 
-        /// <li>The requested notification template with the given language was not found</li>
+        /// <li>1029: Could not find partyId for the following recipients: {recipients}</li>
+        /// <li>3001: The requested notification template with the given language was not found</li>
         /// </ul></response>
-        /// <response code="422">Recipient {recipientId} has reserved themselves from public correspondences. Can be overridden using the 'IgnoreReservation' flag</response>
+        /// <response code="409"><ul>
+        /// <li>1034: A correspondence with the same idempotent key already exists</li>
+        /// </ul></response>
+        /// <response code="422"><ul>
+        /// <li>1030: Recipient {recipientId} has reserved themselves from public correspondences. Can be overridden using the 'IgnoreReservation' flag</li>
+        /// </ul></response>
         [HttpPost]
         [Consumes("application/json")]
         [Produces("application/json")]
@@ -112,48 +126,75 @@ namespace Altinn.Correspondence.API.Controllers
         /// </summary>
         /// <remarks>
         /// One of the scopes: <br/>
-        /// - altinn:correspondence.write
+        /// - altinn:correspondence.write <br />
+        /// Requires uploads of specified attachments if any before it can be Published
         /// </remarks>
         /// <response code="200">Returns metadata about the initialized correspondence</response>
         /// <response code="400"><ul>
-        /// <li>Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService</li>
-        /// <li>Could not retrieve party uuid from lookup in Altinn Register</li>
-        /// <li>Recipients must be unique</li>
-        /// <li>DueDateTime is required when confirmation is needed</li>
-        /// <li>DueDateTime cannot be prior to today</li>
-        /// <li>DueDateTime cannot be prior to RequestedPublishTime</li>
-        /// <li>AllowSystemDelete cannot be prior to today</li>
-        /// <li>AllowSystemDelete cannot be prior to RequestedPublishTime</li>
-        /// <li>The Content field must be provided for the correspondence</li>
-        /// <li>Message title cannot be empty</li>
-        /// <li>Message title must be plain text</li>
-        /// <li>Message body cannot be empty</li>
-        /// <li>Message body must be markdown</li>
-        /// <li>Message summary cannot be empty</li>
-        /// <li>Message summary must be markdown</li>
-        /// <li>Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)</li>
-        /// <li>Recipient overrides with email or mobile number are not allowed when using notification recipient name because of name lookup</li>
-        /// <li>Could not find recipient with id: {id} to override</li>
-        /// <li>No recipients provided for one or more recipient overrides</li>
-        /// <li>Missing email information for custom recipient. Add email or use the OrganizationNumber or NationalIdentityNumber fields for contact information</li>
-        /// <li>Missing mobile number for custom recipient. Add mobile number or use the OrganizationNumber or NationalIdentityNumber fields for contact information</li>
-        /// <li>Organization number cannot be combined with email address, mobile number, or national identity number</li>
-        /// <li>National identity number cannot be combined with email address, mobile number, or organization number.</li>
-        /// <li>Invalid email provided for custom recipient</li>
-        /// <li>Invalid mobile number provided. Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard</li>
-        /// <li>Mismatch between uploaded files and attachment metadata</li>
-        /// <li>File must have content and has a max file size of 250 MB</li>
-        /// <li>The sender of the correspondence must be equal the sender of existing attachments</li>
-        /// <li>Existing attachment not found</li>
-        /// <li>Attachment is not published</li>
+        /// <li>1002: Message title must be plain text</li>
+        /// <li>1003: Message body must be markdown</li>
+        /// <li>1004: Message summary must be markdown</li>
+        /// <li>1005: Mismatch between uploaded files and attachment metadata</li>
+        /// <li>1006: Recipients must be unique</li>
+        /// <li>1007: Existing attachment not found</li>
+        /// <li>1008: DueDateTime cannot be prior to today</li>
+        /// <li>1009: DueDateTime cannot be prior to RequestedPublishTime</li>
+        /// <li>1010: AllowSystemDelete cannot be prior to today</li>
+        /// <li>1011: AllowSystemDelete cannot be prior to RequestedPublishTime</li>
+        /// <li>1012: AllowSystemDelete cannot be prior to DueDateTime</li>
+        /// <li>1013: Sender cannot delete correspondence that has been published</li>
+        /// <li>1016: DueDateTime is required when confirmation is needed</li>
+        /// <li>1017: The sender of the correspondence must be equal the sender of existing attachments</li>
+        /// <li>1018: Attachment is not published</li>
+        /// <li>1019: The Content field must be provided for the correspondence</li>
+        /// <li>1020: Message title cannot be empty</li>
+        /// <li>1021: Message body cannot be empty</li>
+        /// <li>1023: Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)</li>
+        /// <li>1033: The idempotency key must be a valid non-empty GUID</li>
+        /// <li>1035: Reply options must be well-formed URIs and HTTPS with a max length of 255 characters</li>
+        /// <li>2001: The requested attachment was not found</li>
+        /// <li>2004: File must have content and has a max file size of 250 MB</li>
+        /// <li>2008: Checksum mismatch</li>
+        /// <li>2009: Could not get data location url</li>
+        /// <li>2010: Filename is missing</li>
+        /// <li>2011: Filename is too long</li>
+        /// <li>2012: Filename contains invalid characters</li>
+        /// <li>2013: Filetype not allowed</li>
+        /// <li>3001: The requested notification template with the given language was not found</li>
+        /// <li>3002: Email body and subject must be provided when sending email notifications</li>
+        /// <li>3003: Reminder email body and subject must be provided when sending reminder email notifications</li>
+        /// <li>3004: SMS body must be provided when sending SMS notifications</li>
+        /// <li>3005: Reminder SMS body must be provided when sending reminder SMS notifications</li>
+        /// <li>3006: Email body, subject and SMS body must be provided when sending preferred notifications</li>
+        /// <li>3007: Reminder email body, subject and SMS body must be provided when sending reminder preferred notifications</li>
+        /// <li>3011: Invalid email provided for custom recipient</li>
+        /// <li>3012: Invalid mobile number provided. Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard</li>
+        /// <li>3015: Recipient overrides with email or mobile number are not allowed when using notification recipient name because of name lookup</li>
+        /// <li>3017: Custom recipient with multiple recipients is not allowed</li>
+        /// <li>3018: Custom recipient with multiple identifiers is not allowed</li>
+        /// <li>3019: Custom recipient without identifier is not allowed</li>
+        /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li>
+        /// <li>4009: Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService</li>
         /// </ul></response>
-        /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-        /// <response code="403">Resource not whitelisted. Contact us on Slack or servicedesk@altinn.no</response>
+        /// <response code="401"><ul>
+        /// <li>4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</li>
+        /// </ul></response>
+        /// <response code="403"><ul>
+        /// <li>4008: Resource not whitelisted. Contact us on Slack or servicedesk@altinn.no</li>
+        /// </ul></response>
         /// <response code="404"><ul>
-        /// <li>Could not find partyId for the following recipients: {recipients}</li> 
-        /// <li>The requested notification template with the given language was not found</li>
+        /// <li>1029: Could not find partyId for the following recipients: {recipients}</li>
+        /// <li>3001: The requested notification template with the given language was not found</li>
         /// </ul></response>
-        /// <response code="422">Recipient {recipientId} has reserved themselves from public correspondences. Can be overridden using the 'IgnoreReservation' flag</response>
+        /// <response code="409"><ul>
+        /// <li>1034: A correspondence with the same idempotent key already exists</li>
+        /// </ul></response>
+        /// <response code="422"><ul>
+        /// <li>1030: Recipient {recipientId} has reserved themselves from public correspondences. Can be overridden using the 'IgnoreReservation' flag</li>
+        /// </ul></response>
+        /// <response code="502"><ul>
+        /// <li>2002: Error occurred during upload</li>
+        /// </ul></response>
         [HttpPost]
         [Route("upload")]
         [Consumes("multipart/form-data")]
@@ -196,9 +237,9 @@ namespace Altinn.Correspondence.API.Controllers
         /// Mostly for use by recipients and occasional status checks
         /// </remarks>
         /// <response code="200">Returns an overview of metadata about the published correspondence</response>
-        /// <response code="400">Could not retrieve party uuid from lookup in Altinn Register</response>
-        /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-        /// <response code="404">The requested correspondence was not found</response>
+        /// <response code="400">4002: Could not retrieve party uuid from lookup in Altinn Register</response>
+        /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+        /// <response code="404">1001: The requested correspondence was not found</response>
         [HttpGet]
         [Route("{correspondenceId}")]
         [Produces("application/json")]
@@ -235,9 +276,9 @@ namespace Altinn.Correspondence.API.Controllers
         /// Meant for Senders that want a complete overview of the status and history of the Correspondence, but also available for Receivers
         /// </remarks>
         /// <response code="200">Detailed information about the correspondence with current status and status history</response>
-        /// <response code="400">Could not retrieve party uuid from lookup in Altinn Register</response>
-        /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-        /// <response code="404">The requested correspondence was not found</response>
+        /// <response code="400">4002: Could not retrieve party uuid from lookup in Altinn Register</response>
+        /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+        /// <response code="404">1001: The requested correspondence was not found</response>
         [HttpGet]
         [Produces("application/json")]
         [ProducesResponseType(typeof(CorrespondenceDetailsExt), StatusCodes.Status200OK)]
@@ -309,12 +350,12 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <response code="200">Returns a list of Correspondences</response>   
         /// <response code="400"><ul>
-        /// <li>Could not retrieve party uuid from lookup in Altinn Register</li>
-        /// <li>From date cannot be after to date</li>
+        /// <li>1027: From date cannot be after to date</li>
+        /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li>
         /// </ul></response>
         /// <response code="401"><ul>
-        /// <li>You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</li>
-        /// <li>Could not determine the caller</li>
+        /// <li>4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</li>
+        /// <li>4006: Could not determine the caller</li>
         /// </ul></response>
         [HttpGet]
         [Produces("application/json")]
@@ -360,9 +401,9 @@ namespace Altinn.Correspondence.API.Controllers
         /// - altinn:correspondence.read <br />
         /// </remarks>
         /// <response code="200">the Id of the correspondence</response>
-        /// <response code="400">Could not retrieve party uuid from lookup in Altinn Register</response>
-        /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-        /// <response code="404">The requested correspondence was not found</response>
+        /// <response code="400">4002: Could not retrieve party uuid from lookup in Altinn Register</response>
+        /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+        /// <response code="404">1001: The requested correspondence was not found</response>
         [HttpPost]
         [Produces("application/json")]
         [ProducesResponseType(typeof(Guid), StatusCodes.Status200OK)]
@@ -399,9 +440,9 @@ namespace Altinn.Correspondence.API.Controllers
         /// - altinn:correspondence.read <br />
         /// </remarks>
         /// <response code="200">the Id of the correspondence</response>
-        /// <response code="400">Could not retrieve party uuid from lookup in Altinn Register</response>
-        /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-        /// <response code="404">The requested correspondence was not found</response>
+        /// <response code="400">4002: Could not retrieve party uuid from lookup in Altinn Register</response>
+        /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+        /// <response code="404">1001: The requested correspondence was not found</response>
         [HttpPost]
         [Produces("application/json")]
         [ProducesResponseType(typeof(Guid), StatusCodes.Status200OK)]
@@ -440,14 +481,14 @@ namespace Altinn.Correspondence.API.Controllers
         /// </remarks>
         /// <response code="200">the Id of the correspondence</response>
         /// <response code="400"><ul>
-        /// <li>Could not retrieve party uuid from lookup in Altinn Register</li>
-        /// <li>Could not retrieve highest status for correspondence</li>
-        /// <li>Correspondence has already been purged</li>
-        /// <li>Sender cannot delete correspondence that has been published</li>
-        /// <li>Cannot archive or delete a correspondence which has not been confirmed when confirmation is required</li>
+        /// <li>1013: Sender cannot delete correspondence that has been published</li>
+        /// <li>1014: Correspondence has already been purged</li>
+        /// <li>1015: Could not retrieve highest status for correspondence</li>
+        /// <li>1026: Cannot archive or delete a correspondence which has not been confirmed when confirmation is required</li>
+        /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li> 
         /// </ul></response>
-        /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
-        /// <response code="404">The requested correspondence was not found</response>
+        /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+        /// <response code="404">1001: The requested correspondence was not found</response>
         [HttpDelete]
         [Produces("application/json")]
         [ProducesResponseType(typeof(Guid), StatusCodes.Status200OK)]
@@ -484,10 +525,11 @@ namespace Altinn.Correspondence.API.Controllers
         /// - altinn:correspondence.read <br />
         /// </remarks>
         /// <response code="200">Returns the attachment file</response>
-        /// <response code="401">You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
+        /// <response code="400">4002: Could not retrieve party uuid from lookup in Altinn Register</response>
+        /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and orgaization in Altinn Authorization</response>
         /// <response code="404"><ul>
-        /// <li>The requested correspondence was not found</li>
-        /// <li>The requested attachment was not found</li>
+        /// <li>1001: The requested correspondence was not found</li>
+        /// <li>2001: The requested attachment was not found</li>
         /// </ul></response>
         [HttpGet]
         [Produces("application/octet-stream")]
@@ -535,6 +577,9 @@ namespace Altinn.Correspondence.API.Controllers
             );
         }
 
-        private ActionResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
+        private ActionResult Problem(Error error) => Problem(
+            detail: error.Message,
+            statusCode: (int)error.StatusCode, 
+            extensions: new Dictionary<string, object?> { { "errorCode", error.ErrorCode } });
     }
 }

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -33,7 +33,7 @@ namespace Altinn.Correspondence.API.Controllers
         }
 
         /// <summary>
-        /// Initialize Correspondences and uploads attachments in the same request
+        /// Initialize Correspondences
         /// </summary>
         /// <remarks>
         /// One of the scopes: <br/>

--- a/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/LegacyCorrespondenceController.cs
@@ -226,6 +226,9 @@ namespace Altinn.Correspondence.API.Controllers
                 Problem
             );
         }
-        private ActionResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
+        private ActionResult Problem(Error error) => Problem(
+            detail: error.Message, 
+            statusCode: (int)error.StatusCode, 
+            extensions: new Dictionary<string, object?> { { "errorCode", error.ErrorCode } });
     }
 }

--- a/src/Altinn.Correspondence.API/Controllers/MalwareScanController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MalwareScanController.cs
@@ -87,6 +87,9 @@ namespace Altinn.Correspondence.API.Controllers
                 return BadRequest();
             }
         }
-        private ObjectResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
+        private ObjectResult Problem(Error error) => Problem(
+            detail: error.Message, 
+            statusCode: (int)error.StatusCode, 
+            extensions: new Dictionary<string, object?> { { "errorCode", error.ErrorCode } });
     }
 }

--- a/src/Altinn.Correspondence.API/Controllers/MigrationController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MigrationController.cs
@@ -85,6 +85,9 @@ namespace Altinn.Correspondence.API.Controllers
             );
         }
 
-        private ActionResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
+        private ActionResult Problem(Error error) => Problem(
+            detail: error.Message, 
+            statusCode: (int)error.StatusCode, 
+            extensions: new Dictionary<string, object?> { { "errorCode", error.ErrorCode } });
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The api errors have errorCodes but they are not included in the problemDetails response when an api request fails. This PR uses the buildt in extensions property in Problem() to add errorCode to the problemDetails reponse. This PR also updates the API endpoint summaries to have errorCodes for the error responses such that they are visble in the openApi spec.

Example new ProplemDetails response:
![image](https://github.com/user-attachments/assets/a7c073f6-ec1c-43de-a7ae-e1b581a95e80)

## Related Issue(s)
- #908 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to include explicit numeric error codes in error response descriptions for all relevant endpoints, improving clarity and consistency.

- **Bug Fixes**
  - Enhanced error response payloads to include structured error codes, allowing clients to receive both human-readable messages and machine-readable error codes in API error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->