### PR TITLE
Fixed missing mapping of "IsReminder" for Migrated NotificationHistory

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -63,6 +63,8 @@ public class MigrationControllerTests : MigrationTestBase
         // Assert
         Assert.Equal(HttpStatusCode.OK, getCorrespondenceDetailsResponse.StatusCode);
         Assert.Equal(8, response.Notifications.Count);
+        Assert.Equal(4, response.Notifications.Where(n => n.IsReminder == false).Count());
+        Assert.Equal(4, response.Notifications.Where(n => n.IsReminder == true).Count());
         Assert.Equal(migrateCorrespondenceExt.Altinn2CorrespondenceId, response.Altinn2CorrespondenceId);
     }
 
@@ -539,7 +541,7 @@ public class MigrationControllerTests : MigrationTestBase
                 NotificationAddress = "123456789",
                 NotificationChannel = NotificationChannelExt.Sms,
                 NotificationSent = new DateTimeOffset(new DateTime(2024, 01, 11)),
-                IsReminder = false
+                IsReminder = true
             },
             new MigrateCorrespondenceNotificationExt()
             {
@@ -547,7 +549,7 @@ public class MigrationControllerTests : MigrationTestBase
                 NotificationAddress = "223456789",
                 NotificationChannel = NotificationChannelExt.Sms,
                 NotificationSent = new DateTimeOffset(new DateTime(2024, 01, 11)),
-                IsReminder = false
+                IsReminder = true
             },
             new MigrateCorrespondenceNotificationExt()
             {
@@ -555,7 +557,7 @@ public class MigrationControllerTests : MigrationTestBase
                 NotificationAddress = "323456789",
                 NotificationChannel = NotificationChannelExt.Sms,
                 NotificationSent = new DateTimeOffset(new DateTime(2024, 01, 11)),
-                IsReminder = false
+                IsReminder = true
             },
             new MigrateCorrespondenceNotificationExt()
             {
@@ -563,7 +565,7 @@ public class MigrationControllerTests : MigrationTestBase
                 NotificationAddress = "423456789",
                 NotificationChannel = NotificationChannelExt.Sms,
                 NotificationSent = new DateTimeOffset(new DateTime(2024, 01, 11)),
-                IsReminder = false
+                IsReminder = true
             }
         ];
     }

--- a/src/Altinn.Correspondence.API/Mappers/MigrateCorrespondenceMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/MigrateCorrespondenceMapper.cs
@@ -28,7 +28,8 @@ internal static class MigrateCorrespondenceMapper
                 NotificationChannel = (NotificationChannel)n.NotificationChannel,
                 NotificationTemplate = NotificationTemplate.Altinn2Message,
                 NotificationAddress = n.NotificationAddress,
-                Altinn2NotificationId = n.Altinn2NotificationId
+                Altinn2NotificationId = n.Altinn2NotificationId,
+                IsReminder = n.IsReminder
             }).ToList(),
             ForwardingEvents = migrateCorrespondenceExt.ForwardingHistory.Select(fh => new CorrespondenceForwardingEventEntity()
             {


### PR DESCRIPTION
## Description
Fixed missing mapping of "IsReminder" property for migrated correspodence Notification History and added unit tests.

## Related Issue(s)
- #1213

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
