### PR TITLE
Delete orphaned dialogs for purged correspondences

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CleanupOrphanedDialogsHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CleanupOrphanedDialogsHandlerTests.cs
@@ -1,0 +1,79 @@
+using Altinn.Correspondence.Application.CleanupOrphanedDialogs;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Altinn.Correspondence.Tests.TestingHandler;
+
+public class CleanupOrphanedDialogsHandlerTests
+{
+    [Fact]
+    public async Task ExecuteCleanupInBackground_DeletesAndCountsAlreadyDeleted()
+    {
+        // Arrange
+        var now = DateTimeOffset.UtcNow;
+        var c1 = new CorrespondenceEntity
+        {
+            Id = Guid.NewGuid(),
+            Created = now.AddMinutes(-2),
+            ResourceId = "test-resource",
+            Recipient = "0192:987654321",
+            Sender = "0192:123456789",
+            SendersReference = "ref-1",
+            RequestedPublishTime = now.AddMinutes(-2),
+            ExternalReferences = new List<ExternalReferenceEntity>
+            {
+                new ExternalReferenceEntity { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = "d1" }
+            },
+            Statuses = new List<CorrespondenceStatusEntity>
+            {
+                new CorrespondenceStatusEntity { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = now }
+            }
+        };
+        var c2 = new CorrespondenceEntity
+        {
+            Id = Guid.NewGuid(),
+            Created = now.AddMinutes(-1),
+            ResourceId = "test-resource",
+            Recipient = "0192:987654321",
+            Sender = "0192:123456789",
+            SendersReference = "ref-2",
+            RequestedPublishTime = now.AddMinutes(-1),
+            ExternalReferences = new List<ExternalReferenceEntity>
+            {
+                new ExternalReferenceEntity { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = "d2" }
+            },
+            Statuses = new List<CorrespondenceStatusEntity>
+            {
+                new CorrespondenceStatusEntity { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = now }
+            }
+        };
+
+        var repo = new Mock<ICorrespondenceRepository>();
+        repo.SetupSequence(r => r.GetPurgedCorrespondencesWithDialogsAfter(It.IsAny<int>(), It.IsAny<DateTimeOffset?>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CorrespondenceEntity> { c1, c2 })
+            .ReturnsAsync(new List<CorrespondenceEntity>());
+
+        var dialog = new Mock<IDialogportenService>();
+        dialog.Setup(s => s.TrySoftDeleteDialog("d1")).ReturnsAsync(true);
+        dialog.Setup(s => s.TrySoftDeleteDialog("d2")).ReturnsAsync(false);
+
+        var bg = new Mock<IBackgroundJobClient>();
+        var logger = new Mock<ILogger<CleanupOrphanedDialogsHandler>>();
+
+        var handler = new CleanupOrphanedDialogsHandler(repo.Object, dialog.Object, bg.Object, logger.Object);
+
+        // Act
+        await handler.ExecuteCleanupInBackground(CancellationToken.None);
+
+        // Assert
+        dialog.Verify(s => s.TrySoftDeleteDialog("d1"), Times.Once);
+        dialog.Verify(s => s.TrySoftDeleteDialog("d2"), Times.Once);
+    }
+}
+
+

--- a/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.API/Auth/DependencyInjection.cs
@@ -178,6 +178,9 @@ namespace Altinn.Correspondence.API.Auth
                     policy.RequireScopeIfAltinn(config, AuthorizationConstants.RecipientScope)
                           .AddAuthenticationSchemes(AuthorizationConstants.AllSchemes));
                 options.AddPolicy(AuthorizationConstants.Legacy, policy => policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.LegacyScope)).AddAuthenticationSchemes(AuthorizationConstants.LegacyScheme));
+                options.AddPolicy(AuthorizationConstants.Maintenance, policy =>
+                    policy.AddRequirements(new ScopeAccessRequirement(AuthorizationConstants.MaintenanceScope))
+                          .AddAuthenticationSchemes(AuthorizationConstants.MaskinportenScheme));
             });
         }
 

