### PR TITLE
Update storage size for database server

### DIFF
--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -46,7 +46,7 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     administratorLogin: databaseUser
     administratorLoginPassword: administratorLoginPassword
     storage: {
-      storageSizeGB: prodLikeEnvironment ? 2048 : 32
+      storageSizeGB: prodLikeEnvironment ? 4096 : 32
       autoGrow: 'Enabled'
       tier: prodLikeEnvironment ? 'P40' : 'P4'
     }


### PR DESCRIPTION
## Description
It's a required parameter despite autogrow being enabled which leads to having to periodically update it. Alternative solution, using an "existing" definition for the postgres definition, can cause trouble when deploying to new environment.

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
