### PR TITLE
Filter out OPTIONS calls from logs

### DIFF
--- a/src/Altinn.Correspondence.API/Altinn.Correspondence.API.csproj
+++ b/src/Altinn.Correspondence.API/Altinn.Correspondence.API.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1.1" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.10" />     
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
     <PackageReference Include="Microsoft.Identity.Web" Version="3.8.0" />

--- a/src/Altinn.Correspondence.Integrations/Azure/OpenTelemetryConfiguration.cs
+++ b/src/Altinn.Correspondence.Integrations/Azure/OpenTelemetryConfiguration.cs
@@ -43,6 +43,10 @@ public static class OpenTelemetryConfiguration
                     {
                         options.Filter = httpContext =>
                         {
+                            if (httpContext.Request.Method == "OPTIONS")
+                            {
+                                return false;
+                            }
                             var path = httpContext.Request.Path.Value?.ToLowerInvariant();
                             return path != null &&
                                    !path.Contains("/health") &&

--- a/tools/Altinn.Correspondence.Dashboard/Altinn.Correspondence.Dashboard.csproj
+++ b/tools/Altinn.Correspondence.Dashboard/Altinn.Correspondence.Dashboard.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />

--- a/tools/Altinn.Correspondence.Dashboard/Program.cs
+++ b/tools/Altinn.Correspondence.Dashboard/Program.cs
@@ -2,7 +2,6 @@ using Altinn.Correspondence.Integrations.Hangfire;
 using Altinn.Correspondence.Persistence;
 using Hangfire;
 using Hangfire.PostgreSql;
-using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.Extensions.Logging.Abstractions;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,10 +10,6 @@ builder.Configuration
     .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", true, true)
     .AddJsonFile("appsettings.local.json", true, true);
 builder.Services.AddPersistence(builder.Configuration, new NullLogger<Program>());
-builder.Services.AddApplicationInsightsTelemetry(new ApplicationInsightsServiceOptions()
-{
-    EnableAdaptiveSampling = false
-});
 builder.Services.AddSingleton<IConnectionFactory, HangfireConnectionFactory>();
 builder.Services.AddHangfire((provider, config) =>
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Main issue is that we got a lot of OPTIONS call in our OpenTelemetry logs where the OperationName was different for each log entry. This lead to grouping issues as each OPTIONS count was counted as a separete operation in our performance metrics.
![image](https://github.com/user-attachments/assets/9482972f-3fb8-4d8f-9817-41a1a66f9afa)


## Related Issue(s)
- #893 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed Application Insights telemetry and related package references from the API and Dashboard components.

- **Refactor**
  - Updated telemetry configuration to exclude HTTP requests with the "OPTIONS" method from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->