### PR TITLE
removed staging from tests env

### DIFF
--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -14,7 +14,6 @@ on:
                 type: choice
                 options:
                 - test
-                - staging
                 - yt01
             tag:
                 description: 'tag the performance test'
@@ -58,9 +57,9 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: OIDC Login to Azure Public Cloud
-      uses: azure/login@v2
+      uses: azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -84,7 +83,7 @@ jobs:
           exit 1
         fi
     - name: Setup k6
-      uses: grafana/setup-k6-action@v1
+      uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1.1.0
     - name: Run K6 tests (${{ inputs.testSuitePath }})
       run: |
         echo "Running k6 test suite ${{ inputs.testSuitePath }} with ${{ inputs.vus }} VUs for ${{ inputs.duration }} on ${{ inputs.parallelism }} parallelism"


### PR DESCRIPTION
## Description
Removed staging as an alternative for performance testing and enhanced the security of the GitHub Actions workflow in by implementing commit SHA pinning instead of version tag pinning for all third-party actions.

## Related Issue(s)
- #1190 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to use exact versions of actions for improved reliability.
  * Removed "staging" as an environment option in workflow inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->