### PR TITLE
Fix recipient with systemuser token

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/MaskinportenAuthenticationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/MaskinportenAuthenticationTests.cs
@@ -1,9 +1,11 @@
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.Application.InitializeCorrespondences;
 using Altinn.Correspondence.Common.Constants;
+using Altinn.Correspondence.Common.Helpers.Models;
 using Altinn.Correspondence.Tests.Factories;
 using Altinn.Correspondence.Tests.Fixtures;
 using Altinn.Correspondence.Tests.Helpers;
+using Microsoft.AspNetCore.Identity.Data;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -43,7 +45,34 @@ namespace Altinn.Correspondence.Tests.TestingFeature
                 ("consumer", TestConsumerClaim)
             );
         }
+        private HttpClient CreateMaskinportenSystemUserClient(params string[] scopes)
+        {
+            var scopeString = string.Join(" ", scopes);
 
+            var authorizationDetails = new SystemUserAuthorizationDetails()
+            {
+                Type = "",
+                SystemUserOrg = new SystemUserOrg()
+                {
+                    Authority = "",
+                    ID = ""
+                },
+                SystemUserId = new List<string>()
+                    {
+                        Guid.NewGuid().ToString()
+                    },
+                SystemId = ""
+            };
+
+            var authDetailsJson = JsonSerializer.Serialize(authorizationDetails);
+
+            return _factory.CreateClientWithAddedClaims(
+                ("scope", scopeString),
+                ("iss", MaskinportenIssuer),
+                ("consumer", TestConsumerClaim),
+                ("authorization_details", authDetailsJson)
+            );
+        }
         private HttpClient CreateValidMaskinportenClient()
         {
             return CreateMaskinportenClient(AuthorizationConstants.ServiceOwnerScope, AuthorizationConstants.SenderScope);
@@ -178,9 +207,9 @@ namespace Altinn.Correspondence.Tests.TestingFeature
         {
             // Arrange
             var maskinportenClient = CreateMaskinportenClient(
-                "some:other:scope", 
-                AuthorizationConstants.ServiceOwnerScope, 
-                AuthorizationConstants.SenderScope, 
+                "some:other:scope",
+                AuthorizationConstants.ServiceOwnerScope,
+                AuthorizationConstants.SenderScope,
                 "another:scope"
             );
             var correspondence = CreateTestCorrespondence();
@@ -251,5 +280,76 @@ namespace Altinn.Correspondence.Tests.TestingFeature
             // Assert - Should succeed, indicating the authentication scheme was correctly identified
             Assert.True(initializeResponse.IsSuccessStatusCode, await initializeResponse.Content.ReadAsStringAsync());
         }
+
+        [Fact]
+        public async Task GetCorrespondenceDetails_WithMaskinportenToken_BothRequiredScopes_Succeeds()
+        {
+            // Arrange
+            var maskinportenClient = CreateValidMaskinportenClient();
+            var correspondence = CreateTestCorrespondence();
+
+            // Act
+            var initializeResponse = await maskinportenClient.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
+            var correspondenceResponse = await initializeResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+            var correspondenceId = correspondenceResponse.Correspondences.First().CorrespondenceId;
+            var detailsResponse = await maskinportenClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/details");
+
+            // Assert
+            Assert.True(detailsResponse.IsSuccessStatusCode, await detailsResponse.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task GetCorrespondenceDetails_WithMaskinportenToken_OnlyServiceOwnerScope_Fails()
+        {
+            // Arrange
+            var validMaskinportenClient = CreateMaskinportenClient(AuthorizationConstants.SenderScope, AuthorizationConstants.ServiceOwnerScope);
+            var invalidMaskinportenClient = CreateMaskinportenClient(AuthorizationConstants.ServiceOwnerScope);
+            var correspondence = CreateTestCorrespondence();
+
+            // Act
+            var initializeResponse = await validMaskinportenClient.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
+            var correspondenceResponse = await initializeResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+            var correspondenceId = correspondenceResponse.Correspondences.First().CorrespondenceId;
+            var detailsResponse = await invalidMaskinportenClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/details");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, detailsResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetCorrespondenceDetails_WithMaskinportenToken_OnlyCorrespondenceWriteScope_Fails()
+        {
+            // Arrange
+            var validMaskinportenClient = CreateMaskinportenClient(AuthorizationConstants.SenderScope, AuthorizationConstants.ServiceOwnerScope);
+            var invalidMaskinportenClient = CreateMaskinportenClient(AuthorizationConstants.SenderScope);
+            var correspondence = CreateTestCorrespondence();
+
+            // Act
+            var initializeResponse = await validMaskinportenClient.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
+            var correspondenceResponse = await initializeResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+            var correspondenceId = correspondenceResponse.Correspondences.First().CorrespondenceId;
+            var detailsResponse = await invalidMaskinportenClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/details");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, detailsResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetCorrespondenceContent_WithMaskinportenSystemUserToken_CorrespondenceReadScope_Succeeds()
+        {
+            // Arrange
+            var maskinportenSenderClient = CreateMaskinportenClient(AuthorizationConstants.SenderScope, AuthorizationConstants.ServiceOwnerScope);
+            var systemUserRecipientClient = CreateMaskinportenSystemUserClient(AuthorizationConstants.RecipientScope);
+            var correspondence = CreateTestCorrespondence();
+
+            // Act
+            var initializeResponse = await maskinportenSenderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
+            var correspondenceResponse = await initializeResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+            var correspondenceId = correspondenceResponse.Correspondences.First().CorrespondenceId;
+            var contentResponse = await systemUserRecipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/content");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, contentResponse.StatusCode);
+        }
     }
-} 
+}

--- a/Test/Altinn.Correspondence.Tests/TestingFeature/MaskinportenAuthenticationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/MaskinportenAuthenticationTests.cs
@@ -1,15 +1,12 @@
 using Altinn.Correspondence.API.Models;
-using Altinn.Correspondence.Application.InitializeCorrespondences;
 using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Common.Helpers.Models;
 using Altinn.Correspondence.Tests.Factories;
 using Altinn.Correspondence.Tests.Fixtures;
 using Altinn.Correspondence.Tests.Helpers;
-using Microsoft.AspNetCore.Identity.Data;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Xunit;
 
 namespace Altinn.Correspondence.Tests.TestingFeature
 {
@@ -51,17 +48,17 @@ namespace Altinn.Correspondence.Tests.TestingFeature
 
             var authorizationDetails = new SystemUserAuthorizationDetails()
             {
-                Type = "",
+                Type = UrnConstants.SystemUser,
                 SystemUserOrg = new SystemUserOrg()
                 {
-                    Authority = "",
-                    ID = ""
+                    Authority = "iso6523-actorid-upis",
+                    ID = "991825827"
                 },
                 SystemUserId = new List<string>()
                     {
                         Guid.NewGuid().ToString()
                     },
-                SystemId = ""
+                SystemId = "991825827_correspondencesystem"
             };
 
             var authDetailsJson = JsonSerializer.Serialize(authorizationDetails);
@@ -340,7 +337,10 @@ namespace Altinn.Correspondence.Tests.TestingFeature
             // Arrange
             var maskinportenSenderClient = CreateMaskinportenClient(AuthorizationConstants.SenderScope, AuthorizationConstants.ServiceOwnerScope);
             var systemUserRecipientClient = CreateMaskinportenSystemUserClient(AuthorizationConstants.RecipientScope);
-            var correspondence = CreateTestCorrespondence();
+            var correspondence = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRequestedPublishTime(DateTimeOffset.UtcNow.AddMinutes(-1))
+                .Build();
 
             // Act
             var initializeResponse = await maskinportenSenderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
@@ -349,7 +349,7 @@ namespace Altinn.Correspondence.Tests.TestingFeature
             var contentResponse = await systemUserRecipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/content");
 
             // Assert
-            Assert.Equal(HttpStatusCode.OK, contentResponse.StatusCode);
+            Assert.True(contentResponse.IsSuccessStatusCode, await contentResponse.Content.ReadAsStringAsync());
         }
     }
 }