--- a/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
@@ -1,0 +1,48 @@
+using Altinn.Correspondence.Application;
+using Altinn.Correspondence.Application.CleanupOrphanedDialogs;
+using Altinn.Correspondence.Common.Constants;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Correspondence.API.Controllers;
+
+[ApiController]
+[ApiExplorerSettings(IgnoreApi = true)]
+[Route("correspondence/api/v1/maintenance")]
+[Authorize]
+public class MaintenanceController(ILogger<MaintenanceController> logger) : Controller
+{
+    private readonly ILogger<MaintenanceController> _logger = logger;
+
+    /// <summary>
+    /// Enqueue cleanup of orphaned dialogs in Dialogporten for correspondences already purged in our system
+    /// </summary>
+    /// <response code="200">Returns the enqueued job id</response>
+    /// <response code="401">Unauthorized</response>
+    /// <response code="403">Forbidden</response>
+    [HttpPost]
+    [Route("cleanup-orphaned-dialogs")] 
+    [Authorize(Policy = AuthorizationConstants.Maintenance)]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(CleanupOrphanedDialogsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult> CleanupOrphanedDialogs(
+        [FromServices] CleanupOrphanedDialogsHandler handler,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Request to cleanup orphaned dialogs received");
+        var result = await handler.Process(HttpContext.User, cancellationToken);
+        return result.Match(
+            Ok,
+            Problem
+        );
+    }
+
+    private ActionResult Problem(Error error) => Problem(
+        detail: error.Message,
+        statusCode: (int)error.StatusCode,
+        extensions: new Dictionary<string, object?> { { "errorCode", error.ErrorCode } });
+}
+
+

--- a/src/Altinn.Correspondence.Application/CleanupOrphanedDialogs/CleanupOrphanedDialogsHandler.cs
+++ b/src/Altinn.Correspondence.Application/CleanupOrphanedDialogs/CleanupOrphanedDialogsHandler.cs
@@ -1,0 +1,145 @@
+
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using Microsoft.Extensions.Logging;
+using OneOf;
+using System.Security.Claims;
+using Hangfire;
+
+namespace Altinn.Correspondence.Application.CleanupOrphanedDialogs;
+
+public class CleanupOrphanedDialogsHandler(
+    ICorrespondenceRepository correspondenceRepository,
+    IDialogportenService dialogportenService,
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<CleanupOrphanedDialogsHandler> logger) : IHandler<CleanupOrphanedDialogsResponse>
+{
+    public Task<OneOf<CleanupOrphanedDialogsResponse, Error>> Process(ClaimsPrincipal? user, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Starting cleanup of orphaned dialogs");
+
+        var jobId = backgroundJobClient.Enqueue(() => ExecuteCleanupInBackground(CancellationToken.None));
+
+        logger.LogInformation("Cleanup job {jobId} has been enqueued", jobId);
+
+        return Task.FromResult<OneOf<CleanupOrphanedDialogsResponse, Error>>(new CleanupOrphanedDialogsResponse
+        {
+            JobId = jobId,
+            Message = "Cleanup job has been Enqueued"
+        });
+    }
+
+    [AutomaticRetry(Attempts = 3)]
+    public async Task ExecuteCleanupInBackground(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Executing cleanup of orphaned dialogs in background job");
+        
+        var totalProcessed = 0;
+        var totalDeleted = 0;
+        var totalErrors = 0;
+        var totalAlreadyDeleted = 0;
+        var allErrors = new List<string>();
+
+        try
+        {
+            const int batchSize = 100;
+            DateTimeOffset? lastCreated = null;
+            Guid? lastId = null;
+            bool isMoreCorrespondences = true;
+            
+            while (isMoreCorrespondences)
+            {
+                logger.LogInformation("Processing batch starting after cursor {lastCreated} / {lastId}", lastCreated, lastId);
+                
+                var correspondencesWithDialogs = await correspondenceRepository.GetPurgedCorrespondencesWithDialogsAfter(
+                    batchSize + 1,
+                    lastCreated,
+                    lastId,
+                    true,
+                    cancellationToken);
+                    
+                isMoreCorrespondences = correspondencesWithDialogs.Count > batchSize;
+                if (isMoreCorrespondences)
+                {
+                    var last = correspondencesWithDialogs[batchSize - 1];
+                    lastCreated = last.Created;
+                    lastId = last.Id;
+                    correspondencesWithDialogs = correspondencesWithDialogs.Take(batchSize).ToList();
+                }
+                
+                logger.LogInformation("Found {count} correspondences with dialogs in this batch (IsMore: {isMore})", 
+                    correspondencesWithDialogs.Count, isMoreCorrespondences);
+
+                foreach (var correspondence in correspondencesWithDialogs)
+                {
+                    try
+                    {
+                        var (deleted, alreadyDeleted) = await ProcessSingleCorrespondence(correspondence);
+                        if (deleted) totalDeleted++;
+                        if (alreadyDeleted) totalAlreadyDeleted++;
+                    }
+                    catch (Exception ex)
+                    {
+                        totalErrors++;
+                        var errorMessage = $"Failed to process correspondence {correspondence.Id}: {ex.Message}";
+                        allErrors.Add(errorMessage);
+                        logger.LogError(ex, "Failed to process correspondence {correspondenceId}", correspondence.Id);
+                    }
+                }
+
+                totalProcessed += correspondencesWithDialogs.Count;
+
+                // If no correspondences were found in this batch, all purged correspondences have been processed
+                if (correspondencesWithDialogs.Count == 0)
+                {
+                    isMoreCorrespondences = false;
+                }
+            }
+
+            logger.LogInformation("Background cleanup completed. Total processed: {processedCount}, Total deleted: {deletedCount}, Already deleted: {alreadyDeletedCount}, Total errors: {errorCount}", 
+                totalProcessed, totalDeleted, totalAlreadyDeleted, totalErrors);
+                
+            if (allErrors.Count > 0)
+            {
+                logger.LogWarning("Cleanup completed with {errorCount} errors: {errors}", totalErrors, string.Join("; ", allErrors));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to execute background cleanup of orphaned dialogs");
+            throw;
+        }
+    }
+
+    private async Task<(bool deleted, bool alreadyDeleted)> ProcessSingleCorrespondence(CorrespondenceEntity correspondence)
+    {
+        var dialogId = correspondence.ExternalReferences
+            .FirstOrDefault(er => er.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
+
+        if (dialogId == null)
+        {
+            if (correspondence.Altinn2CorrespondenceId.GetValueOrDefault() > 0)
+            {
+                logger.LogWarning("Skipping purging correspondence {correspondenceId} as it is an Altinn2 correspondence without Dialogporten dialog",
+                    correspondence.Id);
+                return (false, false);
+            }
+            logger.LogError("Correspondence {correspondenceId} has no dialog reference", correspondence.Id);
+            return (false, false);
+        }
+
+        logger.LogInformation("Attempting to delete dialog {dialogId} for purged correspondence {correspondenceId}", 
+            dialogId, correspondence.Id);
+
+        var deleted = await dialogportenService.TrySoftDeleteDialog(dialogId);
+        if (deleted)
+        {
+            logger.LogInformation("Successfully deleted dialog {dialogId} for correspondence {correspondenceId}", dialogId, correspondence.Id);
+            return (true, false);
+        }
+        logger.LogInformation("Dialog {dialogId} already deleted in Dialogporten for correspondence {correspondenceId}", dialogId, correspondence.Id);
+        return (false, true);
+    }
+} 

--- a/src/Altinn.Correspondence.Application/CleanupOrphanedDialogs/CleanupOrphanedDialogsHandler.cs
+++ b/src/Altinn.Correspondence.Application/CleanupOrphanedDialogs/CleanupOrphanedDialogsHandler.cs
@@ -31,7 +31,8 @@ public class CleanupOrphanedDialogsHandler(
         });
     }
 
-    [AutomaticRetry(Attempts = 3)]
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(timeoutInSeconds: 1800)]
     public async Task ExecuteCleanupInBackground(CancellationToken cancellationToken)
     {
         logger.LogInformation("Executing cleanup of orphaned dialogs in background job");

--- a/src/Altinn.Correspondence.Application/CleanupOrphanedDialogs/CleanupOrphanedDialogsResponse.cs
+++ b/src/Altinn.Correspondence.Application/CleanupOrphanedDialogs/CleanupOrphanedDialogsResponse.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Correspondence.Application.CleanupOrphanedDialogs;
+
+public class CleanupOrphanedDialogsResponse
+{
+    public string? JobId { get; set; }
+    public string? Message { get; set; }
+} 

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -23,6 +23,7 @@ using Altinn.Correspondence.Application.UpdateCorrespondenceStatus;
 using Altinn.Correspondence.Application.UploadAttachment;
 using Altinn.Notifications.Core.Helpers;
 using Microsoft.Extensions.DependencyInjection;
+using Altinn.Correspondence.Application.CleanupOrphanedDialogs;
 
 namespace Altinn.Correspondence.Application;
 
@@ -56,6 +57,9 @@ public static class DependencyInjection
         services.AddScoped<CheckNotificationHandler>();
         services.AddScoped<ProcessLegacyPartyHandler>();
         services.AddScoped<CancelNotificationHandler>();
+
+        // Maintenance
+        services.AddScoped<CleanupOrphanedDialogsHandler>();
 
         // Helpers
         services.AddScoped<AttachmentHelper>();

--- a/src/Altinn.Correspondence.Application/IHandler.cs
+++ b/src/Altinn.Correspondence.Application/IHandler.cs
@@ -7,3 +7,7 @@ internal interface IHandler<TRequest, TResponse>
 {
     Task<OneOf<TResponse, Error>> Process(TRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken);
 }
+internal interface IHandler<TResponse>
+{
+    Task<OneOf<TResponse, Error>> Process(ClaimsPrincipal? user, CancellationToken cancellationToken);
+}

--- a/src/Altinn.Correspondence.Common/Constants/AuthorizationConstants.cs
+++ b/src/Altinn.Correspondence.Common/Constants/AuthorizationConstants.cs
@@ -15,12 +15,14 @@ public static class AuthorizationConstants
     public const string SenderScope = "altinn:correspondence.write";
     public const string RecipientScope = "altinn:correspondence.read";
     public const string MigrateScope = "altinn:correspondence.migrate";
+    public const string MaintenanceScope = "altinn:correspondence.maintenance";
     public const string LegacyScope = "altinn:portal/enduser";
     public const string NotificationCheckScope = "altinn:system/notifications.condition.check";
     public const string ServiceOwnerScope = "altinn:serviceowner";
     public const string MaskinportenScheme = "Maskinporten";
     public const string ArbeidsflateCors = "ArbeidsflateCors";
     public const string DownloadAttachmentPolicy = "DownloadAttachmentPolicy";
+    public const string Maintenance = "Maintenance";
     public const string AltinnTokenOrDialogportenScheme = DialogportenScheme + "," + JwtBearerDefaults.AuthenticationScheme;
     public const string LegacyScheme = "LegacyScheme";
     public const string AllSchemes = "AllSchemes";

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -54,5 +54,11 @@ namespace Altinn.Correspondence.Core.Repositories
         Task UpdatePublished(Guid correspondenceId, DateTimeOffset published, CancellationToken cancellationToken);
         Task UpdateIsMigrating(Guid correspondenceId, bool isMigrating, CancellationToken cancellationToken);
         Task<bool> AreAllAttachmentsPublished(Guid correspondenceId, CancellationToken cancellationToken = default);
+        Task<List<CorrespondenceEntity>> GetPurgedCorrespondencesWithDialogsAfter(
+            int limit,
+            DateTimeOffset? lastCreated,
+            Guid? lastId,
+            bool filterMigrated,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
@@ -12,5 +12,6 @@ public interface IDialogportenService
     Task CreateOpenedActivity(Guid correspondenceId, DialogportenActorType actorType, DateTimeOffset activityTimestamp);
     Task PurgeCorrespondenceDialog(Guid correspondenceId);
     Task SoftDeleteDialog(string dialogId);
+    Task<bool> TrySoftDeleteDialogAsync(string dialogId);
     Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName, DateTimeOffset activityTimestamp);
 }

