### PR TITLE
Added AttachmentsDownloaded as an active status in legacy search

### DIFF
--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -76,6 +76,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
                     statusesToFilter.Add(CorrespondenceStatus.Read);
                     statusesToFilter.Add(CorrespondenceStatus.Confirmed);
                     statusesToFilter.Add(CorrespondenceStatus.Replied);
+                    statusesToFilter.Add(CorrespondenceStatus.AttachmentsDownloaded);
                 }
 
                 if (includeArchived) // Include correspondences with active status


### PR DESCRIPTION
## Description
Small bugfix. 

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated filtering so that correspondences with the status "AttachmentsDownloaded" are now included among active items when viewing or processing active correspondences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->