### PR TITLE
Fix bug where adding to activity log was attempted for migrated elements

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -99,6 +99,11 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
+            if (correspondence.Altinn2CorrespondenceId.GetValueOrDefault() > 0)
+            {
+                logger.LogWarning("Skipping patching correspondence {correspondenceId} to confirmed as it is an Altinn2 correspondence without Dialogporten dialog", correspondenceId);
+                return;
+            }
             throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
         }
         var patchRequestBuilder = new DialogPatchRequestBuilder();
@@ -146,6 +151,11 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
+            if (correspondence.Altinn2CorrespondenceId.GetValueOrDefault() > 0)
+            {
+                logger.LogWarning("Skipping creating information activity for {correspondenceId} as it is an Altinn2 correspondence without Dialogporten dialog", correspondenceId);
+                return;
+            }
             throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
         }
 
@@ -240,6 +250,11 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
+            if (correspondence.Altinn2CorrespondenceId.GetValueOrDefault() > 0)
+            {
+                logger.LogWarning("Skipping creating opened activity for {correspondenceId} as it is an Altinn2 correspondence without Dialogporten dialog", correspondenceId);
+                return;
+            }
             throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
         }
 
@@ -296,6 +311,11 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
+            if (correspondence.Altinn2CorrespondenceId.GetValueOrDefault() > 0)
+            {
+                logger.LogWarning("Skipping purging correspondence {correspondenceId} as it is an Altinn2 correspondence without Dialogporten dialog", correspondenceId);
+                return;
+            }
             throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
         }
 
@@ -335,6 +355,11 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
+            if (correspondence.Altinn2CorrespondenceId.GetValueOrDefault() > 0)
+            {
+                logger.LogWarning("Skipping creating dialog purged activity for correspondence {correspondenceId} as it is an Altinn2 correspondence without Dialogporten dialog", correspondenceId);
+                return;
+            }
             throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
         }
 


### PR DESCRIPTION
## Description
Migrated elements that have not been added to Dialogporten yet should not have activities posted to their Dialogporten logs as they do not exist in Dialogporten yet. The activity log will be filled with correct elements upon migration A3->DP

## Related Issue(s)
- #1086 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of Altinn2 correspondences without associated Dialogporten dialogs, preventing unnecessary errors and ensuring smoother processing for these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->