### PR TITLE
1181 fixed long title of correspondence

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
@@ -1,5 +1,6 @@
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Common.Constants;
 
 namespace Altinn.Correspondence.Tests.Factories
 {
@@ -13,13 +14,22 @@ namespace Altinn.Correspondence.Tests.Factories
             {
                 Id = Guid.NewGuid(),
                 ResourceId = "test-resource-id",
-                Recipient = "test-recipient",
-                Sender = "test-sender",
+                Recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827",
+                Sender = $"{UrnConstants.OrganizationNumberAttribute}:991825827",
                 SendersReference = "test-senders-reference",
                 RequestedPublishTime = DateTimeOffset.UtcNow,
                 Statuses = new List<CorrespondenceStatusEntity>(),
                 ExternalReferences = new List<ExternalReferenceEntity>(),
-                Created = DateTimeOffset.UtcNow
+                Created = DateTimeOffset.UtcNow,
+                Content = new CorrespondenceContentEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Language = "nb",
+                    MessageTitle = "Default title",
+                    MessageSummary = "Default summary",
+                    MessageBody = "Default body",
+                    Attachments = new List<CorrespondenceAttachmentEntity>()
+                }
             };
         }
 
@@ -45,6 +55,15 @@ namespace Altinn.Correspondence.Tests.Factories
                 ReferenceType = referenceType,
                 ReferenceValue = referenceValue
             });
+            return this;
+        }
+
+        public CorrespondenceEntityBuilder WithMessageTitle(string? messageTitle)
+        {
+            if (_correspondenceEntity.Content != null)
+            {
+                _correspondenceEntity.Content.MessageTitle = messageTitle ?? "";
+            }
             return this;
         }
     }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -224,6 +224,41 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
             Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
         }
