### PR TITLE
1146 removed sender in initialize attachments, added deprecated to the API

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/AttachmentBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/AttachmentBuilder.cs
@@ -17,7 +17,6 @@ namespace Altinn.Correspondence.Tests.Factories
             _attachment = new InitializeAttachmentExt()
             {
                 ResourceId = "1",
-                Sender = $"{UrnConstants.OrganizationNumberAttribute}:991825827",
                 SendersReference = "1234",
                 FileName = "test-file.txt",
                 DisplayName = "Test file",

--- a/Test/Altinn.Correspondence.Tests/Factories/MigrateAttachmentBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/MigrateAttachmentBuilder.cs
@@ -56,9 +56,9 @@ namespace Altinn.Correspondence.Tests.Factories
             _attachment.Checksum = checksum;
             return this;
         }
-        public MigrateAttachmentBuilder WithSenderPartyUuid(Guid sender)
+        public MigrateAttachmentBuilder WithSenderPartyUuid(Guid senderPartyUuid)
         {
-            _attachment.SenderPartyUuid = sender;
+            _attachment.SenderPartyUuid = senderPartyUuid;
             return this;
         }
     }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Attachment/AttachmentInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Attachment/AttachmentInitializationTests.cs
@@ -82,37 +82,5 @@ namespace Altinn.Correspondence.Tests.TestingController.Attachment
             var initializeAttachmentResponse = await _wrongSenderClient.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);
             Assert.Equal(HttpStatusCode.Unauthorized, initializeAttachmentResponse.StatusCode);
         }
-
-        [Theory]
-        [InlineData("123456789")]
-        [InlineData("invalid-sender")]
-        public async Task InitializeAttachment_WithWrongSender_ReturnsBadRequest(string sender)
-        {
-            var attachment = new AttachmentBuilder()
-                .CreateAttachment()
-                .WithSender(sender)
-                .Build();
-            var initializeAttachmentResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);
-            Assert.Equal(HttpStatusCode.BadRequest, initializeAttachmentResponse.StatusCode);
-        }
-        [Fact]
-        public async Task InitializeAttachment_WithoutUrnFormat_AddsUrnFormat()
-        {
-            // Arrange
-            var sender = "0192:991825827";
-            var attachment = new AttachmentBuilder()
-                .CreateAttachment()
-                .WithSender(sender)
-                .Build();
-            var initializeAttachmentResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);
-            var initContent = await initializeAttachmentResponse.Content.ReadFromJsonAsync<Guid>(_responseSerializerOptions);
-
-            // Act
-            var attachmentOverview = await _senderClient.GetAsync($"correspondence/api/v1/attachment/{initContent}");
-            var overviewContent = await attachmentOverview.Content.ReadFromJsonAsync<AttachmentOverviewExt>(_responseSerializerOptions);
-
-            // Assert
-            Assert.Equal(overviewContent.Sender, $"{UrnConstants.OrganizationNumberAttribute}:{sender.WithoutPrefix()}");
-        }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
@@ -428,11 +428,9 @@ public class MigrationAccessTests : MigrationTestBase
         using StreamContent content = new(memoryStream);
         string command = GetAttachmentCommand(migrateAttachmentExt);
         var uploadResponse = await _migrationClient.PostAsync(command, content);
-
         Assert.True(uploadResponse.IsSuccessStatusCode, uploadResponse.ReasonPhrase + ":" + await uploadResponse.Content.ReadAsStringAsync());
-        string attachmentId = await uploadResponse.Content.ReadAsStringAsync();
-
-        return new Guid(attachmentId.Trim('"'));
+        Guid attachmentId = Guid.Parse(uploadResponse.Content.ReadAsStringAsync().Result.Trim('"'));
+        return attachmentId;
     }
 
     private LegacyGetCorrespondencesRequestExt GetBasicLegacyGetCorrespondenceRequestExt()

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationAccessTests.cs
@@ -14,8 +14,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Migration;
 
 [Collection(nameof(CustomWebApplicationTestsCollection))]
 public class MigrationAccessTests : MigrationTestBase
-{   
-    private readonly HttpClient  _recipientClient, _legacyClient;
+{
+    private readonly HttpClient _recipientClient, _legacyClient;
     private readonly string _partyIdClaim = "urn:altinn:partyid";
     private readonly int _digdirPartyId = 50952483;
 
@@ -97,7 +97,7 @@ public class MigrationAccessTests : MigrationTestBase
         var correspondenceList = await _legacyClient.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", correspondenceListRequest);
         Assert.True(correspondenceList.IsSuccessStatusCode, await correspondenceList.Content.ReadAsStringAsync());
 
-        var correspondenceListResponse = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);        
+        var correspondenceListResponse = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_responseSerializerOptions);
         Assert.False(correspondenceListResponse?.Items.Any(x => x.CorrespondenceId == createdCorrespondenceId));
 
         var correspondenceOverview = await _legacyClient.GetAsync($"correspondence/api/v1/legacy/correspondence/{createdCorrespondenceId}/overview");
@@ -369,10 +369,10 @@ public class MigrationAccessTests : MigrationTestBase
         Assert.Equal(HttpStatusCode.NotFound, fetchResponse.StatusCode);
 
         var downloadAttachmentResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{createdCorrespondenceId}/attachment/{attachmentId}/download");
-        var data = await downloadAttachmentResponse.Content.ReadAsByteArrayAsync();        
+        var data = await downloadAttachmentResponse.Content.ReadAsByteArrayAsync();
         Assert.Equal(HttpStatusCode.NotFound, downloadAttachmentResponse.StatusCode);
 
