### PR TITLE
Bug/correspondence fails for subunit

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Brreg/BrregServiceIntegrationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Brreg/BrregServiceIntegrationTests.cs
@@ -94,11 +94,51 @@ namespace Altinn.Correspondence.Tests.Brreg
         public async Task GetOrganizationDetailsAsync_WithNonExisitingOrg_ThrowsNotFoundException()
         {
             // Arrange
-            var organizationNumber = "000000000"; // Invalid org
+            var organizationNumber = "000000000";
 
             // Act & Assert
             await Assert.ThrowsAsync<BrregNotFoundException>(() => 
                 _service.GetOrganizationDetailsAsync(organizationNumber));
+        }
+
+        [Fact]
+        public async Task GetOrganizationDetailsAsync_WithSubOrganization_ThrowsNotFoundException()
+        {
+            // Arrange
+            var organizationNumber = "315649978";
+
+            // Act & Assert
+            await Assert.ThrowsAsync<BrregNotFoundException>(() => 
+                _service.GetOrganizationDetailsAsync(organizationNumber));
+        }
+
+        [Fact]
+        public async Task GetSubOrganizationDetailsAsync_WithSubOrganization_ReturnsDetails()
+        {
+            // Arrange
+            var organizationNumber = "315649978";
+
+            // Act
+            var result = await _service.GetSubOrganizationDetailsAsync(organizationNumber);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(organizationNumber, result.OrganizationNumber);
+            Assert.NotNull(result.Name);
+            Assert.False(result.IsDeleted);
+            Assert.False(result.IsBankrupt);
+            Assert.NotNull(result.OrganizationNumber);
+        }
+
+        [Fact]
+        public async Task GetSubOrganizationDetailsAsync_WithNonExisitingSubOrg_ThrowsNotFoundException()
+        {
+            // Arrange
+            var organizationNumber = "000000000";
+
+            // Act & Assert
+            await Assert.ThrowsAsync<BrregNotFoundException>(() => 
+                _service.GetSubOrganizationDetailsAsync(organizationNumber));
         }
 
         public void Dispose()

--- a/Test/Altinn.Correspondence.Tests/Brreg/BrregServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Brreg/BrregServiceTests.cs
@@ -233,5 +233,97 @@ namespace Altinn.Correspondence.Tests.Brreg
             // Act & Assert
             await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetOrganizationDetailsAsync(organizationNumber));
         }
+
+        [Fact]
+        public async Task GetSubOrganizationDetailsAsync_WhenSuccessfulResponse_ReturnsDetails()
+        {
+            // Arrange
+            var organizationNumber = "123456789";
+            var expectedResponse = new OrganizationDetails
+            {
+                OrganizationNumber = organizationNumber,
+                Name = "Test Sub Organization",
+                IsBankrupt = false,
+                DeletionDate = null
+            };
+
+            var jsonResponse = JsonSerializer.Serialize(expectedResponse);
+
+            _mockHttpMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.Method == HttpMethod.Get &&
+                        req.RequestUri!.ToString().EndsWith($"underenheter/{organizationNumber}")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(jsonResponse)
+                });
+
+            // Act
+            var result = await _service.GetSubOrganizationDetailsAsync(organizationNumber);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(organizationNumber, result.OrganizationNumber);
+            Assert.Equal("Test Sub Organization", result.Name);
+            Assert.False(result.IsBankrupt);
+            Assert.False(result.IsDeleted);
+        }
+
+        [Fact]
+        public async Task GetSubOrganizationDetailsAsync_WhenNotFound_ThrowsBrregNotFoundException()
+        {
+            // Arrange
+            var organizationNumber = "123456789";
+
+            _mockHttpMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.Method == HttpMethod.Get &&
+                        req.RequestUri!.ToString().EndsWith($"underenheter/{organizationNumber}")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.NotFound,
+                    Content = new StringContent("Not found")
+                });
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<BrregNotFoundException>(
+                () => _service.GetSubOrganizationDetailsAsync(organizationNumber));
+            
+            Assert.Equal(organizationNumber, exception.OrganizationNumber);
+            Assert.Contains(organizationNumber, exception.Message);
+        }
+
+        [Fact]
+        public async Task GetSubOrganizationDetailsAsync_WhenOtherError_ThrowsHttpRequestException()
+        {
+            // Arrange
+            var organizationNumber = "123456789";
+
+            _mockHttpMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.Method == HttpMethod.Get &&
+                        req.RequestUri!.ToString().EndsWith($"underenheter/{organizationNumber}")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.InternalServerError,
+                    Content = new StringContent("Server error")
+                });
+
+            // Act & Assert
+            await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetSubOrganizationDetailsAsync(organizationNumber));
+        }
     }
 }

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -105,7 +105,15 @@ public class PublishCorrespondenceHandler(
             }
             catch (BrregNotFoundException)
             {
-                OrganizationNotFoundInBrreg = true;
+                try
+                {
+                    details = await brregService.GetSubOrganizationDetailsAsync(correspondence.Recipient.WithoutPrefix(), cancellationToken);
+                    roles = new OrganizationRoles();
+                }
+                catch (BrregNotFoundException)
+                {
+                    OrganizationNotFoundInBrreg = true;
+                }
             }
         }
 

--- a/src/Altinn.Correspondence.Core/Services/IBrregService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IBrregService.cs
@@ -17,6 +17,16 @@ namespace Altinn.Correspondence.Core.Services
         /// <exception cref="BrregNotFoundException">Thrown when the organization is not found</exception>
         /// <exception cref="HttpRequestException">Thrown when the API call fails for other reasons</exception>
         Task<OrganizationDetails> GetOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets detailed information about a sub organization
+        /// </summary>
+        /// <param name="organizationNumber">The organization number for the sub organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Organization details model</returns>
+        /// <exception cref="BrregNotFoundException">Thrown when the sub organization is not found</exception>
+        /// <exception cref="HttpRequestException">Thrown when the API call fails for other reasons</exception>
+        Task<OrganizationDetails> GetSubOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Gets roles information for an organization

--- a/src/Altinn.Correspondence.Integrations/Brreg/BrregDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Brreg/BrregDevService.cs
@@ -25,6 +25,20 @@ namespace Altinn.Correspondence.Integrations.Brreg
             return Task.FromResult(details);
         }
 
+        public Task<OrganizationDetails> GetSubOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default)
+        {
+            // Returns mock data for development testing
+            var details = new OrganizationDetails
+            {
+                OrganizationNumber = organizationNumber,
+                Name = "Test Sub Organization",
+                IsBankrupt = false,
+                DeletionDate = null
+            };
+            
+            return Task.FromResult(details);
+        }
+
         public Task<OrganizationRoles> GetOrganizationRolesAsync(string organizationNumber, CancellationToken cancellationToken = default)
         {
             // Returns mock data for development testing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Correspondences with a sub organization as a recipient would fail because it was not found in enhetsregisteret. This was because sub organizations are retrieved from a different endpoint than regular organizations. This PR checks if the given organization is a sub organization if it is not a regular organization. 

## Related Issue(s)
- #1070 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