--- a/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
@@ -191,7 +191,16 @@ namespace Altinn.Correspondence.API.Auth
             // Altinn
             if (issuerClaim.Value.Contains("altinn.no"))
             {
-                return context.User.HasClaim(c => c.Type == "scope" && c.Value.Split(' ').Contains(AuthorizationConstants.SenderScope));
+                var scopeClaim = context.User.Claims.FirstOrDefault(c => c.Type == "scope");
+                if (scopeClaim != null)
+                {
+                    var scopes = scopeClaim.Value.Split(' ');
+                    if (scopes.Contains(AuthorizationConstants.MigrateScope))
+                    {
+                        return true;
+                    }
+                    return scopes.Contains(AuthorizationConstants.SenderScope);
+                }
             }
 
             // Maskinporten
@@ -201,6 +210,10 @@ namespace Altinn.Correspondence.API.Auth
                 if (scopeClaim != null)
                 {
                     var scopes = scopeClaim.Value.Split(' ');
+                    if (scopes.Contains(AuthorizationConstants.MigrateScope))
+                    {
+                        return true;
+                    }
                     return scopes.Contains(AuthorizationConstants.ServiceOwnerScope) &&
                            scopes.Contains(AuthorizationConstants.SenderScope);
                 }
@@ -228,7 +241,16 @@ namespace Altinn.Correspondence.API.Auth
             // Altinn
             if (issuerClaim.Value.Contains("altinn.no"))
             {
-                return context.User.HasClaim(c => c.Type == "scope" && c.Value.Split(' ').Contains(AuthorizationConstants.RecipientScope));
+                var scopeClaim = context.User.Claims.FirstOrDefault(c => c.Type == "scope");
+                if (scopeClaim != null)
+                {
+                    var scopes = scopeClaim.Value.Split(' ');
+                    if (scopes.Contains(AuthorizationConstants.MigrateScope))
+                    {
+                        return true;
+                    }
+                    return scopes.Contains(AuthorizationConstants.RecipientScope);
+                }
             }
 
             // Maskinporten
