### PR TITLE
Change slack filter for hangfire retry

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Slack/SlackExceptionNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Integrations/Slack/SlackExceptionNotificationHandler.cs
@@ -61,15 +61,14 @@ public class SlackExceptionNotificationHandler(
 
     public async ValueTask<bool> TryHandleAsync(string jobId, string jobName, Exception exception, int retryCount, CancellationToken cancellationToken)
     {
-        // Skip notifications for retries 0-6 (likely transient issues)
-        // retryCount is 0-based: 0=first attempt, 1=first retry, etc.
-        if (retryCount >= 0 && retryCount < 7)
+        var shouldNotify = retryCount == 3 || retryCount == 6 || retryCount == 10;
+        
+        if (!shouldNotify)
         {
-            logger.LogInformation("Skipping Slack notification for job {JobId} on retry {RetryCount} (skipping notifications for retries 0-6)", jobId, retryCount);
+            logger.LogInformation("Skipping Slack notification for job {JobId} on retry {RetryCount} (only notifying on retries 3, 6, and 10)", jobId, retryCount);
             return true;
         }
 
-        // Always notify on retries 7, 8, 9, and 10 (likely persistent issues)
         var exceptionMessage = FormatExceptionMessage(jobId, jobName, exception, retryCount);
         logger.LogError(
             exception,


### PR DESCRIPTION
## Description
Changed slack filter to show retry number 3, 6 and 10

## Related Issue(s)
- #1087 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the schedule for Slack notifications on job retries. Notifications are now sent only on retries 3, 6, and 10, with updated log messages to match the new schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->