### PR TITLE
Fix/limit searchtag to 63 chars

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Options;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Integrations.Dialogporten;
+using Altinn.Correspondence.Integrations.Dialogporten.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Altinn.Correspondence.Tests.Factories;
+
+namespace Altinn.Correspondence.Tests.Dialogporten;
+
+public class DialogportenServiceTests
+{
+    private static (DialogportenService service, Func<string> getLastRequestBody) CreateServiceWithMockedDialogPost(CorrespondenceEntity correspondence)
+    {
+        var capturedRequestBody = string.Empty;
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Post &&
+                    m.RequestUri != null &&
+                    m.RequestUri.AbsolutePath.EndsWith("/dialogporten/api/v1/serviceowner/dialogs")),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                capturedRequestBody = await req.Content!.ReadAsStringAsync();
+            })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("\"dialog-id\"", Encoding.UTF8, "application/json")
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object)
+        {
+            BaseAddress = new Uri("https://dialogporten.example/")
+        };
+
+        var mockRepo = new Mock<ICorrespondenceRepository>();
+        mockRepo
+            .Setup(r => r.GetCorrespondenceById(correspondence.Id, true, true, false, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(correspondence);
+
+        var mockIdem = new Mock<IIdempotencyKeyRepository>();
+        mockIdem
+            .Setup(i => i.CreateAsync(It.IsAny<IdempotencyKeyEntity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyKeyEntity e, CancellationToken _) => e);
+        mockIdem
+            .Setup(i => i.CreateRangeAsync(It.IsAny<IEnumerable<IdempotencyKeyEntity>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var mockLogger = new Mock<ILogger<DialogportenService>>();
+        var options = Options.Create(new GeneralSettings { CorrespondenceBaseUrl = "https://correspondence.example" });
+
+        var service = new DialogportenService(httpClient, mockRepo.Object, options, mockLogger.Object, mockIdem.Object);
+        return (service, () => capturedRequestBody);
+    }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialog_TruncatesSearchTags_ToMax63AndSucceeds()
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+        var longValue = new string('A', 100);
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithStatus(CorrespondenceStatus.Initialized)
+            .WithSendersReference(longValue)
+            .WithId(correspondenceId)
+            .Build();
+        var (service, getBody) = CreateServiceWithMockedDialogPost(correspondence);
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialog(correspondenceId);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+        var capturedRequestBody = getBody();
+        Assert.False(string.IsNullOrWhiteSpace(capturedRequestBody));
+
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.SearchTags);
+        Assert.NotEmpty(deserialized.SearchTags);
+        Assert.All(deserialized.SearchTags, t => Assert.True(t.Value.Length <= 63));
+
+        var expectedTruncated = longValue.Substring(0, 63);
+        Assert.Contains(deserialized.SearchTags, t => t.Value == expectedTruncated);
+    }
+}
+
+

--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
@@ -38,6 +38,18 @@ namespace Altinn.Correspondence.Tests.Factories
             return _correspondenceEntity;
         }
 
+        public CorrespondenceEntityBuilder WithId(Guid id)
+        {
+            _correspondenceEntity.Id = id;
+            return this;
+        }
+
+        public CorrespondenceEntityBuilder WithSendersReference(string sendersReference)
+        {
+            _correspondenceEntity.SendersReference = sendersReference;
+            return this;
+        }
+
         public CorrespondenceEntityBuilder WithStatus(CorrespondenceStatus status)
         {
             _correspondenceEntity.Statuses.Add(new CorrespondenceStatusEntity

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -32,7 +32,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         // Create idempotency key for open dialog activity
         await CreateIdempotencyKeysForCorrespondence(correspondence, cancellationToken);
 
-        var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, generalSettings.Value.CorrespondenceBaseUrl);
+        var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, generalSettings.Value.CorrespondenceBaseUrl, false, logger);
         var response = await _httpClient.PostAsJsonAsync("dialogporten/api/v1/serviceowner/dialogs", createDialogRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
@@ -443,7 +443,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
 
         await CreateIdempotencyKeysForCorrespondence(correspondence, cancellationToken);
 
-        var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, generalSettings.Value.CorrespondenceBaseUrl, true);
+        var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, generalSettings.Value.CorrespondenceBaseUrl, true, logger);
         string updateType = enableEvents ? "" : "?IsSilentUpdate=true";
         var response = await _httpClient.PostAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs{updateType}", createDialogRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Dialogporten has a validation that makes it so a searchTag cannot be longer than 63 chars. This PR adds logic to trunctate SearchTags for the dialogs we create for the correspondences down to 63 chars, if they are longer than 63 chars. This prevents an exception from being thrown when sendersreference is longer than 63 chars.

## Related Issue(s)
- #1241 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Dialog creation now safely handles overly long search tags by truncating them to 63 characters, improving reliability and preventing failures with long sender references.
- Tests
  - Added unit test validating successful dialog creation with truncated search tags.
  - Enhanced test builders to support setting ID and sender reference for easier test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->