-        var markAsReadResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{createdCorrespondenceId}/markasread", null);        
+        var markAsReadResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{createdCorrespondenceId}/markasread", null);
         Assert.Equal(HttpStatusCode.NotFound, markAsReadResponse.StatusCode);
 
         var confirmResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{createdCorrespondenceId}/confirm", null);
@@ -429,7 +429,8 @@ public class MigrationAccessTests : MigrationTestBase
         string command = GetAttachmentCommand(migrateAttachmentExt);
         var uploadResponse = await _migrationClient.PostAsync(command, content);
         Assert.True(uploadResponse.IsSuccessStatusCode, uploadResponse.ReasonPhrase + ":" + await uploadResponse.Content.ReadAsStringAsync());
-        Guid attachmentId = Guid.Parse(uploadResponse.Content.ReadAsStringAsync().Result.Trim('"'));
+        string responseContent = await uploadResponse.Content.ReadAsStringAsync();
+        Guid attachmentId = Guid.Parse(responseContent.Trim('"'));
         return attachmentId;
     }
 

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -1,5 +1,6 @@
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
+using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Tests.Factories;

--- a/src/Altinn.Correspondence.API/Mappers/InitializeAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeAttachmentMapper.cs
@@ -1,5 +1,6 @@
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.Application.InitializeAttachment;
+using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
 
@@ -14,7 +15,7 @@ internal static class InitializeAttachmentMapper
             ResourceId = initializeAttachmentExt.ResourceId.WithoutPrefix(),
             FileName = initializeAttachmentExt.FileName,
             DisplayName = initializeAttachmentExt.DisplayName,
-            Sender = initializeAttachmentExt.Sender,
+            Sender = UrnConstants.PlaceholderSender, // Placeholder - will be set by handler from ResourceRegistryService
             SendersReference = initializeAttachmentExt.SendersReference,
             Checksum = initializeAttachmentExt.Checksum,
             IsEncrypted = initializeAttachmentExt.IsEncrypted,

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
@@ -1,6 +1,7 @@
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application.InitializeCorrespondences;
+using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
 using System.Text.Json;
@@ -18,7 +19,7 @@ internal static class InitializeCorrespondencesMapper
             SendersReference = request.Correspondence.SendersReference,
             Recipient = null,
             ResourceId = request.Correspondence.ResourceId.WithoutPrefix(),
-            Sender = "urn:altinn:organization:identifier-no:000000000", // This is not required anymore from caller, but it still has to be set to a valid format
+            Sender = UrnConstants.PlaceholderSender, // This is not required anymore from caller, but it still has to be set to a valid format
             MessageSender = request.Correspondence.MessageSender,
             RequestedPublishTime = request.Correspondence.RequestedPublishTime ?? DateTimeOffset.UtcNow,
             AllowSystemDeleteAfter = request.Correspondence.AllowSystemDeleteAfter,

--- a/src/Altinn.Correspondence.API/Models/InitializeAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeAttachmentExt.cs
@@ -25,8 +25,7 @@ namespace Altinn.Correspondence.API.Models
         /// Organization number in countrycode:organizationnumber format.
         /// </remarks>
         [JsonPropertyName("sender")]
-        [OrganizationNumber(ErrorMessage = $"Organization numbers should be on the format '{UrnConstants.OrganizationNumberAttribute}:organizationnumber' or the format countrycode:organizationnumber, for instance 0192:910753614")]
-        [Required]
-        public required string Sender { get; set; }
+        [Obsolete("Sender is deprecated and will be removed in a future version. The sender is now automatically determined from the Resource Registry based on the resourceId.")]
+        public string? Sender { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.Application/InitializeAttachment/InitializeAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeAttachment/InitializeAttachmentHandler.cs
@@ -29,7 +29,7 @@ public class InitializeAttachmentHandler(
         logger.LogInformation("Starting attachment initialization process for resource {ResourceId}", sanitizedResourceId);
         
         var serviceOwnerOrgNumber = await resourceRegistryService.GetServiceOwnerOrganizationNumber(request.Attachment.ResourceId, cancellationToken);
-        if (serviceOwnerOrgNumber is null || serviceOwnerOrgNumber == string.Empty)
+        if (string.IsNullOrEmpty(serviceOwnerOrgNumber))
         {
             logger.LogError("Service owner/sender's organization number (9 digits) not found for resource {ResourceId}", sanitizedResourceId);
             return CorrespondenceErrors.ServiceOwnerOrgNumberNotFound;

--- a/src/Altinn.Correspondence.Common/Constants/UrnConstants.cs
+++ b/src/Altinn.Correspondence.Common/Constants/UrnConstants.cs
@@ -33,4 +33,8 @@ public static class UrnConstants
     /// xacml string that represents session id
     /// </summary>
     public const string SessionId = "urn:altinn:sessionid";
+    /// <summary>
+    /// Placeholder sender value used in mappers before the actual serviceOwnerOrgNumber is determined from ResourceRegistryService
+    /// </summary>
+    public const string PlaceholderSender = "urn:altinn:organization:identifier-no:000000000";
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The sender is retrieved from Altinn Registry in initializing attachment(s) as we have done for initializing correspondence(s)

## Related Issue(s)
- #1146 
- We are considering the sanitizer for logging in another issue: #1149 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a placeholder value for the sender field during attachment and correspondence initialization.

* **Bug Fixes**
  * Improved handling of sender information by retrieving it from the Resource Registry, ensuring accurate assignment and validation.

* **Refactor**
  * Deprecated and marked the sender property as obsolete in the attachment initialization model.
  * Updated internal logic to use constants and streamlined sender normalization.

* **Tests**
  * Removed tests related to sender validation and URN formatting.
  * Minor updates to test utility methods and parameter names for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->