### PR TITLE
Ny Migration Operasjon bør inkluderes i DisableTelemetry test

### DIFF
--- a/src/Altinn.Correspondence.Integrations/OpenTelemetry/RequestFilterProcessor.cs
+++ b/src/Altinn.Correspondence.Integrations/OpenTelemetry/RequestFilterProcessor.cs
@@ -131,6 +131,7 @@ public class RequestFilterProcessor : BaseProcessor<Activity>
         if (_generalSettings.DisableTelemetryForMigration)
         {
             return pathSpan.Contains("/correspondence/api/v1/migration/correspondence".AsSpan(), StringComparison.InvariantCultureIgnoreCase)
+                || pathSpan.Contains("/correspondence/api/v1/migration/makemigratedcorrespondenceavailable".AsSpan(), StringComparison.InvariantCultureIgnoreCase)
                 || pathSpan.Contains("/correspondence/api/v1/migration/attachment".AsSpan(), StringComparison.InvariantCultureIgnoreCase);
         }
 


### PR DESCRIPTION
Har lagt på en ny operasjon på migration.
Oppdaget nå at disabletelemetry ikke inkluderer den nye pathen.

## Description
Ekstra path i Disabletelemetry check. 
Kunne det kanskje vært nok å kun ha path opp til Migration der?

## Related Issue(s)
- #1142
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