--- a/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
@@ -12,6 +12,6 @@ public interface IDialogportenService
     Task CreateOpenedActivity(Guid correspondenceId, DialogportenActorType actorType, DateTimeOffset activityTimestamp);
     Task PurgeCorrespondenceDialog(Guid correspondenceId);
     Task SoftDeleteDialog(string dialogId);
-    Task<bool> TrySoftDeleteDialogAsync(string dialogId);
+    Task<bool> TrySoftDeleteDialog(string dialogId);
     Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName, DateTimeOffset activityTimestamp);
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
@@ -38,6 +38,11 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
             return Task.CompletedTask;
         }
 
+        public Task<bool> TrySoftDeleteDialogAsync(string dialogId)
+        {
+            return Task.FromResult(true);
+        }
+
         public Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType,  string actorName, DateTimeOffset activityTimestamp)
         {
             return Task.CompletedTask;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
@@ -38,7 +38,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
             return Task.CompletedTask;
         }
 
-        public Task<bool> TrySoftDeleteDialogAsync(string dialogId)
+        public Task<bool> TrySoftDeleteDialog(string dialogId)
         {
             return Task.FromResult(true);
         }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -8,6 +8,7 @@ using Altinn.Correspondence.Integrations.Dialogporten.Mappers;
 using Altinn.Correspondence.Integrations.Dialogporten.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Net;
 using System.Net.Http.Json;
 using UUIDNext;
 
