### PR TITLE
Use parentorg roles for suborg when validating confidential correspondence

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Brreg/BrregDevServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Brreg/BrregDevServiceTests.cs
@@ -20,7 +20,7 @@ namespace Altinn.Correspondence.Tests.Brreg
             var organizationNumber = "123456789";
 
             // Act
-            var result = await _service.GetOrganizationDetailsAsync(organizationNumber);
+            var result = await _service.GetOrganizationDetails(organizationNumber);
 
             // Assert
             Assert.NotNull(result);
@@ -37,7 +37,7 @@ namespace Altinn.Correspondence.Tests.Brreg
             var organizationNumber = "123456789";
 
             // Act
-            var result = await _service.GetOrganizationRolesAsync(organizationNumber);
+            var result = await _service.GetOrganizationRoles(organizationNumber);
 
             // Assert
             Assert.NotNull(result);

--- a/Test/Altinn.Correspondence.Tests/Brreg/BrregServiceIntegrationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Brreg/BrregServiceIntegrationTests.cs
@@ -45,7 +45,7 @@ namespace Altinn.Correspondence.Tests.Brreg
             var requiredRoles = new List<string> { "BEST", "DAGL", "DTPR", "DTSO", "INNH", "LEDE"}; // Required roles for confidential correspondence
 
             // Act
-            var result = await _service.GetOrganizationRolesAsync(organizationNumber);
+            var result = await _service.GetOrganizationRoles(organizationNumber);
 
             // Assert
             Assert.NotNull(result);
@@ -63,7 +63,7 @@ namespace Altinn.Correspondence.Tests.Brreg
             var requiredRoles = new List<string> { "BEST", "DAGL", "DTPR", "DTSO", "INNH", "LEDE"}; // Required roles for confidential correspondence
 
             // Act
-            var result = await _service.GetOrganizationRolesAsync(organizationNumber);
+            var result = await _service.GetOrganizationRoles(organizationNumber);
 
             // Assert
             Assert.NotNull(result);
@@ -79,7 +79,7 @@ namespace Altinn.Correspondence.Tests.Brreg
             var organizationNumber = "312585065";
 
             // Act
-            var result = await _service.GetOrganizationDetailsAsync(organizationNumber);
+            var result = await _service.GetOrganizationDetails(organizationNumber);
 
             // Assert
             Assert.NotNull(result);
@@ -98,7 +98,7 @@ namespace Altinn.Correspondence.Tests.Brreg
 
             // Act & Assert
             await Assert.ThrowsAsync<BrregNotFoundException>(() => 
-                _service.GetOrganizationDetailsAsync(organizationNumber));
+                _service.GetOrganizationDetails(organizationNumber));
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace Altinn.Correspondence.Tests.Brreg
 
             // Act & Assert
             await Assert.ThrowsAsync<BrregNotFoundException>(() => 
-                _service.GetOrganizationDetailsAsync(organizationNumber));
+                _service.GetOrganizationDetails(organizationNumber));
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace Altinn.Correspondence.Tests.Brreg
             var organizationNumber = "315649978";
 
             // Act
-            var result = await _service.GetSubOrganizationDetailsAsync(organizationNumber);
+            var result = await _service.GetSubOrganizationDetails(organizationNumber);
 
             // Assert
             Assert.NotNull(result);
@@ -138,7 +138,7 @@ namespace Altinn.Correspondence.Tests.Brreg
 
             // Act & Assert
             await Assert.ThrowsAsync<BrregNotFoundException>(() => 
-                _service.GetSubOrganizationDetailsAsync(organizationNumber));
+                _service.GetSubOrganizationDetails(organizationNumber));
         }
 
         public void Dispose()

--- a/Test/Altinn.Correspondence.Tests/Brreg/BrregServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Brreg/BrregServiceTests.cs
@@ -79,7 +79,7 @@ namespace Altinn.Correspondence.Tests.Brreg
                 });
 
             // Act
-            var result = await _service.GetOrganizationRolesAsync(organizationNumber);
+            var result = await _service.GetOrganizationRoles(organizationNumber);
 
             // Assert
             Assert.NotNull(result);
@@ -112,7 +112,7 @@ namespace Altinn.Correspondence.Tests.Brreg
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<BrregNotFoundException>(
-                () => _service.GetOrganizationRolesAsync(organizationNumber));
+                () => _service.GetOrganizationRoles(organizationNumber));
             
             Assert.Equal(organizationNumber, exception.OrganizationNumber);
             Assert.Contains(organizationNumber, exception.Message);
