### PR TITLE
Set correct storage tier for prodlike environments

### DIFF
--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -48,7 +48,7 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     storage: {
       storageSizeGB: prodLikeEnvironment ? 4096 : 32
       autoGrow: 'Enabled'
-      tier: prodLikeEnvironment ? 'P40' : 'P4'
+      tier: prodLikeEnvironment ? 'P50' : 'P4'
     }
     backup: { backupRetentionDays: 35 }
     authConfig: {

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -76,7 +76,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
                     statusesToFilter.Add(CorrespondenceStatus.Read);
                     statusesToFilter.Add(CorrespondenceStatus.Confirmed);
                     statusesToFilter.Add(CorrespondenceStatus.Replied);
-                    statusesToFilter.Add(CorrespondenceStatus.AttachmentsDownloaded);
+                    //statusesToFilter.Add(CorrespondenceStatus.AttachmentsDownloaded);
                 }
 
                 if (includeArchived) // Include correspondences with active status


### PR DESCRIPTION
## Description
Set correct storage tier for prodlike environments

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased storage size and tier for PostgreSQL flexible server in production-like environments.

* **Bug Fixes**
  * Adjusted correspondence status filtering to exclude items marked as "AttachmentsDownloaded" from active status results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->