@@ -238,6 +260,10 @@ namespace Altinn.Correspondence.API.Auth
                 if (scopeClaim != null)
                 {
                     var scopes = scopeClaim.Value.Split(' ');
+                    if (scopes.Contains(AuthorizationConstants.MigrateScope))
+                    {
+                        return true;
+                    }
                     return scopes.Contains(AuthorizationConstants.RecipientScope);
                 }
             }

--- a/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
@@ -159,37 +159,17 @@ namespace Altinn.Correspondence.API.Auth
             services.AddTransient<IAuthorizationHandler, ScopeAccessHandler>();
             services.AddAuthorization(options =>
             {
-                options.AddPolicy(AuthorizationConstants.Sender, policy => 
-                    policy.RequireAssertion(context =>
-                    {
-                        var issuerClaim = context.User.Claims.FirstOrDefault(c => c.Type == "iss");
-                        if (issuerClaim == null) return false;
+                options.AddPolicy(AuthorizationConstants.Sender, policy =>
+                    policy.RequireAssertion(SenderScopePolicy)
+                          .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, AuthorizationConstants.MaskinportenScheme));
 
-                        // Allow Altinn JWT Bearer tokens with the sender scope
-                        if (issuerClaim.Value.Contains("altinn.no"))
-                        {
-                            return context.User.HasClaim(c => c.Type == "scope" && c.Value.Split(' ').Contains(AuthorizationConstants.SenderScope));
-                        }
-                        
-                        // Allow Maskinporten tokens with both serviceowner and correspondence.write scopes
-                        if (issuerClaim.Value.Contains("maskinporten.no"))
-                        {
-                            var scopeClaim = context.User.Claims.FirstOrDefault(c => c.Type == "scope");
-                            if (scopeClaim != null)
-                            {
-                                var scopes = scopeClaim.Value.Split(' ');
-                                return scopes.Contains(AuthorizationConstants.ServiceOwnerScope) && 
-                                       scopes.Contains(AuthorizationConstants.SenderScope);
-                            }
-                        }
-                        
-                        return false;
-                    })
-                    .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, AuthorizationConstants.MaskinportenScheme));
                 options.AddPolicy(AuthorizationConstants.Recipient, policy =>
-                    policy.RequireScopeIfAltinn(config, AuthorizationConstants.RecipientScope).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, AuthorizationConstants.DialogportenScheme));
+                    policy.RequireScopeIfAltinn(config, AuthorizationConstants.RecipientScope)
+                          .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, AuthorizationConstants.DialogportenScheme));
+
                 options.AddPolicy(AuthorizationConstants.SenderOrRecipient, policy =>
-                    policy.RequireScopeIfAltinn(config, AuthorizationConstants.SenderScope, AuthorizationConstants.RecipientScope).AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, AuthorizationConstants.DialogportenScheme));
+                    policy.RequireAssertion(context => SenderScopePolicy(context) || RecipientScopePolicy(context))
+                    .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, AuthorizationConstants.MaskinportenScheme, AuthorizationConstants.DialogportenScheme));
                 options.AddPolicy(AuthorizationConstants.DialogportenPolicy, policy =>
                 {
                     policy.AddAuthenticationSchemes(AuthorizationConstants.DialogportenScheme).RequireAuthenticatedUser();
@@ -201,6 +181,68 @@ namespace Altinn.Correspondence.API.Auth
                           .AddAuthenticationSchemes(AuthorizationConstants.AllSchemes));
                 options.AddPolicy(AuthorizationConstants.Legacy, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.LegacyScope)).AddAuthenticationSchemes(AuthorizationConstants.LegacyScheme));
             });