+
+        [Fact]
+        public async Task InitializeCorrespondence_WithTitleTooLong_ReturnsBadRequest()
+        {
+            // Arrange - Create a title that exceeds 255 characters
+            var longTitle = new string('A', 256); // 256 characters to exceed the limit
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithMessageTitle(longTitle)
+                .Build();
+
+            // Act
+            var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task InitializeCorrespondence_WithTitleAt255Characters_Succeeds()
+        {
+            // Arrange - Create a title exactly at the 255 character limit
+            var maxLengthTitle = new string('A', 255); // Exactly 255 characters
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithMessageTitle(maxLengthTitle)
+                .Build();
+
+            // Act
+            var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
+        }
+
         [Fact]
         public async Task InitializeCorrespondence_With_RecipientToken_succeeds()
         {

--- a/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
@@ -1,0 +1,154 @@
+using Altinn.Correspondence.Integrations.Dialogporten.Mappers;
+using Altinn.Correspondence.Tests.Factories;
+
+namespace Altinn.Correspondence.Tests.TestingUtility;
+
+public class CreateDialogRequestMapperTests
+{
+    [Fact]
+    public void CreateCorrespondenceDialog_WithShortTitle_PreservesTitle()
+    {
+        // Arrange
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithMessageTitle("Short title")
+            .Build();
+        var baseUrl = "https://example.com";
+
+        // Act
+        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
+
+        // Assert
+        Assert.NotNull(result.Content);
+        Assert.NotNull(result.Content.Title);
+        Assert.Single(result.Content.Title.Value);
+        Assert.Equal("Short title", result.Content.Title.Value[0].Value);
+    }
+
+    [Fact]
+    public void CreateCorrespondenceDialog_WithTitleAt252Characters_PreservesTitle()
+    {
+        // Arrange
+        var title252 = new string('A', 252); // Exactly 252 characters
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithMessageTitle(title252)
+            .Build();
+        var baseUrl = "https://example.com";
+
+        // Act
+        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
+
+        // Assert
+        Assert.NotNull(result.Content);
+        Assert.NotNull(result.Content.Title);
+        Assert.Single(result.Content.Title.Value);
+        Assert.Equal(title252, result.Content.Title.Value[0].Value);
+        Assert.Equal(252, result.Content.Title.Value[0].Value.Length);
+    }
+
+    [Fact]
+    public void CreateCorrespondenceDialog_WithTitleAt255Characters_PreservesTitle()
+    {
+        // Arrange
+        var title255 = new string('A', 255); // 255 characters - should be preserved as-is
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithMessageTitle(title255)
+            .Build();
+        var baseUrl = "https://example.com";
+
+        // Act
+        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
+
+        // Assert
+        Assert.NotNull(result.Content);
+        Assert.NotNull(result.Content.Title);
+        Assert.Single(result.Content.Title.Value);
+        Assert.Equal(title255, result.Content.Title.Value[0].Value);
+        Assert.Equal(255, result.Content.Title.Value[0].Value.Length);
+    }
+
+    [Fact]
+    public void CreateCorrespondenceDialog_WithTitleAt256Characters_TruncatesTitle()
+    {
+        // Arrange
+        var title256 = new string('A', 256); // 256 characters - should be truncated (first length to exceed 255)
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithMessageTitle(title256)
+            .Build();
+        var baseUrl = "https://example.com";
+
+        // Act
+        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
+
+        // Assert
+        Assert.NotNull(result.Content);
+        Assert.NotNull(result.Content.Title);
+        Assert.Single(result.Content.Title.Value);
+        
+        var resultTitle = result.Content.Title.Value[0].Value;
+        Assert.Equal(255, resultTitle.Length); // 252 + 3 for "..."
+        Assert.EndsWith("...", resultTitle);
+        Assert.StartsWith(new string('A', 252), resultTitle);
+    }
+
+    [Fact]
+    public void CreateCorrespondenceDialog_WithVeryLongTitle_TruncatesCorrectly()
+    {
+        // Arrange
+        var veryLongTitle = new string('A', 500); // Very long title - should be truncated to exactly 255
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithMessageTitle(veryLongTitle)
+            .Build();
+        var baseUrl = "https://example.com";
+
+        // Act
+        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
+
+        // Assert
+        Assert.NotNull(result.Content);
+        Assert.NotNull(result.Content.Title);
+        Assert.Single(result.Content.Title.Value);
+        
+        var resultTitle = result.Content.Title.Value[0].Value;
+        Assert.Equal(255, resultTitle.Length); // Should be exactly 255 (252 + "...")
+        Assert.EndsWith("...", resultTitle);
+        Assert.StartsWith(new string('A', 252), resultTitle);
+    }
+
+    [Fact]
+    public void CreateCorrespondenceDialog_WithNullTitle_HandlesGracefully()
+    {
+        // Arrange
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithMessageTitle(null)
+            .Build();
+        var baseUrl = "https://example.com";
+
+        // Act
+        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
+
+        // Assert
+        Assert.NotNull(result.Content);
+        Assert.NotNull(result.Content.Title);
+        Assert.Single(result.Content.Title.Value);
+        Assert.Equal("", result.Content.Title.Value[0].Value);
+    }
+
+    [Fact]
+    public void CreateCorrespondenceDialog_WithEmptyTitle_HandlesGracefully()
+    {
+        // Arrange
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithMessageTitle("")
+            .Build();
+        var baseUrl = "https://example.com";
+
+        // Act
+        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
+
+        // Assert
+        Assert.NotNull(result.Content);
+        Assert.NotNull(result.Content.Title);
+        Assert.Single(result.Content.Title.Value);
+        Assert.Equal("", result.Content.Title.Value[0].Value);
+    }
+}

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -42,6 +42,7 @@ public static class CorrespondenceErrors
     public static Error DuplicateInitCorrespondenceRequest = new Error(1034, "A correspondence with the same idempotent key already exists", HttpStatusCode.Conflict);
     public static Error InvalidReplyOptions = new Error(1035, "Reply options must be well-formed URIs and HTTPS with a max length of 255 characters", HttpStatusCode.BadRequest);
     public static Error ServiceOwnerOrgNumberNotFound = new Error(1036, "Service owner/sender's organization number (9 digits) not found for resource", HttpStatusCode.InternalServerError);
+    public static Error MessageTitleTooLong = new Error(1037, "Message title cannot exceed 255 characters", HttpStatusCode.BadRequest);
 }
 
 public static class AttachmentErrors

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -70,6 +70,10 @@ namespace Altinn.Correspondence.Application.Helpers
             {
                 return CorrespondenceErrors.MessageTitleIsNotPlainText;
             }
+            if (content.MessageTitle.Length > 255)
+            {
+                return CorrespondenceErrors.MessageTitleTooLong;
+            }
             if (string.IsNullOrWhiteSpace(content.MessageBody))
             {
                 return CorrespondenceErrors.MessageBodyEmpty;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -69,7 +69,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 Value = new List<DialogValue> {
                     new DialogValue()
                     {
-                        Value = correspondence.Content!.MessageTitle ?? "",
+                        Value = TruncateTitleForDialogporten(correspondence.Content!.MessageTitle ?? ""),
                         LanguageCode = correspondence.Content.Language
                     }
                 }
@@ -421,6 +421,23 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     }
                 }
             }).ToList() ?? new List<Attachment>();
+        }
+
+        /// <summary>
+        /// Truncates titles longer than 255 characters to 252 characters and adds "..." to fit within Dialogporten's 255 character limit.
+        /// Titles 255 characters or shorter are sent as-is to Dialogporten.
+        /// This serves as a safety net for existing correspondence with long titles that failed Dialog Porten creation,
+        /// allowing them to retry successfully. New correspondence requests are validated to prevent titles > 255 chars.
+        /// </summary>
+        /// <param name="title">The original title</param>
+        /// <returns>The title truncated to fit Dialogporten's requirements</returns>
+        private static string TruncateTitleForDialogporten(string title)
+        {
+            if (string.IsNullOrEmpty(title))
+                return title;
+
+            // Dialogporten has a 255 character limit, so we truncate to 252 and add "..." only for titles > 255 chars
+            return title.Length <= 255 ? title : title.Substring(0, 252) + "...";
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1181 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure message titles do not exceed 255 characters.
  * Introduced error messaging for titles that are too long.

* **Bug Fixes**
  * Implemented automatic truncation of overly long message titles to prevent failures during integration.

* **Tests**
  * Added tests to verify correct handling, truncation, and validation of message titles at various lengths, including boundary and excessive cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->