### PR TITLE
UpdatedAt should be latest date

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -27,7 +27,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 ServiceResource = UrnConstants.Resource + ":" + correspondence.ResourceId,
                 Party = correspondence.GetRecipientUrn(),
                 CreatedAt = correspondence.Created,
-                UpdatedAt = correspondence.Statuses?.Select(s => s.StatusChanged).DefaultIfEmpty().Concat([correspondence.Created]).Max(),
+                UpdatedAt = (correspondence.Statuses ?? []).Select(s => s.StatusChanged).Concat([correspondence.Created]).Max(),
                 VisibleFrom = correspondence.RequestedPublishTime < DateTime.UtcNow.AddMinutes(1) ? null : correspondence.RequestedPublishTime,
                 Process = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenProcessId)?.ReferenceValue,
                 ExpiresAt = correspondence.AllowSystemDeleteAfter,

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -27,7 +27,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 ServiceResource = UrnConstants.Resource + ":" + correspondence.ResourceId,
                 Party = correspondence.GetRecipientUrn(),
                 CreatedAt = correspondence.Created,
-                UpdatedAt = correspondence.Statuses?.Select(s => s.StatusChanged).DefaultIfEmpty().Max(),
+                UpdatedAt = correspondence.Statuses?.Select(s => s.StatusChanged).DefaultIfEmpty().Concat([correspondence.Created]).Max(),
                 VisibleFrom = correspondence.RequestedPublishTime < DateTime.UtcNow.AddMinutes(1) ? null : correspondence.RequestedPublishTime,
                 Process = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenProcessId)?.ReferenceValue,
                 ExpiresAt = correspondence.AllowSystemDeleteAfter,

--- a/src/Altinn.Correspondence.Integrations/OpenTelemetry/RequestFilterProcessor.cs
+++ b/src/Altinn.Correspondence.Integrations/OpenTelemetry/RequestFilterProcessor.cs
@@ -94,7 +94,7 @@ public class RequestFilterProcessor : BaseProcessor<Activity>
     /// <param name="activity">xx</param>
     public override void OnEnd(Activity activity)
     {
-        if (activity.OperationName == RequestKind && _httpContextAccessor.HttpContext is not null)
+        if (activity.OperationName == RequestKind && _httpContextAccessor?.HttpContext?.Request is not null)
         {
             if (_httpContextAccessor.HttpContext.Request.Headers.TryGetValue("X-Forwarded-For", out StringValues ipAddress))
             {
@@ -128,11 +128,10 @@ public class RequestFilterProcessor : BaseProcessor<Activity>
         {
             return true;
         }
-
         if (_generalSettings.DisableTelemetryForMigration)
         {
-            return pathSpan.SequenceEqual("/correspondence/api/v1/migration/correspondence".AsSpan())
-                || pathSpan.SequenceEqual("/correspondence/api/v1/migration/attachment".AsSpan());
+            return pathSpan.Contains("/correspondence/api/v1/migration/correspondence".AsSpan(), StringComparison.InvariantCultureIgnoreCase)
+                || pathSpan.Contains("/correspondence/api/v1/migration/attachment".AsSpan(), StringComparison.InvariantCultureIgnoreCase);
         }
 
         return false;


### PR DESCRIPTION
## Description
We get errors of type:
"errors":{"dto.updatedAt":["'UpdatedAt' must be greater than or equal to 'CreatedAt'."]

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of the "Updated At" timestamp to ensure it is never earlier than the creation date, even if there are no status updates or all status updates are older.
  * Enhanced request filtering to better exclude telemetry data from migration-related endpoints by broadening path matching criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->