+        }
+
+        private static bool SenderScopePolicy(AuthorizationHandlerContext context)
+        {
+            var issuerClaim = context.User.Claims.FirstOrDefault(c => c.Type == "iss");
+            if (issuerClaim == null) return false;
+
+            // Altinn
+            if (issuerClaim.Value.Contains("altinn.no"))
+            {
+                return context.User.HasClaim(c => c.Type == "scope" && c.Value.Split(' ').Contains(AuthorizationConstants.SenderScope));
+            }
+
+            // Maskinporten
+            if (issuerClaim.Value.Contains("maskinporten.no"))
+            {
+                var scopeClaim = context.User.Claims.FirstOrDefault(c => c.Type == "scope");
+                if (scopeClaim != null)
+                {
+                    var scopes = scopeClaim.Value.Split(' ');
+                    return scopes.Contains(AuthorizationConstants.ServiceOwnerScope) &&
+                           scopes.Contains(AuthorizationConstants.SenderScope);
+                }
+            }
+
+            return false;
+        }
+
+        private static bool RecipientScopePolicy(AuthorizationHandlerContext context)
+        {
+            var issuerClaim = context.User.Claims.FirstOrDefault(c => c.Type == "iss");
+            if (issuerClaim == null) return false;
+
+            // Dialogporten
+            if (issuerClaim.Value.Contains("dialogporten"))
+            {
+                var actionsClaim = context.User.Claims.FirstOrDefault(c => c.Type == "a");
+                if (actionsClaim != null)
+                {
+                    var actions = actionsClaim.Value.Split(',');
+                    return actions.Contains("read");
+                }
+            }
+
+            // Altinn
+            if (issuerClaim.Value.Contains("altinn.no"))
+            {
+                return context.User.HasClaim(c => c.Type == "scope" && c.Value.Split(' ').Contains(AuthorizationConstants.RecipientScope));
+            }
+
+            // Maskinporten
+            if (issuerClaim.Value.Contains("maskinporten.no"))
+            {
+                var scopeClaim = context.User.Claims.FirstOrDefault(c => c.Type == "scope");
+                if (scopeClaim != null)
+                {
+                    var scopes = scopeClaim.Value.Split(' ');
+                    return scopes.Contains(AuthorizationConstants.RecipientScope);
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
@@ -162,11 +162,9 @@ namespace Altinn.Correspondence.API.Auth
                 options.AddPolicy(AuthorizationConstants.Sender, policy =>
                     policy.RequireAssertion(SenderScopePolicy)
                           .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, AuthorizationConstants.MaskinportenScheme));
-
                 options.AddPolicy(AuthorizationConstants.Recipient, policy =>
-                    policy.RequireScopeIfAltinn(config, AuthorizationConstants.RecipientScope)
+                    policy.RequireAssertion(RecipientScopePolicy)
                           .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, AuthorizationConstants.DialogportenScheme));
-
                 options.AddPolicy(AuthorizationConstants.SenderOrRecipient, policy =>
                     policy.RequireAssertion(context => SenderScopePolicy(context) || RecipientScopePolicy(context))
                     .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, AuthorizationConstants.MaskinportenScheme, AuthorizationConstants.DialogportenScheme));

