### PR TITLE
Created batch correspondences should have their own ReplyOptions

### DIFF
--- a/src/Altinn.Correspondence.API/Models/CorrespondenceExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceExt.cs
@@ -1,0 +1,72 @@
+﻿using Altinn.Correspondence.Common.Constants;
+using Altinn.Correspondence.Core.Models.Entities;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Altinn.Correspondence.API.Models;
+
+public class CorrespondenceExt
+{
+    public Guid Id { get; set; }
+
+    [StringLength(255, MinimumLength = 1)]
+    [Required]
+    public required string ResourceId { get; set; }
+
+    [Required]
+    public required string Recipient { get; set; }
+
+    [Required]
+    [RegularExpression($@"^(?:0192:|{UrnConstants.OrganizationNumberAttribute}):\d{{9}}$", ErrorMessage = "Organization numbers should be on the format countrycode:organizationnumber, for instance 0192:910753614")]
+    public required string Sender { get; set; }
+
+    [StringLength(4096, MinimumLength = 1)]
+    [Required]
+    public required string SendersReference { get; set; }
+
+    [StringLength(256, MinimumLength = 0)]
+    public string? MessageSender { get; set; }
+
+    public CorrespondenceContentEntity? Content { get; set; }
+
+    public required DateTimeOffset RequestedPublishTime { get; set; }
+
+    public DateTimeOffset? AllowSystemDeleteAfter { get; set; }
+
+    public DateTimeOffset? DueDateTime { get; set; }
+
+    public List<ExternalReferenceEntity> ExternalReferences { get; set; } = new List<ExternalReferenceEntity>();
+
+    [MaxLength(10, ErrorMessage = "propertyList can contain at most 10 properties")]
+    public Dictionary<string, string> PropertyList { get; set; } = new Dictionary<string, string>();
+
+    public List<CorrespondenceReplyOptionEntity> ReplyOptions { get; set; } = new List<CorrespondenceReplyOptionEntity>();
+
+    [MaxLength(6, ErrorMessage = "Notifications can contain at most 6 notifcations")]
+    public List<CorrespondenceNotificationEntity> Notifications { get; set; } = new List<CorrespondenceNotificationEntity>();
+
+    public bool? IgnoreReservation { get; set; }
+
+    public required List<CorrespondenceStatusEntity> Statuses { get; set; }
+
+    public List<CorrespondenceForwardingEventEntity>? ForwardingEvents { get; set; }
+
+    public List<IdempotencyKeyEntity> IdempotencyKeys { get; set; } = [];
+
+    [Column(TypeName = "jsonb")]
+    public string? OriginalRequest { get; set; }
+
+    [Required]
+    public required DateTimeOffset Created { get; set; }
+
+    public int? Altinn2CorrespondenceId { get; set; }
+
+    public DateTimeOffset? Published { get; set; }
+
+    public bool IsConfirmationNeeded { get; set; }
+
+    public bool IsMigrating { get; set; }
+
+    public bool IsConfidential { get; set; }
+    public int PartyId { get; set; } = 0;
+}

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -120,6 +120,7 @@ public class GetCorrespondenceOverviewHandler(
                 Recipient = correspondence.Recipient,
                 ReplyOptions = correspondence.ReplyOptions ?? new List<CorrespondenceReplyOptionEntity>(),
                 Notifications = notificationsOverview,
+                PropertyList = correspondence.PropertyList,
                 ExternalReferences = correspondence.ExternalReferences ?? new List<ExternalReferenceEntity>(),
                 RequestedPublishTime = correspondence.RequestedPublishTime,
                 IgnoreReservation = correspondence.IgnoreReservation ?? false,

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -120,7 +120,7 @@ public class GetCorrespondenceOverviewHandler(
                 Recipient = correspondence.Recipient,
                 ReplyOptions = correspondence.ReplyOptions ?? new List<CorrespondenceReplyOptionEntity>(),
                 Notifications = notificationsOverview,
-                PropertyList = correspondence.PropertyList,
+                PropertyList = correspondence.PropertyList ?? new Dictionary<string, string>(),
                 ExternalReferences = correspondence.ExternalReferences ?? new List<ExternalReferenceEntity>(),
                 RequestedPublishTime = correspondence.RequestedPublishTime,
                 IgnoreReservation = correspondence.IgnoreReservation ?? false,

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -279,11 +279,19 @@ namespace Altinn.Correspondence.Application.Helpers
                 AllowSystemDeleteAfter = request.Correspondence.AllowSystemDeleteAfter,
                 DueDateTime = request.Correspondence.DueDateTime,
                 PropertyList = request.Correspondence.PropertyList.ToDictionary(x => x.Key, x => x.Value),
-                ReplyOptions = request.Correspondence.ReplyOptions,
+                ReplyOptions = request.Correspondence.ReplyOptions.Select(requestReplyOption => new CorrespondenceReplyOptionEntity()
+                {
+                    LinkText = requestReplyOption.LinkText,
+                    LinkURL = requestReplyOption.LinkURL
+                }).ToList(),
                 IgnoreReservation = request.Correspondence.IgnoreReservation,
                 Statuses = statuses,
                 Created = DateTime.UtcNow,
-                ExternalReferences = request.Correspondence.ExternalReferences,
+                ExternalReferences = request.Correspondence.ExternalReferences.Select(requestExternalReference => new ExternalReferenceEntity()
+                {
+                    ReferenceType = requestExternalReference.ReferenceType,
+                    ReferenceValue = requestExternalReference.ReferenceValue
+                }).ToList(),
                 Published = currentStatus == CorrespondenceStatus.Published ? DateTimeOffset.UtcNow : null,
                 IsConfirmationNeeded = request.Correspondence.IsConfirmationNeeded,
                 IsConfidential = request.Correspondence.IsConfidential,

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -283,7 +283,7 @@ namespace Altinn.Correspondence.Application.Helpers
                 {
                     LinkText = requestReplyOption.LinkText,
                     LinkURL = requestReplyOption.LinkURL
-                }).ToList(),
+                }).ToList() ?? new List<CorrespondenceReplyOptionEntity>(),
                 IgnoreReservation = request.Correspondence.IgnoreReservation,
                 Statuses = statuses,
                 Created = DateTime.UtcNow,
@@ -291,7 +291,7 @@ namespace Altinn.Correspondence.Application.Helpers
                 {
                     ReferenceType = requestExternalReference.ReferenceType,
                     ReferenceValue = requestExternalReference.ReferenceValue
-                }).ToList(),
+                }).ToList() ?? new List<ExternalReferenceEntity>(),
                 Published = currentStatus == CorrespondenceStatus.Published ? DateTimeOffset.UtcNow : null,
                 IsConfirmationNeeded = request.Correspondence.IsConfirmationNeeded,
                 IsConfidential = request.Correspondence.IsConfidential,


### PR DESCRIPTION
## Description
Need to create new child entities for batch entities for EF to work as intended.

## Related Issue(s)
- #1251

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Correspondence overview now includes property list metadata.
  - Reply options are returned with each created correspondence and visible in overviews.
  - Multiple recipients are fully supported with consistent reply options and properties.

- **Tests**
  - Added tests verifying reply options and property lists are present for all correspondences created for multiple recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->