### PR TITLE
Add storage provider to context

### DIFF
--- a/src/Altinn.Correspondence.Persistence/Repositories/AttachmentRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/AttachmentRepository.cs
@@ -4,6 +4,7 @@ using Altinn.Correspondence.Core.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System.Net.Mail;
+using System.Text.Json;
 
 namespace Altinn.Correspondence.Persistence.Repositories
 {
@@ -13,8 +14,18 @@ namespace Altinn.Correspondence.Persistence.Repositories
 
         public async Task<AttachmentEntity> InitializeAttachment(AttachmentEntity attachment, CancellationToken cancellationToken)
         {
+            logger.LogInformation("Attachment storageprovider " + JsonSerializer.Serialize(attachment?.StorageProvider));
             await _context.Attachments.AddAsync(attachment, cancellationToken);
-            await _context.SaveChangesAsync(cancellationToken);
+            try
+            {
+                await _context.SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogInformation("Error saving attachment: {Message}, content: {Attachment}", ex.Message, JsonSerializer.Serialize(attachment));
+                throw;
+            }
+
             return attachment;
         }
 

--- a/src/Altinn.Correspondence.Persistence/Repositories/AttachmentRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/AttachmentRepository.cs
@@ -15,6 +15,10 @@ namespace Altinn.Correspondence.Persistence.Repositories
         public async Task<AttachmentEntity> InitializeAttachment(AttachmentEntity attachment, CancellationToken cancellationToken)
         {
             logger.LogInformation("Attachment storageprovider " + JsonSerializer.Serialize(attachment?.StorageProvider));
+            if (attachment.StorageProvider is not null) 
+            { 
+                _context.Entry(attachment.StorageProvider).State = EntityState.Unchanged;
+            }
             await _context.Attachments.AddAsync(attachment, cancellationToken);
             try
             {


### PR DESCRIPTION
## Description
Entity Framework wasn't able to properly track that the storage provider entity already existed. Added code to ensure this was set.

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
