### PR TITLE
Fixed sync of "Read" event to update Dialog with OpenedActivity.

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
@@ -13,7 +13,6 @@ using Hangfire.Common;
 using Hangfire.States;
 using Microsoft.Extensions.Logging;
 using Moq;
-using System.Collections.Generic;
 
 namespace Altinn.Correspondence.Tests.TestingHandler
 {
@@ -487,8 +486,9 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             VerifyAltinnEventEnqueued(correspondenceId, AltinnEventType.CorrespondenceReceiverConfirmed, recipient);
             // Verify background jobs Dialogporten activities
             VerifyDialogportenServiceCreateInformationActivityEnqueued(correspondenceId, DialogportenActorType.Recipient, DialogportenTextType.CorrespondenceConfirmed, recipient);
-            VerifyDialogportenServicePatchCorredpondenceDialogToConfirmedEnqueued(correspondenceId);
-            
+            VerifyDialogportenServicePatchCorrespondenceDialogToConfirmedEnqueued(correspondenceId);
+            VerifyDialogportenServiceCreateOpenedActivityEnqueued(correspondenceId);
+
             // Should not trigger any additional Dialogporten changes or background jobs
             _backgroundJobClientMock.VerifyNoOtherCalls();
             _dialogPortenServiceMock.VerifyNoOtherCalls();
@@ -555,7 +555,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceStatusRepositoryMock.VerifyNoOtherCalls();
             
             // Verify background jobs Dialogporten activities            
-            VerifyDialogportenServiceSetArchivedSystemLabelOnDialogDialogToConfirmedEnqueued(correspondenceId, partyIdentifier);
+            VerifyDialogportenServiceSetArchivedSystemLabelOnDialogEnqueued(correspondenceId, partyIdentifier);
 
             // Verify register lookup performed
             _altinnRegisterServiceMock.Verify(_altinnRegisterServiceMock => _altinnRegisterServiceMock.LookUpPartyByPartyUuid(partyUuid, It.IsAny<CancellationToken>()), Times.Once);
@@ -875,17 +875,24 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 It.IsAny<EnqueuedState>()));
         }
 
-        private void VerifyDialogportenServicePatchCorredpondenceDialogToConfirmedEnqueued(Guid correspondenceId)
+        private void VerifyDialogportenServicePatchCorrespondenceDialogToConfirmedEnqueued(Guid correspondenceId)
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.PatchCorrespondenceDialogToConfirmed) && (Guid)job.Args[0] == correspondenceId),
                 It.IsAny<EnqueuedState>()));
         }
 
-        private void VerifyDialogportenServiceSetArchivedSystemLabelOnDialogDialogToConfirmedEnqueued(Guid correspondenceId, string partyIdentifier)
+        private void VerifyDialogportenServiceSetArchivedSystemLabelOnDialogEnqueued(Guid correspondenceId, string partyIdentifier)
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.SetArchivedSystemLabelOnDialog) && (Guid)job.Args[0] == correspondenceId && (string)job.Args[1] == partyIdentifier),
+                It.IsAny<EnqueuedState>()));
+        }
+
+        private void VerifyDialogportenServiceCreateOpenedActivityEnqueued(Guid correspondenceId)
+        {
+            _backgroundJobClientMock.Verify(x => x.Create(
+                It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.CreateOpenedActivity) && (Guid)job.Args[0] == correspondenceId),
                 It.IsAny<EnqueuedState>()));
         }
     }

--- a/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceStatusEventHandler.cs
+++ b/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceStatusEventHandler.cs
@@ -126,6 +126,10 @@ public class SyncCorrespondenceStatusEventHandler(
                         {
                             await syncCorrespondenceStatusHelper.ReportArchivedToDialogporten(request.CorrespondenceId, eventToExecute.PartyUuid, cancellationToken);
                         }
+                        else if (eventToExecute.Status == CorrespondenceStatus.Read)
+                        {
+                            syncCorrespondenceStatusHelper.ReportReadToDialogporten(request.CorrespondenceId, eventToExecute.StatusChanged);
+                        }
                     }
                 }
 

--- a/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceStatusEventHelper.cs
+++ b/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceStatusEventHelper.cs
@@ -6,7 +6,6 @@ using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
 using Hangfire;
-using static Dapper.SqlMapper;
 
 namespace Altinn.Correspondence.Application.SyncCorrespondenceEvent;
 public class SyncCorrespondenceStatusEventHelper(    
@@ -89,6 +88,11 @@ public class SyncCorrespondenceStatusEventHelper(
         }
 
         backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.SetArchivedSystemLabelOnDialog(correspondenceId, GetPrefixedIdentifierForParty(endUserParty)));
+    }
+
+    public void ReportReadToDialogporten(Guid correspondenceId, DateTimeOffset operationTimestamp)
+    {
+        backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondenceId, DialogportenActorType.Recipient, operationTimestamp));
     }
 
     private string GetPrefixedIdentifierForParty(Party party)

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -9,9 +9,7 @@ using Altinn.Correspondence.Integrations.Dialogporten.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Json;
-using System.Threading;
 using UUIDNext;
 
 namespace Altinn.Correspondence.Integrations.Dialogporten;
@@ -501,7 +499,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var response = await _httpClient.PutAsJsonAsync(url, request, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
-            throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+            throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()} when setting archived system label for dialogid {dialogId} for correpondence {correspondenceId}");
         }
     }
         #endregion


### PR DESCRIPTION
Fixed sync of "Read" event to update Dialog with OpenedActivity so that this is correctly synced from Altinn 2.
Also minor usings cleanup and slight improvement in logging text for SetArchivedSystemLabelOnDialog.


## Related Issue(s)
- #1253 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Read events are now reported to Dialogporten, enabling accurate “opened” activity tracking and improved correspondence status visibility.
* **Tests**
  * Added and updated tests to verify enqueuing of “opened activity” and archived labeling, with clearer helper names.
* **Chores**
  * Improved error messages when applying archived labels to dialogs for better troubleshooting context.
  * Minor code cleanup (imports and naming) with no impact on functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->