--- a/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
@@ -231,7 +231,7 @@ namespace Altinn.Correspondence.API.Auth
                 var actionsClaim = context.User.Claims.FirstOrDefault(c => c.Type == "a");
                 if (actionsClaim != null)
                 {
-                    var actions = actionsClaim.Value.Split(',');
+                    var actions = actionsClaim.Value.Split(';');
                     return actions.Contains("read");
                 }
             }

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -250,7 +250,7 @@ namespace Altinn.Correspondence.API.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient, AuthenticationSchemes = AuthorizationConstants.AltinnTokenOrDialogportenScheme)]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         public async Task<ActionResult<CorrespondenceOverviewExt>> GetCorrespondenceOverview(
             Guid correspondenceId,
             [FromServices] GetCorrespondenceOverviewHandler handler,
@@ -290,7 +290,7 @@ namespace Altinn.Correspondence.API.Controllers
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Route("{correspondenceId}/details")]
-        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient, AuthenticationSchemes = AuthorizationConstants.AltinnTokenOrDialogportenScheme)]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         public async Task<ActionResult<CorrespondenceDetailsExt>> GetCorrespondenceDetails(
             Guid correspondenceId,
             [FromServices] GetCorrespondenceDetailsHandler handler,
@@ -319,7 +319,7 @@ namespace Altinn.Correspondence.API.Controllers
         [HttpGet]
         [Route("{correspondenceId}/content")]
         [Produces("text/plain")]
-        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient, AuthenticationSchemes = AuthorizationConstants.AltinnTokenOrDialogportenScheme)]
+        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
         [ApiExplorerSettings(IgnoreApi = true)]
         public async Task<ActionResult> GetCorrespondenceContent(

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -319,7 +319,7 @@ namespace Altinn.Correspondence.API.Controllers
         [HttpGet]
         [Route("{correspondenceId}/content")]
         [Produces("text/plain")]
-        [Authorize(Policy = AuthorizationConstants.SenderOrRecipient)]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
         [ApiExplorerSettings(IgnoreApi = true)]
         public async Task<ActionResult> GetCorrespondenceContent(
@@ -415,7 +415,7 @@ namespace Altinn.Correspondence.API.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [Authorize(Policy = AuthorizationConstants.Recipient, AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [Route("{correspondenceId}/markasread")]
 
         public async Task<ActionResult> MarkAsRead(
@@ -454,7 +454,7 @@ namespace Altinn.Correspondence.API.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [Authorize(Policy = AuthorizationConstants.Recipient, AuthenticationSchemes = AuthorizationConstants.AltinnTokenOrDialogportenScheme)]
+        [Authorize(Policy = AuthorizationConstants.Recipient)]
         [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
         [Route("{correspondenceId}/confirm")]
         public async Task<ActionResult> Confirm(

--- a/src/Altinn.Correspondence.Common/Constants/UrnConstants.cs
+++ b/src/Altinn.Correspondence.Common/Constants/UrnConstants.cs
@@ -37,4 +37,8 @@ public static class UrnConstants
     /// Placeholder sender value used in mappers before the actual serviceOwnerOrgNumber is determined from ResourceRegistryService
     /// </summary>
     public const string PlaceholderSender = "urn:altinn:organization:identifier-no:000000000";
+    /// <summary>
+    /// xacml string that refers to systemuser authentication
+    /// </summary>
+    public const string SystemUser = "urn:altinn:systemuser";
 }


### PR DESCRIPTION
## Description
Also updated authorization policy for /content to only permit recipients (403 error instead of 401).

## Related Issue(s)
- #1022

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for system user authentication in correspondence services.
  * Enhanced authorization policies to recognize a new "migrate" scope for both sender and recipient roles.

* **Refactor**
  * Authorization logic has been modularized for improved maintainability and clarity.

* **Bug Fixes**
  * Adjusted authorization on several endpoints to simplify and ensure correct policy application.

* **Tests**
  * Added comprehensive tests for Maskinporten token scope validation and system user access scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->