### PR TITLE
Fix af failing to retrieve correspondence

### DIFF
--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -109,7 +109,7 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
                           policy =>
                           {
                               policy.WithOrigins("https://af.tt.altinn.no").SetIsOriginAllowedToAllowWildcardSubdomains();
-                              policy.WithMethods("GET", "POST", "DELETE");
+                              policy.WithMethods("GET", "POST", "DELETE", "OPTIONS");
                               policy.WithHeaders("Authorization", "request-id", "request-context", "traceparent");
                               policy.AllowCredentials();
                           });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
AF started to fail retrieving correspondence content as well as failing to call confirm. It seems to be an issue with CORS because of new headers and CORS preflight request used in the requests from dialogporten that are not explicitly allowed in our cors policy (CORS preflight requests are OPTIONS requests). This PR fixes these CORS issues for local dev. Made the same changes to apim cors policy which fixed the issue they had in staging.

## Related Issue(s)
- #1140 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CORS policy to support the HTTP "OPTIONS" method and additional headers, improving compatibility with various client requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->