@@ -139,7 +139,7 @@ namespace Altinn.Correspondence.Tests.Brreg
                 });
 
             // Act & Assert
-            await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetOrganizationRolesAsync(organizationNumber));
+            await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetOrganizationRoles(organizationNumber));
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace Altinn.Correspondence.Tests.Brreg
                 });
 
             // Act
-            var result = await _service.GetOrganizationDetailsAsync(organizationNumber);
+            var result = await _service.GetOrganizationDetails(organizationNumber);
 
             // Assert
             Assert.NotNull(result);
@@ -204,7 +204,7 @@ namespace Altinn.Correspondence.Tests.Brreg
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<BrregNotFoundException>(
-                () => _service.GetOrganizationDetailsAsync(organizationNumber));
+                () => _service.GetOrganizationDetails(organizationNumber));
             
             Assert.Equal(organizationNumber, exception.OrganizationNumber);
             Assert.Contains(organizationNumber, exception.Message);
@@ -231,7 +231,7 @@ namespace Altinn.Correspondence.Tests.Brreg
                 });
 
             // Act & Assert
-            await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetOrganizationDetailsAsync(organizationNumber));
+            await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetOrganizationDetails(organizationNumber));
         }
 
         [Fact]
@@ -265,7 +265,7 @@ namespace Altinn.Correspondence.Tests.Brreg
                 });
 
             // Act
-            var result = await _service.GetSubOrganizationDetailsAsync(organizationNumber);
+            var result = await _service.GetSubOrganizationDetails(organizationNumber);
 
             // Assert
             Assert.NotNull(result);
@@ -298,7 +298,7 @@ namespace Altinn.Correspondence.Tests.Brreg
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<BrregNotFoundException>(
-                () => _service.GetSubOrganizationDetailsAsync(organizationNumber));
+                () => _service.GetSubOrganizationDetails(organizationNumber));
             
             Assert.Equal(organizationNumber, exception.OrganizationNumber);
             Assert.Contains(organizationNumber, exception.Message);
@@ -325,7 +325,7 @@ namespace Altinn.Correspondence.Tests.Brreg
                 });
 
             // Act & Assert
-            await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetSubOrganizationDetailsAsync(organizationNumber));
+            await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetSubOrganizationDetails(organizationNumber));
         }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/PublishCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/PublishCorrespondenceHandlerTests.cs
