### PR TITLE
Updated roles and added seperate list for confidential correspondences

### DIFF
--- a/src/Altinn.Correspondence.Application/ApplicationConstants.cs
+++ b/src/Altinn.Correspondence.Application/ApplicationConstants.cs
@@ -30,6 +30,18 @@ public static class ApplicationConstants
         "DTSO",
         "INNH",
         "LEDE",
-        "REPR"
+        "KOMP",
+        "BOBE"
+    ];
+
+    public static readonly List<string> RequiredOrganizationRolesForConfidentialCorrespondenceRecipient = 
+    [
+        "BEST",
+        "DAGL",
+        "DTPR",
+        "DTSO",
+        "INNH",
+        "LEDE",
+        "KOMP"
     ];
 }

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -132,7 +132,10 @@ public class PublishCorrespondenceHandler(
         {
             errorMessage = $"Recipient of {correspondenceId} is deleted";
         }
-        else if (roles != null && !roles.HasAnyOfRolesOnPerson(ApplicationConstants.RequiredOrganizationRolesForCorrespondenceRecipient))
+        else if (roles != null && !roles.HasAnyOfRolesOnPerson(
+            correspondence.IsConfidential
+                ? ApplicationConstants.RequiredOrganizationRolesForConfidentialCorrespondenceRecipient
+                : ApplicationConstants.RequiredOrganizationRolesForCorrespondenceRecipient))
         {
             errorMessage = $"Recipient of {correspondenceId} lacks roles required to read correspondences. Consider sending physical mail to this recipient instead.";
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The roles that have permission to read ordinary and confidential correspondences are specified here: https://docs.altinn.studio/nb/authorization/what-do-you-get/accessgroups/accessgroups/postogarkiv/. The roles that have access to ordinary correspondences can also delegate the right to read them to others if they have permission to delegate.
No role has permission to open confidential post by default it has to be delegated by roles with 'hovedadministrator' access which is listed here https://docs.altinn.studio/nb/authorization/what-do-you-get/accessgroups/accessgroups/adminstreretilganger/.

To read ordinary correspondences one of the roles listed in the ordinary correspondence permission package is needed and to read confidential correspondences the organisation must have one of the roles with 'hovedadministartor' access.

This PR updates the required organisation roles on the correspondence recipient for ordinary and confidential correspondences.

## Related Issue(s)
- #1098 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
