### PR TITLE
added handling for empty message summary

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
@@ -47,7 +47,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
         {
             // var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, "https://platform.tt02.altinn.no/", true);
             // string result = JsonConvert.SerializeObject(createDialogRequest);
-            // File.WriteAllText(@"c:\temp\output8.json", result);
+            // File.WriteAllText($@"c:\temp\{Guid.NewGuid()}.json", result);
             return Task.FromResult(Guid.NewGuid().ToString());
         }
     }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -67,7 +67,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     }
                 }
             },
-            Summary = new ContentValue()
+            Summary = string.IsNullOrWhiteSpace(correspondence.Content.MessageSummary) ? null : new ContentValue()
             {
                 MediaType = "text/plain",
                 Value = new List<DialogValue> {


### PR DESCRIPTION
When a correspondence doesn't have a summary, it should not submit a "Summary field" to Dialogporten because when this field is submittet DP requires that it has content.


## Description
Changed the Dialogporten call generation to set Summary to NULL value when no summary exists in correspondence.

## Related Issue(s)
- #1150

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or missing message summaries to ensure they are not incorrectly included in correspondence content.

* **Tests**
  * Added a new test to verify that correspondences without a message summary are processed and made available correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->