@@ -135,7 +135,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         private void SetupBrregServiceWithRoles(string organizationNumber, OrganizationRoles organizationRoles)
         {
             _brregServiceMock
-                .Setup(x => x.GetOrganizationRolesAsync(organizationNumber, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetOrganizationRoles(organizationNumber, It.IsAny<CancellationToken>()))
                 .Returns((string id, CancellationToken token) =>
                     Task.FromResult(organizationRoles));
         }
@@ -143,7 +143,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         private void SetupBrregServiceWithOrgDetails(string organizationNumber, bool isBankrupt = false)
         {
             _brregServiceMock
-                .Setup(x => x.GetOrganizationDetailsAsync(organizationNumber, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetOrganizationDetails(organizationNumber, It.IsAny<CancellationToken>()))
                 .Returns((string id, CancellationToken token) =>
                     Task.FromResult(new OrganizationDetails { IsBankrupt = isBankrupt }));
         }
@@ -151,7 +151,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         private void SetupBrregServiceWithSubOrgDetails(string organizationNumber, string parentOrganizationNumber, bool isBankrupt = false)
         {
             _brregServiceMock
-                .Setup(x => x.GetSubOrganizationDetailsAsync(organizationNumber, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetSubOrganizationDetails(organizationNumber, It.IsAny<CancellationToken>()))
                 .Returns((string id, CancellationToken token) =>
                     Task.FromResult(new SubOrganizationDetails { IsBankrupt = isBankrupt, ParentOrganizationNumber = parentOrganizationNumber }));
         }
@@ -159,7 +159,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         private void SetupBrregServiceToThrowNotFoundForOrg(string organizationNumber)
         {
             _brregServiceMock
-                .Setup(x => x.GetOrganizationDetailsAsync(organizationNumber, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetOrganizationDetails(organizationNumber, It.IsAny<CancellationToken>()))
                 .Throws(new BrregNotFoundException(organizationNumber));
         }
 
@@ -272,7 +272,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             SetupBrregServiceToThrowNotFoundForOrg(organizationNumber);
 
             _brregServiceMock
-                .Setup(x => x.GetSubOrganizationDetailsAsync(organizationNumber, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetSubOrganizationDetails(organizationNumber, It.IsAny<CancellationToken>()))
                 .Throws(new BrregNotFoundException(organizationNumber));
 
             // Act

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/PublishCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/PublishCorrespondenceHandlerTests.cs
@@ -143,7 +143,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         private void SetupBrregServiceWithOrgDetails(string organizationNumber, bool isBankrupt = false)
         {
             _brregServiceMock
-                .Setup(x => x.GetSubOrganizationDetailsAsync(organizationNumber, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetOrganizationDetailsAsync(organizationNumber, It.IsAny<CancellationToken>()))
                 .Returns((string id, CancellationToken token) =>
                     Task.FromResult(new OrganizationDetails { IsBankrupt = isBankrupt }));
         }

--- a/src/Altinn.Correspondence.Application/ApplicationConstants.cs
+++ b/src/Altinn.Correspondence.Application/ApplicationConstants.cs
@@ -22,4 +22,13 @@ public static class ApplicationConstants
         ".png",
         ".json"
     ];
+    public static readonly List<string> RequiredOrganizationRolesForConfidentialPost = 
+    [
+        "BEST",
+        "DAGL",
+        "DTPR",
+        "DTSO",
+        "INNH",
+        "LEDE"
+    ];
 }

--- a/src/Altinn.Correspondence.Application/ApplicationConstants.cs
+++ b/src/Altinn.Correspondence.Application/ApplicationConstants.cs
@@ -22,7 +22,7 @@ public static class ApplicationConstants
         ".png",
         ".json"
     ];
-    public static readonly List<string> RequiredOrganizationRolesForConfidentialPost = 
+    public static readonly List<string> RequiredOrganizationRolesForConfidentialCorrespondence = 
     [
         "BEST",
         "DAGL",

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -255,7 +255,10 @@ public class PublishCorrespondenceHandler(
             try
             {
                 details = await brregService.GetOrganizationDetailsAsync(correspondence.Recipient.WithoutPrefix(), cancellationToken);
-                roles = await brregService.GetOrganizationRolesAsync(correspondence.Recipient.WithoutPrefix(), cancellationToken);
+                if (correspondence.IsConfidential)
+                {
+                    roles = await brregService.GetOrganizationRolesAsync(correspondence.Recipient.WithoutPrefix(), cancellationToken);
+                }
             }
             catch (BrregNotFoundException)
             {

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -19,6 +19,7 @@ using System.Security.Claims;
 using Altinn.Correspondence.Integrations.Redlock;
 using Altinn.Correspondence.Core.Models.Brreg;
 using Altinn.Correspondence.Core.Exceptions;
+using Altinn.Correspondence.Application.Settings;
 
 namespace Altinn.Correspondence.Application.PublishCorrespondence;
 
@@ -95,7 +96,6 @@ public class PublishCorrespondenceHandler(
         OrganizationDetails? details = null;
         OrganizationRoles? roles = null;
         bool OrganizationNotFoundInBrreg = false;
-        var requiredOrganizationRolesForConfidentialPost = new List<string> { "BEST", "DAGL", "DTPR", "DTSO", "INNH", "LEDE"};
         if (correspondence.GetRecipientUrn().WithoutPrefix().IsOrganizationNumber())
         {
             (details, roles, OrganizationNotFoundInBrreg) = await GetOrganizationDetailsAndRolesAsync(correspondence, cancellationToken);
@@ -142,7 +142,7 @@ public class PublishCorrespondenceHandler(
         {
             errorMessage = $"Recipient of {correspondenceId} is deleted";
         }
-        else if (roles != null && correspondence.IsConfidential && !roles.HasAnyOfRolesOnPerson(requiredOrganizationRolesForConfidentialPost))
+        else if (roles != null && correspondence.IsConfidential && !roles.HasAnyOfRolesOnPerson(ApplicationConstants.RequiredOrganizationRolesForConfidentialPost))
         {
             errorMessage = $"Recipient of {correspondenceId} is missing required roles to read confidential correspondences";
         }

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -98,7 +98,7 @@ public class PublishCorrespondenceHandler(
         bool OrganizationNotFoundInBrreg = false;
         if (correspondence.GetRecipientUrn().WithoutPrefix().IsOrganizationNumber())
         {
-            (details, roles, OrganizationNotFoundInBrreg) = await GetOrganizationDetailsAndRolesAsync(correspondence, cancellationToken);
+            (details, roles, OrganizationNotFoundInBrreg) = await GetOrganizationDetailsAndRoles(correspondence, cancellationToken);
         }
 
         var errorMessage = "";
@@ -240,7 +240,7 @@ public class PublishCorrespondenceHandler(
         return false;
     }
 
-    private async Task<(OrganizationDetails?, OrganizationRoles?, bool)> GetOrganizationDetailsAndRolesAsync(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
+    private async Task<(OrganizationDetails?, OrganizationRoles?, bool)> GetOrganizationDetailsAndRoles(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
     {
         OrganizationDetails? details = null;
         OrganizationRoles? roles = null;
@@ -249,21 +249,21 @@ public class PublishCorrespondenceHandler(
         {
             try
             {
-                details = await brregService.GetOrganizationDetailsAsync(correspondence.Recipient.WithoutPrefix(), cancellationToken);
+                details = await brregService.GetOrganizationDetails(correspondence.Recipient.WithoutPrefix(), cancellationToken);
                 if (correspondence.IsConfidential)
                 {
-                    roles = await brregService.GetOrganizationRolesAsync(correspondence.Recipient.WithoutPrefix(), cancellationToken);
+                    roles = await brregService.GetOrganizationRoles(correspondence.Recipient.WithoutPrefix(), cancellationToken);
                 }
             }
             catch (BrregNotFoundException)
             {
                 try
                 {
-                    var subOrganizationDetails = await brregService.GetSubOrganizationDetailsAsync(correspondence.Recipient.WithoutPrefix(), cancellationToken);
+                    var subOrganizationDetails = await brregService.GetSubOrganizationDetails(correspondence.Recipient.WithoutPrefix(), cancellationToken);
                     details = subOrganizationDetails;
                     if (correspondence.IsConfidential && subOrganizationDetails.ParentOrganizationNumber != null)
                     {
-                        roles = await brregService.GetOrganizationRolesAsync(subOrganizationDetails.ParentOrganizationNumber, cancellationToken);
+                        roles = await brregService.GetOrganizationRoles(subOrganizationDetails.ParentOrganizationNumber, cancellationToken);
                     }
                     else
                     {

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -137,7 +137,7 @@ public class PublishCorrespondenceHandler(
         {
             errorMessage = $"Recipient of {correspondenceId} is deleted";
         }
-        else if (roles != null && correspondence.IsConfidential && !roles.HasAnyOfRolesOnPerson(ApplicationConstants.RequiredOrganizationRolesForConfidentialPost))
+        else if (roles != null && correspondence.IsConfidential && !roles.HasAnyOfRolesOnPerson(ApplicationConstants.RequiredOrganizationRolesForConfidentialCorrespondence))
         {
             errorMessage = $"Recipient of {correspondenceId} is missing required roles to read confidential correspondences";
         }

--- a/src/Altinn.Correspondence.Core/Models/Brreg/SubOrganizationDetails.cs
+++ b/src/Altinn.Correspondence.Core/Models/Brreg/SubOrganizationDetails.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Correspondence.Core.Models.Brreg
+{
+    /// <summary>
+    /// Model for sub-organization details from Brønnøysundregistrene
+    /// </summary>
+    public class SubOrganizationDetails: OrganizationDetails
+    {
+        /// <summary>
+        /// Parent organization number
+        /// </summary>
+        [JsonPropertyName("overordnetEnhet")]
+        public string? ParentOrganizationNumber { get; set; }
+    }
+}

--- a/src/Altinn.Correspondence.Core/Services/IBrregService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IBrregService.cs
@@ -16,7 +16,7 @@ namespace Altinn.Correspondence.Core.Services
         /// <returns>Organization details model</returns>
         /// <exception cref="BrregNotFoundException">Thrown when the organization is not found</exception>
         /// <exception cref="HttpRequestException">Thrown when the API call fails for other reasons</exception>
-        Task<OrganizationDetails> GetOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default);
+        Task<OrganizationDetails> GetOrganizationDetails(string organizationNumber, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets detailed information about a sub organization
@@ -26,7 +26,7 @@ namespace Altinn.Correspondence.Core.Services
         /// <returns>Organization details model</returns>
         /// <exception cref="BrregNotFoundException">Thrown when the sub organization is not found</exception>
         /// <exception cref="HttpRequestException">Thrown when the API call fails for other reasons</exception>
-        Task<SubOrganizationDetails> GetSubOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default);
+        Task<SubOrganizationDetails> GetSubOrganizationDetails(string organizationNumber, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Gets roles information for an organization
@@ -36,6 +36,6 @@ namespace Altinn.Correspondence.Core.Services
         /// <returns>Organization roles model</returns>
         /// <exception cref="BrregNotFoundException">Thrown when the organization is not found</exception>
         /// <exception cref="HttpRequestException">Thrown when the API call fails for other reasons</exception>
-        Task<OrganizationRoles> GetOrganizationRolesAsync(string organizationNumber, CancellationToken cancellationToken = default);
+        Task<OrganizationRoles> GetOrganizationRoles(string organizationNumber, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.Correspondence.Core/Services/IBrregService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IBrregService.cs
@@ -17,6 +17,16 @@ namespace Altinn.Correspondence.Core.Services
         /// <exception cref="BrregNotFoundException">Thrown when the organization is not found</exception>
         /// <exception cref="HttpRequestException">Thrown when the API call fails for other reasons</exception>
         Task<OrganizationDetails> GetOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets detailed information about a sub organization
+        /// </summary>
+        /// <param name="organizationNumber">The organization number for the sub organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Organization details model</returns>
+        /// <exception cref="BrregNotFoundException">Thrown when the sub organization is not found</exception>
+        /// <exception cref="HttpRequestException">Thrown when the API call fails for other reasons</exception>
+        Task<SubOrganizationDetails> GetSubOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Gets roles information for an organization

--- a/src/Altinn.Correspondence.Integrations/Brreg/BrregDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Brreg/BrregDevService.cs
@@ -11,7 +11,7 @@ namespace Altinn.Correspondence.Integrations.Brreg
     /// </remarks>
     public class BrregDevService() : IBrregService
     {
-        public Task<OrganizationDetails> GetOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default)
+        public Task<OrganizationDetails> GetOrganizationDetails(string organizationNumber, CancellationToken cancellationToken = default)
         {
             // Returns mock data for development testing
             var details = new OrganizationDetails
@@ -25,7 +25,7 @@ namespace Altinn.Correspondence.Integrations.Brreg
             return Task.FromResult(details);
         }
 
-        public Task<SubOrganizationDetails> GetSubOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default)
+        public Task<SubOrganizationDetails> GetSubOrganizationDetails(string organizationNumber, CancellationToken cancellationToken = default)
         {
             // Returns mock data for development testing
             var details = new SubOrganizationDetails
@@ -40,7 +40,7 @@ namespace Altinn.Correspondence.Integrations.Brreg
             return Task.FromResult(details);
         }
 
-        public Task<OrganizationRoles> GetOrganizationRolesAsync(string organizationNumber, CancellationToken cancellationToken = default)
+        public Task<OrganizationRoles> GetOrganizationRoles(string organizationNumber, CancellationToken cancellationToken = default)
         {
             // Returns mock data for development testing
             var roles = new OrganizationRoles();

--- a/src/Altinn.Correspondence.Integrations/Brreg/BrregDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Brreg/BrregDevService.cs
@@ -25,6 +25,21 @@ namespace Altinn.Correspondence.Integrations.Brreg
             return Task.FromResult(details);
         }
 
+        public Task<SubOrganizationDetails> GetSubOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default)
+        {
+            // Returns mock data for development testing
+            var details = new SubOrganizationDetails
+            {
+                OrganizationNumber = organizationNumber,
+                Name = "Test Sub Organization",
+                IsBankrupt = false,
+                DeletionDate = null,
+                ParentOrganizationNumber = "312585065"
+            };
+            
+            return Task.FromResult(details);
+        }
+
         public Task<OrganizationRoles> GetOrganizationRolesAsync(string organizationNumber, CancellationToken cancellationToken = default)
         {
             // Returns mock data for development testing

--- a/src/Altinn.Correspondence.Integrations/Brreg/BrregService.cs
+++ b/src/Altinn.Correspondence.Integrations/Brreg/BrregService.cs
@@ -30,7 +30,7 @@ namespace Altinn.Correspondence.Integrations.Brreg
             }
         }
 
-        public async Task<OrganizationRoles> GetOrganizationRolesAsync(string organizationNumber, CancellationToken cancellationToken = default)
+        public async Task<OrganizationRoles> GetOrganizationRoles(string organizationNumber, CancellationToken cancellationToken = default)
         {
             var endpoint = $"enheter/{organizationNumber}/roller";
             var response = await _httpClient.GetAsync(endpoint, cancellationToken);
@@ -60,7 +60,7 @@ namespace Altinn.Correspondence.Integrations.Brreg
             return rolesResponse;
         }
 
-        public async Task<OrganizationDetails> GetOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default)
+        public async Task<OrganizationDetails> GetOrganizationDetails(string organizationNumber, CancellationToken cancellationToken = default)
         {
             var endpoint = $"enheter/{organizationNumber}";
             var response = await _httpClient.GetAsync(endpoint, cancellationToken);
@@ -90,7 +90,7 @@ namespace Altinn.Correspondence.Integrations.Brreg
             return detailsResponse;
         }
 
-        public async Task<SubOrganizationDetails> GetSubOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default)
+        public async Task<SubOrganizationDetails> GetSubOrganizationDetails(string organizationNumber, CancellationToken cancellationToken = default)
         {
             var endpoint = $"underenheter/{organizationNumber}";
             var response = await _httpClient.GetAsync(endpoint, cancellationToken);

--- a/src/Altinn.Correspondence.Integrations/Brreg/BrregService.cs
+++ b/src/Altinn.Correspondence.Integrations/Brreg/BrregService.cs
@@ -89,5 +89,35 @@ namespace Altinn.Correspondence.Integrations.Brreg
             
             return detailsResponse;
         }
+
+        public async Task<SubOrganizationDetails> GetSubOrganizationDetailsAsync(string organizationNumber, CancellationToken cancellationToken = default)
+        {
+            var endpoint = $"underenheter/{organizationNumber}";
+            var response = await _httpClient.GetAsync(endpoint, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    _logger.LogWarning("Sub organization with organization number {OrganizationNumber} not found in Brreg", organizationNumber);
+                    throw new BrregNotFoundException(organizationNumber);
+                }
+                
+                _logger.LogError("Failed to get sub organization details for organization {OrganizationNumber}. Status code: {StatusCode}, Error: {Error}", 
+                    organizationNumber, response.StatusCode, errorContent);
+                throw new HttpRequestException($"Failed to get sub organization details for organization {organizationNumber}. Status code: {response.StatusCode}, Error: {errorContent}");
+            }
+
+            var detailsResponse = await response.Content.ReadFromJsonAsync<SubOrganizationDetails>(cancellationToken: cancellationToken);
+            if (detailsResponse == null)
+            {
+                _logger.LogError("Unexpected response format from Brreg API when getting sub organization details for organization {OrganizationNumber}", organizationNumber);
+                throw new HttpRequestException($"Unexpected response format from Brreg API when getting sub organization details for organization {organizationNumber}");
+            }
+
+            return detailsResponse;
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sub organizations do not have any roles on them. It is the roles on the parent organization that applies for sub organizations. Currently confidential correspondences can not be sendt to sub organizations as they do not have any roles on them. This PR retrieves the roles of the parent organization for sub organizations when validating confidential correspondences. This makes it so confidential correspondences are valid for sub organization recipiencts that have a parent organization with the required roles to read confidential correspondences.

Also refactored publishCorrespondenceHandlerTests to reuse mock setups acros tests and moved the requiredRolesForConfidentialCorrespondence constant to the applicationConstants class to keep it centralized.

## Related Issue(s)
- #1070

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving and handling sub-organization details, including parent organization information, when processing correspondence.
  - Introduced a dedicated list of required organization roles for confidential correspondence.

- **Bug Fixes**
  - Improved error handling for cases where sub-organizations or their parent organizations are not found.

- **Refactor**
  - Streamlined logic for retrieving organization and sub-organization details, enhancing maintainability and clarity.
  - Refactored tests for better code reuse and readability.
  - Renamed service methods to remove "Async" suffix for consistency.

- **Tests**
  - Added new unit tests covering sub-organization scenarios and error handling.
  - Enhanced test structure with reusable helpers and clearer test data setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->