### PR TITLE
Made message summary field optional in request

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -187,7 +187,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response1.StatusCode);
-            Assert.Equal(HttpStatusCode.BadRequest, response2.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
             Assert.Equal(HttpStatusCode.BadRequest, response3.StatusCode);
         }
 

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -60,7 +60,6 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1019: The Content field must be provided for the correspondence</li>
         /// <li>1020: Message title cannot be empty</li>
         /// <li>1021: Message body cannot be empty</li>
-        /// <li>1022: Message summary cannot be empty</li>
         /// <li>1023: Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)</li>
         /// <li>1033: The idempotency key must be a valid non-empty GUID</li>
         /// <li>1035: Reply options must be well-formed URIs and HTTPS with a max length of 255 characters</li>
@@ -151,7 +150,6 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1019: The Content field must be provided for the correspondence</li>
         /// <li>1020: Message title cannot be empty</li>
         /// <li>1021: Message body cannot be empty</li>
-        /// <li>1022: Message summary cannot be empty</li>
         /// <li>1023: Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)</li>
         /// <li>1033: The idempotency key must be a valid non-empty GUID</li>
         /// <li>1035: Reply options must be well-formed URIs and HTTPS with a max length of 255 characters</li>

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondencesMapper.cs
@@ -35,7 +35,7 @@ internal static class InitializeCorrespondencesMapper
             {
                 Language = request.Correspondence.Content.Language,
                 MessageTitle = request.Correspondence.Content.MessageTitle,
-                MessageSummary = request.Correspondence.Content.MessageSummary,
+                MessageSummary = request.Correspondence.Content.MessageSummary ?? string.Empty,
                 MessageBody = request.Correspondence.Content.MessageBody,
                 Attachments = request.Correspondence.Content.Attachments.Select(
                     attachment => InitializeCorrespondenceAttachmentMapper.MapToEntity(attachment, request.Correspondence.ResourceId, request.Correspondence.Sender)

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceContentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceContentExt.cs
@@ -27,7 +27,7 @@ namespace Altinn.Correspondence.API.Models
         /// Gets or sets a summary text of the correspondence.
         /// </summary>
         [JsonPropertyName("messageSummary")]
-        public required string MessageSummary { get; set; }
+        public string? MessageSummary { get; set; }
 
         /// <summary>
         /// Gets or sets the main body of the correspondence.

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -27,7 +27,6 @@ public static class CorrespondenceErrors
     public static Error MissingContent = new Error(1019, "The Content field must be provided for the correspondence", HttpStatusCode.BadRequest);
     public static Error MessageTitleEmpty = new Error(1020, "Message title cannot be empty", HttpStatusCode.BadRequest);
     public static Error MessageBodyEmpty = new Error(1021, "Message body cannot be empty", HttpStatusCode.BadRequest);
-    public static Error MessageSummaryEmpty = new Error(1022, "Message summary cannot be empty", HttpStatusCode.BadRequest);
     public static Error InvalidLanguage = new Error(1023, "Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)", HttpStatusCode.BadRequest);
     public static Error ReadBeforeFetched = new Error(1024, "Correspondence must be fetched before it can be read", HttpStatusCode.BadRequest);
     public static Error ConfirmBeforeFetched = new Error(1025, "Correspondence must be fetched before it can be confirmed", HttpStatusCode.BadRequest);

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -83,11 +83,7 @@ namespace Altinn.Correspondence.Application.Helpers
             {
                 return CorrespondenceErrors.MessageBodyIsNotMarkdown;
             }
-            if (string.IsNullOrWhiteSpace(content.MessageSummary))
-            {
-                return CorrespondenceErrors.MessageSummaryEmpty;
-            }
-            if (!TextValidation.ValidateMarkdown(content.MessageSummary))
+            if (!string.IsNullOrWhiteSpace(content.MessageSummary) && !TextValidation.ValidateMarkdown(content.MessageSummary))
             {
                 return CorrespondenceErrors.MessageSummaryIsNotMarkdown;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
MessageSummary is not required in dialogporten now. The dialog creation request to dialogporten needs to have null for message summary instead of an empty object when messageSummary is not specified in the correspondence. That was fixed in this commit: https://github.com/Altinn/altinn-correspondence/commit/cd754bbf01564c48ec76f451f6d257b3aac57a0c. This PR makes message summary field optional instead of required.

## Related Issue(s)
- #1232 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message summary is now optional when initializing a correspondence; empty or whitespace-only summaries are accepted.
  * If a summary is provided, it must be valid Markdown; invalid Markdown will be rejected.

* **Documentation**
  * Removed the obsolete API documentation entry for the "summary cannot be empty" error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->