### PR TITLE
Validate max total attachments

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -959,6 +959,89 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
+        public async Task InitializeCorrespondence_WithMoreThan100ExistingAttachments_ReturnsBadRequest()
+        {
+            // Arrange: create 101 published attachments
+            var existing = new List<Guid>();
+            for (int i = 0; i < 101; i++)
+            {
+                var id = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions);
+                existing.Add(id);
+            }
+
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithExistingAttachments(existing)
+                .Build();
+
+            // Act
+            var response = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.Contains(CorrespondenceErrors.AttachmentCountExceeded.Message, body);
+        }
+
+        [Fact]
+        public async Task InitializeCorrespondence_With100ExistingAttachments_ReturnsOk()
+        {
+            // Arrange: create 100 published attachments
+            var existing = new List<Guid>();
+            for (int i = 0; i < 100; i++)
+            {
+                var id = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions);
+                existing.Add(id);
+            }
+
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithExistingAttachments(existing)
+                .Build();
+
+            // Act
+            var response = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task InitializeCorrespondence_WithCombinedExistingAndNew_Attachments_Over100_ReturnsBadRequest()
+        {
+            // Arrange:
+            var existing = new List<Guid>();
+            for (int i = 0; i < 50; i++)
+            {
+                var id = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions);
+                existing.Add(id);
+            }
+
+            var newAttachments = new List<InitializeCorrespondenceAttachmentExt>();
+            for (int i = 0; i < 51; i++)
+            {
+                var attachment = AttachmentHelper.GetAttachmentMetaData($"file-combined-{i}.txt");
+                attachment.DataLocationType = InitializeAttachmentDataLocationTypeExt.NewCorrespondenceAttachment;
+                attachment.ExpirationTime = DateTimeOffset.UtcNow.AddDays(1);
+                newAttachments.Add(attachment);
+            }
+
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithExistingAttachments(existing)
+                .WithAttachments(newAttachments)
+                .Build();
+
+            // Act
+            var response = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.Contains(CorrespondenceErrors.AttachmentCountExceeded.Message, body);
+        }
+
+        [Fact]
         public async Task InitializeCorrespondence_MultipleAttachments_Succeeds()
         {
             // Arrange

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -961,7 +961,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         [Fact]
         public async Task InitializeCorrespondence_WithMoreThan100ExistingAttachments_ReturnsBadRequest()
         {
-            // Arrange: create 101 published attachments
+            // Arrange
             var existing = new List<Guid>();
             for (int i = 0; i < 101; i++)
             {
@@ -986,7 +986,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         [Fact]
         public async Task InitializeCorrespondence_With100ExistingAttachments_ReturnsOk()
         {
-            // Arrange: create 100 published attachments
+            // Arrange
             var existing = new List<Guid>();
             for (int i = 0; i < 100; i++)
             {
@@ -1009,7 +1009,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         [Fact]
         public async Task InitializeCorrespondence_WithMoreThan100ExistingAndNewAttachmentsCombined_ReturnsBadRequest()
         {
-            // Arrange:
+            // Arrange
             var existing = new List<Guid>();
             for (int i = 0; i < 50; i++)
             {

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -1007,7 +1007,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
-        public async Task InitializeCorrespondence_WithCombinedExistingAndNew_Attachments_Over100_ReturnsBadRequest()
+        public async Task InitializeCorrespondence_WithMoreThan100ExistingAndNewAttachmentsCombined_ReturnsBadRequest()
         {
             // Arrange:
             var existing = new List<Guid>();

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -63,6 +63,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1023: Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)</li>
         /// <li>1033: The idempotency key must be a valid non-empty GUID</li>
         /// <li>1035: Reply options must be well-formed URIs and HTTPS with a max length of 255 characters</li>
+        /// <li>1038: A correspondence cannot contain more than 100 attachments in total</li>
         /// <li>3001: The requested notification template with the given language was not found</li>
         /// <li>3002: Email body and subject must be provided when sending email notifications</li>
         /// <li>3003: Reminder email body and subject must be provided when sending reminder email notifications</li>
@@ -153,6 +154,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1023: Invalid language chosen. Supported languages is Norsk bokmål (nb), Nynorsk (nn) and English (en)</li>
         /// <li>1033: The idempotency key must be a valid non-empty GUID</li>
         /// <li>1035: Reply options must be well-formed URIs and HTTPS with a max length of 255 characters</li>
+        /// <li>1038: A correspondence cannot contain more than 100 attachments in total</li>
         /// <li>2001: The requested attachment was not found</li>
         /// <li>2004: File must have content and has a max file size of 2GB</li>
         /// <li>2008: Checksum mismatch</li>

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceContentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceContentExt.cs
@@ -38,11 +38,7 @@ namespace Altinn.Correspondence.API.Models
         /// <summary>
         /// Gets or sets a list of attachments.
         /// </summary>
-        /// <remarks>
-        /// Maximum of 100 attachments allowed.
-        /// </remarks>
         [JsonPropertyName("attachments")]
-        [MaxListCount(100, "attachments")]
         public List<InitializeCorrespondenceAttachmentExt> Attachments { get; set; } = new List<InitializeCorrespondenceAttachmentExt>();
     }
 

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -42,6 +42,7 @@ public static class CorrespondenceErrors
     public static Error InvalidReplyOptions = new Error(1035, "Reply options must be well-formed URIs and HTTPS with a max length of 255 characters", HttpStatusCode.BadRequest);
     public static Error ServiceOwnerOrgNumberNotFound = new Error(1036, "Service owner/sender's organization number (9 digits) not found for resource", HttpStatusCode.InternalServerError);
     public static Error MessageTitleTooLong = new Error(1037, "Message title cannot exceed 255 characters", HttpStatusCode.BadRequest);
+    public static Error AttachmentCountExceeded = new Error(1038, "A correspondence cannot contain more than 100 attachments in total", HttpStatusCode.BadRequest);
 }
 
 public static class AttachmentErrors

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -151,6 +151,13 @@ public class InitializeCorrespondencesHandler(
             return CorrespondenceErrors.ExistingAttachmentNotFound;
         }
 
+        var totalRequestedAttachments = (existingAttachmentIds?.Count ?? 0) + (uploadAttachmentMetadata?.Count ?? 0);
+        if (totalRequestedAttachments > 100)
+        {
+            logger.LogWarning("Attachment count exceeded: existing={ExistingCount}, new={NewCount}", existingAttachmentIds?.Count ?? 0, uploadAttachmentMetadata?.Count ?? 0);
+            return CorrespondenceErrors.AttachmentCountExceeded;
+        }
+
         logger.LogDebug("Checking publication status of existing attachments");
         var anyExistingAttachmentsNotPublished = existingAttachments.Any(a => a.GetLatestStatus()?.Status != AttachmentStatus.Published);
         if (anyExistingAttachmentsNotPublished)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently uploaded attachments in correspondence content is validated to not have a count more than 100. However this limit should be enforced for the total of both existing attachments and new uploaded attachments. This PR adds a validation for the total of both new and existing attachments in the correspondence handler and adds test cases that verify the max limit for existing and new attachments in total. The old validation on just the attachment property is removed by this PR as its covered/corrected by this new validation.

## Related Issue(s)
- #1237

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enforces a maximum of 100 total attachments per correspondence (existing + new). Requests exceeding this limit return Bad Request with error code 1038 and a clear message.

- Documentation
  - API responses for initialization and upload now document error 1038 for exceeding the attachment limit.

- Tests
  - Added tests covering over-limit, exact-limit, and combined attachment scenarios to ensure correct validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->