### PR TITLE
Remove publish rule that checks publish time due to timing error

### DIFF
--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -132,11 +132,6 @@ public class PublishCorrespondenceHandler(
         {
             errorMessage = $"Correspondence {correspondenceId} not ready for publish";
         }
-        else if (correspondence.RequestedPublishTime > DateTimeOffset.UtcNow)
-        {
-            errorMessage = $"Correspondence {correspondenceId} not visible yet - publish time: {correspondence.RequestedPublishTime}";
-            logger.LogWarning(errorMessage);
-        }
         else if (!hasDialogportenDialog)
         {
             errorMessage = $"Dialogporten dialog not created for correspondence {correspondenceId}";


### PR DESCRIPTION
## Description
Seems to be just a sanity check. We get errors from this one where the publish time is before DateTime.Now by milliseconds in staging environment. See:
`AppTraces
| where Message contains 'not visible yet' `

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the restriction preventing correspondence from being published before its requested publish time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->