### PR TITLE
Feat/controll of all recipients

### DIFF
--- a/src/Altinn.Correspondence.Application/ApplicationConstants.cs
+++ b/src/Altinn.Correspondence.Application/ApplicationConstants.cs
@@ -22,13 +22,14 @@ public static class ApplicationConstants
         ".png",
         ".json"
     ];
-    public static readonly List<string> RequiredOrganizationRolesForConfidentialCorrespondence = 
+    public static readonly List<string> RequiredOrganizationRolesForCorrespondenceRecipient = 
     [
         "BEST",
         "DAGL",
         "DTPR",
         "DTSO",
         "INNH",
-        "LEDE"
+        "LEDE",
+        "REPR"
     ];
 }

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -137,9 +137,9 @@ public class PublishCorrespondenceHandler(
         {
             errorMessage = $"Recipient of {correspondenceId} is deleted";
         }
-        else if (roles != null && correspondence.IsConfidential && !roles.HasAnyOfRolesOnPerson(ApplicationConstants.RequiredOrganizationRolesForConfidentialCorrespondence))
+        else if (roles != null && !roles.HasAnyOfRolesOnPerson(ApplicationConstants.RequiredOrganizationRolesForConfidentialCorrespondence))
         {
-            errorMessage = $"Recipient of {correspondenceId} is missing required roles to read confidential correspondences";
+            errorMessage = $"Recipient of {correspondenceId} is missing roles to read correspondences. Consider sending physical post to this recipient instead.";
         }
         CorrespondenceStatusEntity status;
         AltinnEventType eventType = AltinnEventType.CorrespondencePublished;

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -137,7 +137,7 @@ public class PublishCorrespondenceHandler(
         {
             errorMessage = $"Recipient of {correspondenceId} is deleted";
         }
-        else if (roles != null && !roles.HasAnyOfRolesOnPerson(ApplicationConstants.RequiredOrganizationRolesForConfidentialCorrespondence))
+        else if (roles != null && !roles.HasAnyOfRolesOnPerson(ApplicationConstants.RequiredOrganizationRolesForCorrespondenceRecipient))
         {
             errorMessage = $"Recipient of {correspondenceId} is missing roles to read correspondences. Consider sending physical post to this recipient instead.";
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There are organisations that are not able to read correspondences because they are missing someone registered with a role in the organization that can read them. Currently a correspondence fails on publish only if it is flagged as confidential when the recipient do not have one of the requiered roles. This PR makes the check for all correspondences. Also adds REPR (Norsk representant for utenlandsk enhet) as a valid role to read correspondences.

## Related Issue(s)
- #1098

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