@@ -312,7 +313,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         {
             return true;
         }
-        if (response.StatusCode == System.Net.HttpStatusCode.NotFound || response.StatusCode == System.Net.HttpStatusCode.Gone)
+        if (response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == HttpStatusCode.Gone)
         {
             return false;
         }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -302,6 +302,23 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         }
     }
 
+    public async Task<bool> TrySoftDeleteDialogAsync(string dialogId)
+    {
+        var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+
+        var response = await _httpClient.DeleteAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}", cancellationToken);
+        if (response.IsSuccessStatusCode)
+        {
+            return true;
+        }
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound || response.StatusCode == System.Net.HttpStatusCode.Gone)
+        {
+            return false;
+        }
+        throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+    }
+
     public async Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName, DateTimeOffset activityTimestamp)
     {
         logger.LogInformation("CreateCorrespondencePurgedActivity by {actorType}: for correspondence {correspondenceId}",

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -302,7 +302,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         }
     }
 
-    public async Task<bool> TrySoftDeleteDialogAsync(string dialogId)
+    public async Task<bool> TrySoftDeleteDialog(string dialogId)
     {
         var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -105,7 +105,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
                 return query.Where(_ => false);
             }
 
-            return query.Where(c => statuses.Contains(
+            return query.Where(c => c.Statuses.Any() &&statuses.Contains(
                 c.Statuses
                     .OrderBy(s => s.StatusChanged)
                     .ThenBy(s => s.Id)

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -96,6 +96,22 @@ namespace Altinn.Correspondence.Persistence.Helpers
                 .Where(cs => statusesToFilter.Contains(cs.Statuses.OrderBy(cs => cs.Status).Last().Status));
         }
 
+        public static IQueryable<CorrespondenceEntity> WhereCurrentStatusIn(
+            this IQueryable<CorrespondenceEntity> query,
+            params CorrespondenceStatus[] statuses)
+        {
+            if (statuses == null || statuses.Length == 0)
+            {
+                return query.Where(_ => false);
+            }
+
+            return query.Where(c => statuses.Contains(
+                c.Statuses
+                    .OrderBy(s => s.StatusChanged)
+                    .ThenBy(s => s.Id)
+                    .Last().Status));
+        }
+
         /// <summary>
         /// Filters out migrated correspondences when filterMigrated is true
         /// </summary>

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -194,7 +194,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
         {
             var query = _context.Correspondences
                 .Where(c => c.ExternalReferences.Any(er => er.ReferenceType == ReferenceType.DialogportenDialogId))
-                .IncludeByStatuses(includeActive: false, includeArchived: false, includePurged: true, specificStatus: null)
+                .WhereCurrentStatusIn(CorrespondenceStatus.PurgedByAltinn, CorrespondenceStatus.PurgedByRecipient)
                 .FilterMigrated(filterMigrated)
                 .Include(c => c.Statuses)
                 .Include(c => c.ExternalReferences)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously dialogs were not purged correctly when a correspondence was purged. This pr adds a new endpoint for operators which enqueues a job to process all purged correspondences and attempts to purge its dialog. The job will cleanup orphaned dialogs.

The job selects all correspondences that has purged by altinn or purged by recipient as current status and that has a dialogporten externalreference. It selects batches of 200 purged correspondences at a time that it attempts to purge in dialogporten before retrieving and processing the next batch until all purged correspondences has been processed.

Added a new scope altinn:correspondence.maintenance that gives access to this endpoint. Only the org 991825827 has access to this scope.

The backgroundjob has [DisableConcurrentExecution(timeoutInSeconds: 1800)] to prevent concurrent executions of the backgroundjob

## Related Issue(s)
- #1094 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a maintenance API endpoint (protected by a new maintenance scope/policy) to enqueue a background job that cleans up orphaned dialogs and returns a job ID/message.
  * Background job that pages purged correspondences and attempts safe dialog soft-deletes; includes paging, status-filter helper, and reporting of totals.

* **Tests**
  * New unit tests covering repository paging/ordering and cleanup batching/deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->