### PR TITLE
Optimize cleanup dialog batching for prod

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
@@ -50,6 +50,24 @@ namespace Altinn.Correspondence.Tests.Factories
             return this;
         }
 
+        public CorrespondenceEntityBuilder WithRequestedPublishTime(DateTimeOffset requestedPublishTime)
+        {
+            _correspondenceEntity.RequestedPublishTime = requestedPublishTime;
+            return this;
+        }
+
+        public CorrespondenceEntityBuilder WithRecipient(string recipient)
+        {
+            _correspondenceEntity.Recipient = recipient;
+            return this;
+        }
+
+        public CorrespondenceEntityBuilder WithResourceId(string resourceId)
+        {
+            _correspondenceEntity.ResourceId = resourceId;
+            return this;
+        }
+
         public CorrespondenceEntityBuilder WithCreated(DateTime created)
         {
             _correspondenceEntity.Created = new DateTimeOffset(created);

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CleanupOrphanedDialogsHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CleanupOrphanedDialogsHandlerTests.cs
@@ -6,6 +6,7 @@ using Altinn.Correspondence.Core.Services;
 using Hangfire;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Altinn.Correspondence.Tests.Factories;
 
 namespace Altinn.Correspondence.Tests.TestingHandler;
 
@@ -16,47 +17,30 @@ public class CleanupOrphanedDialogsHandlerTests
     {
         // Arrange
         var now = DateTimeOffset.UtcNow;
-        var c1 = new CorrespondenceEntity
-        {
-            Id = Guid.NewGuid(),
-            Created = now.AddMinutes(-2),
-            ResourceId = "test-resource",
-            Recipient = "0192:987654321",
-            Sender = "0192:123456789",
-            SendersReference = "ref-1",
-            RequestedPublishTime = now.AddMinutes(-2),
-            ExternalReferences = new List<ExternalReferenceEntity>
-            {
-                new ExternalReferenceEntity { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = "d1" }
-            },
-            Statuses = new List<CorrespondenceStatusEntity>
-            {
-                new CorrespondenceStatusEntity { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = now }
-            }
-        };
-        var c2 = new CorrespondenceEntity
-        {
-            Id = Guid.NewGuid(),
-            Created = now.AddMinutes(-1),
-            ResourceId = "test-resource",
-            Recipient = "0192:987654321",
-            Sender = "0192:123456789",
-            SendersReference = "ref-2",
-            RequestedPublishTime = now.AddMinutes(-1),
-            ExternalReferences = new List<ExternalReferenceEntity>
-            {
-                new ExternalReferenceEntity { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = "d2" }
-            },
-            Statuses = new List<CorrespondenceStatusEntity>
-            {
-                new CorrespondenceStatusEntity { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = now }
-            }
-        };
+        var c1 = new CorrespondenceEntityBuilder()
+            .WithCreated(now.UtcDateTime.AddMinutes(-2))
+            .WithRequestedPublishTime(now.AddMinutes(-2))
+            .WithExternalReference(ReferenceType.DialogportenDialogId, "d1")
+            .WithStatus(CorrespondenceStatus.PurgedByAltinn, now.UtcDateTime, Guid.NewGuid())
+            .Build();
+        var c2 = new CorrespondenceEntityBuilder()
+            .WithCreated(now.UtcDateTime.AddMinutes(-1))
+            .WithRequestedPublishTime(now.AddMinutes(-1))
+            .WithExternalReference(ReferenceType.DialogportenDialogId, "d2")
+            .WithStatus(CorrespondenceStatus.PurgedByAltinn, now.UtcDateTime, Guid.NewGuid())
+            .Build();
 
         var repo = new Mock<ICorrespondenceRepository>();
-        repo.SetupSequence(r => r.GetPurgedCorrespondencesWithDialogsAfter(It.IsAny<int>(), It.IsAny<DateTimeOffset?>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+        repo.SetupSequence(r => r.GetCorrespondencesWindowAfter(It.IsAny<int>(), It.IsAny<DateTimeOffset?>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<CorrespondenceEntity> { c1, c2 })
             .ReturnsAsync(new List<CorrespondenceEntity>());
+        repo.Setup(r => r.GetCorrespondencesByIdsWithExternalReferenceAndCurrentStatus(
+                It.IsAny<List<Guid>>(),
+                It.IsAny<ReferenceType>(),
+                It.IsAny<List<CorrespondenceStatus>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<Guid> ids, ReferenceType _, List<CorrespondenceStatus> __, CancellationToken ___) =>
+                new List<CorrespondenceEntity> { c1, c2 }.Where(x => ids.Contains(x.Id)).ToList());
 
         var dialog = new Mock<IDialogportenService>();
         dialog.Setup(s => s.TrySoftDeleteDialog("d1")).ReturnsAsync(true);
@@ -83,22 +67,16 @@ public class CleanupOrphanedDialogsHandlerTests
         var all = new List<CorrespondenceEntity>();
         for (int i = 0; i < 5; i++)
         {
-            all.Add(new CorrespondenceEntity
-            {
-                Id = Guid.NewGuid(),
-                Created = baseTime.AddSeconds(i),
-                Recipient = "0192:987654321",
-                RequestedPublishTime = baseTime.AddSeconds(i),
-                ResourceId = "r",
-                Sender = "0192:123456789",
-                SendersReference = i.ToString(),
-                Statuses = new List<CorrespondenceStatusEntity> { new() { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = baseTime.AddSeconds(i) } },
-                ExternalReferences = new List<ExternalReferenceEntity> { new() { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = $"d{i}" } }
-            });
+            all.Add(new CorrespondenceEntityBuilder()
+                .WithCreated(baseTime.AddSeconds(i).UtcDateTime)
+                .WithRequestedPublishTime(baseTime.AddSeconds(i))
+                .WithExternalReference(ReferenceType.DialogportenDialogId, $"d{i}")
+                .WithStatus(CorrespondenceStatus.PurgedByAltinn, baseTime.AddSeconds(i).UtcDateTime, Guid.NewGuid())
+                .Build());
         }
 
         var repo = new Mock<ICorrespondenceRepository>();
-        repo.Setup(r => r.GetPurgedCorrespondencesWithDialogsAfter(It.IsAny<int>(), It.IsAny<DateTimeOffset?>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+        repo.Setup(r => r.GetCorrespondencesWindowAfter(It.IsAny<int>(), It.IsAny<DateTimeOffset?>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync((int limit, DateTimeOffset? lastCreated, Guid? lastId, bool _, CancellationToken __) =>
             {
                 var query = all
@@ -110,6 +88,13 @@ public class CleanupOrphanedDialogsHandlerTests
                     .ToList();
                 return query;
             });
+        repo.Setup(r => r.GetCorrespondencesByIdsWithExternalReferenceAndCurrentStatus(
+                It.IsAny<List<Guid>>(),
+                It.IsAny<ReferenceType>(),
+                It.IsAny<List<CorrespondenceStatus>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<Guid> ids, ReferenceType _, List<CorrespondenceStatus> __, CancellationToken ___) =>
+                all.Where(x => ids.Contains(x.Id)).ToList());
 
         var processed = new HashSet<string>();
         var dialog = new Mock<IDialogportenService>();

--- a/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
@@ -5,6 +5,7 @@ using Altinn.Correspondence.Persistence.Repositories;
 using Altinn.Correspondence.Tests.Fixtures;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Altinn.Correspondence.Tests.Factories;
 
 namespace Altinn.Correspondence.Tests.TestingRepository
 {
@@ -22,17 +23,8 @@ namespace Altinn.Correspondence.Tests.TestingRepository
         {
             // Arrange
             await using var context = _fixture.CreateDbContext();
-            var correspondence = new CorrespondenceEntity
-            {
-                Created = DateTime.UtcNow,
-                Recipient = "0192:987654321",
-                RequestedPublishTime = DateTime.UtcNow,
-                ResourceId = "1",
-                Sender = "0192:123456789",
-                SendersReference = "1",
-                Statuses = new List<CorrespondenceStatusEntity>(),
-                PropertyList = new Dictionary<string, string>()
-            };
+            var correspondence = new CorrespondenceEntityBuilder()
+                .Build();
 
             // Act
             context.Correspondences.Add(correspondence);
@@ -56,29 +48,14 @@ namespace Altinn.Correspondence.Tests.TestingRepository
             var to = DateTimeOffset.UtcNow.AddDays(1);
             var recipient = "0192:987654321";
             var resource = "LegacyCorrespondenceSearch_CorrespondencesAddedForParty_GetCorrespondencesForPartyReturnsSome";
-            var addedCorrespondence = await correspondenceRepository.CreateCorrespondence(new CorrespondenceEntity()
-            {
-                Created = DateTimeOffset.UtcNow,
-                Recipient = recipient,
-                RequestedPublishTime = DateTimeOffset.UtcNow,
-                ResourceId = resource,
-                Sender = "0192:123456789",
-                SendersReference = "1",
-                Statuses = new List<CorrespondenceStatusEntity>()
-                {
-                    new CorrespondenceStatusEntity()
-                    {
-                        Status = Core.Models.Enums.CorrespondenceStatus.Initialized
-                    },
-                    new CorrespondenceStatusEntity()
-                    {
-                        Status = Core.Models.Enums.CorrespondenceStatus.ReadyForPublish
-                    },
-                    new CorrespondenceStatusEntity(){
-                        Status = Core.Models.Enums.CorrespondenceStatus.Published
-                    }
-                },
-            }, CancellationToken.None);
+            var entity = new CorrespondenceEntityBuilder()
+                .WithRecipient(recipient)
+                .WithResourceId(resource)
+                .WithStatus(CorrespondenceStatus.Initialized)
+                .WithStatus(CorrespondenceStatus.ReadyForPublish)
+                .WithStatus(CorrespondenceStatus.Published)
+                .Build();
+            var addedCorrespondence = await correspondenceRepository.CreateCorrespondence(entity, CancellationToken.None);
 
             // Act
             var correspondences = await correspondenceRepository.GetCorrespondencesForParties(1000, from, to, null, [recipient], [resource], true, false, false, "", CancellationToken.None);
@@ -91,107 +68,154 @@ namespace Altinn.Correspondence.Tests.TestingRepository
         }
 
         [Fact]
-        public async Task GetPurgedCorrespondencesWithDialogsAfter_TieBreakerOnEqualCreated_UsesIdAscending()
+        public async Task GetCorrespondencesWindowAfter_TieBreakerOnEqualCreated_UsesIdAscending()
         {
             await using var context = _fixture.CreateDbContext();
             var repo = new CorrespondenceRepository(context, new NullLogger<ICorrespondenceRepository>());
-            var baseTime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var baseTime = new DateTime(2000, 1, 1, 0, 0, 0);
 
             var idA = new Guid("00000000-0000-0000-0000-000000000001");
             var idB = new Guid("00000000-0000-0000-0000-000000000002");
             var items = new List<CorrespondenceEntity>
             {
-                new CorrespondenceEntity
-                {
-                    Id = idA,
-                    Created = baseTime,
-                    Recipient = "0192:987654321",
-                    RequestedPublishTime = baseTime,
-                    ResourceId = "r",
-                    Sender = "0192:123456789",
-                    SendersReference = "A",
-                    Statuses = new List<CorrespondenceStatusEntity> { new() { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = baseTime } },
-                    ExternalReferences = new List<ExternalReferenceEntity> { new() { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = "dA" } }
-                },
-                new CorrespondenceEntity
-                {
-                    Id = idB,
-                    Created = baseTime,
-                    Recipient = "0192:987654321",
-                    RequestedPublishTime = baseTime,
-                    ResourceId = "r",
-                    Sender = "0192:123456789",
-                    SendersReference = "B",
-                    Statuses = new List<CorrespondenceStatusEntity> { new() { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = baseTime } },
-                    ExternalReferences = new List<ExternalReferenceEntity> { new() { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = "dB" } }
-                }
+                new CorrespondenceEntityBuilder()
+                    .WithId(idA)
+                    .WithCreated(baseTime)
+                    .WithRequestedPublishTime(baseTime)
+                    .WithExternalReference(ReferenceType.DialogportenDialogId, "dA")
+                    .WithStatus(CorrespondenceStatus.PurgedByAltinn, baseTime, Guid.NewGuid())
+                    .Build(),
+                new CorrespondenceEntityBuilder()
+                    .WithId(idB)
+                    .WithCreated(baseTime)
+                    .WithRequestedPublishTime(baseTime)
+                    .WithExternalReference(ReferenceType.DialogportenDialogId, "dB")
+                    .WithStatus(CorrespondenceStatus.PurgedByAltinn, baseTime, Guid.NewGuid())
+                    .Build()
             };
             context.Correspondences.AddRange(items);
             await context.SaveChangesAsync();
 
-            var page1 = await repo.GetPurgedCorrespondencesWithDialogsAfter(1, null, null, true, CancellationToken.None);
+            var page1 = await repo.GetCorrespondencesWindowAfter(1, null, null, true, CancellationToken.None);
             Assert.Single(page1);
             Assert.Equal(idA, page1[0].Id);
 
-            var page2 = await repo.GetPurgedCorrespondencesWithDialogsAfter(1, page1[0].Created, page1[0].Id, true, CancellationToken.None);
+            var page2 = await repo.GetCorrespondencesWindowAfter(1, page1[0].Created, page1[0].Id, true, CancellationToken.None);
             Assert.Single(page2);
             Assert.Equal(idB, page2[0].Id);
         }
 
         [Fact]
-        public async Task GetPurgedCorrespondencesWithDialogsAfter_ReturnsInOrderAndPages()
+        public async Task GetCorrespondencesWindowAfter_ReturnsInOrderAndPages()
         {
             await using var context = _fixture.CreateDbContext();
             var repo = new CorrespondenceRepository(context, new NullLogger<ICorrespondenceRepository>());
-            var baseTime = new DateTimeOffset(2000, 1, 2, 0, 0, 0, TimeSpan.Zero);
+            var baseTime = new DateTime(2000, 1, 2, 0, 0, 0);
 
             var items = new List<CorrespondenceEntity>
             {
-                new CorrespondenceEntity
-                {
-                    Created = baseTime,
-                    Recipient = "0192:987654321",
-                    RequestedPublishTime = baseTime,
-                    ResourceId = "r",
-                    Sender = "0192:123456789",
-                    SendersReference = "A",
-                    Statuses = new List<CorrespondenceStatusEntity> { new() { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = baseTime } },
-                    ExternalReferences = new List<ExternalReferenceEntity> { new() { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = "dA" } }
-                },
-                new CorrespondenceEntity
-                {
-                    Created = baseTime.AddMinutes(1),
-                    Recipient = "0192:987654321",
-                    RequestedPublishTime = baseTime.AddMinutes(1),
-                    ResourceId = "r",
-                    Sender = "0192:123456789",
-                    SendersReference = "B",
-                    Statuses = new List<CorrespondenceStatusEntity> { new() { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = baseTime.AddMinutes(1) } },
-                    ExternalReferences = new List<ExternalReferenceEntity> { new() { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = "dB" } }
-                },
-                new CorrespondenceEntity
-                {
-                    Created = baseTime.AddMinutes(2),
-                    Recipient = "0192:987654321",
-                    RequestedPublishTime = baseTime.AddMinutes(2),
-                    ResourceId = "r",
-                    Sender = "0192:123456789",
-                    SendersReference = "C",
-                    Statuses = new List<CorrespondenceStatusEntity> { new() { Status = CorrespondenceStatus.PurgedByAltinn, StatusChanged = baseTime.AddMinutes(2) } },
-                    ExternalReferences = new List<ExternalReferenceEntity> { new() { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = "dC" } }
-                }
+                new CorrespondenceEntityBuilder()
+                    .WithCreated(baseTime)
+                    .WithRequestedPublishTime(baseTime)
+                    .WithExternalReference(ReferenceType.DialogportenDialogId, "dA")
+                    .WithStatus(CorrespondenceStatus.PurgedByAltinn, baseTime, Guid.NewGuid())
+                    .Build(),
+                new CorrespondenceEntityBuilder()
+                    .WithCreated(baseTime.AddMinutes(1))
+                    .WithRequestedPublishTime(baseTime.AddMinutes(1))
+                    .WithExternalReference(ReferenceType.DialogportenDialogId, "dB")
+                    .WithStatus(CorrespondenceStatus.PurgedByAltinn, baseTime.AddMinutes(1), Guid.NewGuid())
+                    .Build(),
+                new CorrespondenceEntityBuilder()
+                    .WithCreated(baseTime.AddMinutes(2))
+                    .WithRequestedPublishTime(baseTime.AddMinutes(2))
+                    .WithExternalReference(ReferenceType.DialogportenDialogId, "dC")
+                    .WithStatus(CorrespondenceStatus.PurgedByAltinn, baseTime.AddMinutes(2), Guid.NewGuid())
+                    .Build()
             };
             context.Correspondences.AddRange(items);
             await context.SaveChangesAsync();
 
-            var page1 = await repo.GetPurgedCorrespondencesWithDialogsAfter(2, null, null, true, CancellationToken.None);
+            var page1 = await repo.GetCorrespondencesWindowAfter(2, null, null, true, CancellationToken.None);
             Assert.Equal(2, page1.Count);
             Assert.True(page1[0].Created <= page1[1].Created);
 
             var last = page1.Last();
-            var page2 = await repo.GetPurgedCorrespondencesWithDialogsAfter(2, last.Created, last.Id, true, CancellationToken.None);
-            Assert.Single(page2);
+            var page2 = await repo.GetCorrespondencesWindowAfter(2, last.Created, last.Id, true, CancellationToken.None);
+            Assert.True(page2[0].Id == items[2].Id);
             Assert.True(page2[0].Created >= last.Created);
+        }
+
+        [Fact]
+        public async Task GetCorrespondencesByIdsWithReferenceAndCurrentStatus_FiltersByLatestPurgedAndReference()
+        {
+            await using var context = _fixture.CreateDbContext();
+            var repo = new CorrespondenceRepository(context, new NullLogger<ICorrespondenceRepository>());
+
+            var baseTime = new DateTime(2002, 1, 1, 0, 0, 0);
+
+            var shouldReturn = new CorrespondenceEntityBuilder()
+                .WithCreated(baseTime)
+                .WithRequestedPublishTime(baseTime)
+                .WithExternalReference(ReferenceType.DialogportenDialogId, "dA")
+                .WithStatus(CorrespondenceStatus.Published, baseTime.AddMinutes(1), Guid.NewGuid())
+                .WithStatus(CorrespondenceStatus.PurgedByAltinn, baseTime.AddMinutes(2), Guid.NewGuid())
+                .Build();
+
+            var notPurgedLatest = new CorrespondenceEntityBuilder()
+                .WithCreated(baseTime)
+                .WithRequestedPublishTime(baseTime)
+                .WithExternalReference(ReferenceType.DialogportenDialogId, "dB")
+                .WithStatus(CorrespondenceStatus.PurgedByRecipient, baseTime.AddMinutes(1), Guid.NewGuid())
+                .WithStatus(CorrespondenceStatus.Archived, baseTime.AddMinutes(2), Guid.NewGuid())
+                .Build();
+
+            var noDialogRef = new CorrespondenceEntityBuilder()
+                .WithCreated(baseTime)
+                .WithRequestedPublishTime(baseTime)
+                .WithStatus(CorrespondenceStatus.PurgedByAltinn, baseTime.AddMinutes(3), Guid.NewGuid())
+                .Build();
+
+            context.Correspondences.AddRange(shouldReturn, notPurgedLatest, noDialogRef);
+            await context.SaveChangesAsync();
+
+            var ids = new List<Guid> { shouldReturn.Id, notPurgedLatest.Id, noDialogRef.Id };
+            var statuses = new List<CorrespondenceStatus> { CorrespondenceStatus.PurgedByAltinn, CorrespondenceStatus.PurgedByRecipient };
+            var result = await repo.GetCorrespondencesByIdsWithExternalReferenceAndCurrentStatus(ids, ReferenceType.DialogportenDialogId, statuses, CancellationToken.None);
+
+            Assert.Single(result);
+            Assert.Equal(shouldReturn.Id, result[0].Id);
+        }
+
+        [Fact]
+        public async Task GetCorrespondencesByIdsWithReferenceAndCurrentStatus_UsesLatestByStatusChangedThenId()
+        {
+            await using var context = _fixture.CreateDbContext();
+            var repo = new CorrespondenceRepository(context, new NullLogger<ICorrespondenceRepository>());
+
+            var t = new DateTime(2003, 2, 2, 0, 0, 0);
+
+            var entity = new CorrespondenceEntityBuilder()
+                .WithCreated(t)
+                .WithRequestedPublishTime(t)
+                .WithExternalReference(ReferenceType.DialogportenDialogId, "dD")
+                .Build();
+
+            var s1 = new CorrespondenceStatusEntity { Status = CorrespondenceStatus.Archived, StatusChanged = t.AddMinutes(1) };
+            var s2 = new CorrespondenceStatusEntity { Status = CorrespondenceStatus.PurgedByRecipient, StatusChanged = t.AddMinutes(1) };
+            if (s2.Id.CompareTo(s1.Id) < 0)
+            {
+                s2 = new CorrespondenceStatusEntity { Status = CorrespondenceStatus.PurgedByRecipient, StatusChanged = t.AddMinutes(1) };
+            }
+            entity.Statuses.AddRange([s1, s2]);
+
+            context.Correspondences.Add(entity);
+            await context.SaveChangesAsync();
+
+            var result = await repo.GetCorrespondencesByIdsWithExternalReferenceAndCurrentStatus([entity.Id], ReferenceType.DialogportenDialogId, [CorrespondenceStatus.PurgedByRecipient], CancellationToken.None);
+
+            Assert.Single(result);
+            Assert.Equal(entity.Id, result[0].Id);
         }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
@@ -188,26 +188,23 @@ namespace Altinn.Correspondence.Tests.TestingRepository
         }
 
         [Fact]
-        public async Task GetCorrespondencesByIdsWithReferenceAndCurrentStatus_UsesLatestByStatusChangedThenId()
+        public async Task GetCorrespondencesByIdsWithReferenceAndCurrentStatus_UsesLatestByStatusChangedThenStatusId()
         {
             await using var context = _fixture.CreateDbContext();
             var repo = new CorrespondenceRepository(context, new NullLogger<ICorrespondenceRepository>());
-
+            var idA = new Guid("00000000-0000-0000-0000-000000000001");
+            var idB = new Guid("00000000-0000-0000-0000-000000000002");
+            var idC = new Guid("00000000-0000-0000-0000-000000000003");
             var t = new DateTime(2003, 2, 2, 0, 0, 0);
 
             var entity = new CorrespondenceEntityBuilder()
                 .WithCreated(t)
                 .WithRequestedPublishTime(t)
                 .WithExternalReference(ReferenceType.DialogportenDialogId, "dD")
+                .WithStatus(CorrespondenceStatus.Archived, t.AddMinutes(1), idA)
+                .WithStatus(CorrespondenceStatus.PurgedByRecipient, t.AddMinutes(1), idB)
+                .WithStatus(CorrespondenceStatus.Initialized, t, idC)
                 .Build();
-
-            var s1 = new CorrespondenceStatusEntity { Status = CorrespondenceStatus.Archived, StatusChanged = t.AddMinutes(1) };
-            var s2 = new CorrespondenceStatusEntity { Status = CorrespondenceStatus.PurgedByRecipient, StatusChanged = t.AddMinutes(1) };
-            if (s2.Id.CompareTo(s1.Id) < 0)
-            {
-                s2 = new CorrespondenceStatusEntity { Status = CorrespondenceStatus.PurgedByRecipient, StatusChanged = t.AddMinutes(1) };
-            }
-            entity.Statuses.AddRange([s1, s2]);
 
             context.Correspondences.Add(entity);
             await context.SaveChangesAsync();

--- a/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
@@ -29,10 +29,11 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult> CleanupOrphanedDialogs(
         [FromServices] CleanupOrphanedDialogsHandler handler,
+        [FromBody] CleanupOrphanedDialogsRequest request,
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Request to cleanup orphaned dialogs received");
-        var result = await handler.Process(HttpContext.User, cancellationToken);
+        var result = await handler.Process(request, HttpContext.User, cancellationToken);
         return result.Match(
             Ok,
             Problem

--- a/src/Altinn.Correspondence.Application/CleanupOrphanedDialogs/CleanupOrphanedDialogsRequest.cs
+++ b/src/Altinn.Correspondence.Application/CleanupOrphanedDialogs/CleanupOrphanedDialogsRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Correspondence.Application.CleanupOrphanedDialogs;
+
+public class CleanupOrphanedDialogsRequest
+{
+    [Range(100, int.MaxValue)]
+    public int WindowSize { get; set; } = 10000;
+}
+
+

--- a/src/Altinn.Correspondence.Application/IHandler.cs
+++ b/src/Altinn.Correspondence.Application/IHandler.cs
@@ -7,7 +7,3 @@ internal interface IHandler<TRequest, TResponse>
 {
     Task<OneOf<TResponse, Error>> Process(TRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken);
 }
-internal interface IHandler<TResponse>
-{
-    Task<OneOf<TResponse, Error>> Process(ClaimsPrincipal? user, CancellationToken cancellationToken);
-}

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -55,11 +55,17 @@ namespace Altinn.Correspondence.Core.Repositories
         Task UpdateIsMigrating(Guid correspondenceId, bool isMigrating, CancellationToken cancellationToken);
         Task<bool> AreAllAttachmentsPublished(Guid correspondenceId, CancellationToken cancellationToken = default);
         Task<List<CorrespondenceEntity>> GetCandidatesForMigrationToDialogporten(int batchSize, int offset, CancellationToken cancellationToken = default);
-        Task<List<CorrespondenceEntity>> GetPurgedCorrespondencesWithDialogsAfter(
+        Task<List<CorrespondenceEntity>> GetCorrespondencesWindowAfter(
             int limit,
             DateTimeOffset? lastCreated,
             Guid? lastId,
             bool filterMigrated,
+            CancellationToken cancellationToken);
+
+        Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndCurrentStatus(
+            List<Guid> correspondenceIds,
+            ReferenceType referenceType,
+            List<CorrespondenceStatus> currentStatuses,
             CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -196,7 +196,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .ToListAsync(cancellationToken);
         }
 
-        public async Task<List<CorrespondenceEntity>> GetPurgedCorrespondencesWithDialogsAfter(
+        public async Task<List<CorrespondenceEntity>> GetCorrespondencesWindowAfter(
             int limit,
             DateTimeOffset? lastCreated,
             Guid? lastId,
@@ -204,11 +204,8 @@ namespace Altinn.Correspondence.Persistence.Repositories
             CancellationToken cancellationToken)
         {
             var query = _context.Correspondences
-                .Where(c => c.ExternalReferences.Any(er => er.ReferenceType == ReferenceType.DialogportenDialogId))
-                .WhereCurrentStatusIn(CorrespondenceStatus.PurgedByAltinn, CorrespondenceStatus.PurgedByRecipient)
+                .AsNoTracking()
                 .FilterMigrated(filterMigrated)
-                .Include(c => c.Statuses)
-                .Include(c => c.ExternalReferences)
                 .AsQueryable();
 
             if (lastCreated.HasValue)
@@ -226,6 +223,39 @@ namespace Altinn.Correspondence.Persistence.Repositories
             query = query.OrderBy(c => c.Created).ThenBy(c => c.Id).Take(limit);
 
             return await query.ToListAsync(cancellationToken);
+        }
+
+        public async Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndCurrentStatus(
+            List<Guid> correspondenceIds,
+            ReferenceType referenceType,
+            List<CorrespondenceStatus> currentStatuses,
+            CancellationToken cancellationToken)
+        {
+            if (correspondenceIds == null || correspondenceIds.Count == 0)
+            {
+                return new List<CorrespondenceEntity>();
+            }
+
+            var results = await _context.Correspondences
+                .AsNoTracking()
+                .Where(c => correspondenceIds.Contains(c.Id))
+                .Where(c => c.ExternalReferences.Any(er => er.ReferenceType == referenceType))
+                .Select(c => new
+                {
+                    Correspondence = c,
+                    LatestStatus = c.Statuses
+                        .OrderByDescending(s => s.StatusChanged)
+                        .ThenByDescending(s => s.Id)
+                        .Select(s => s.Status)
+                        .FirstOrDefault()
+                })
+                .Where(x => currentStatuses.Contains(x.LatestStatus))
+                .Select(x => x.Correspondence)
+                .Include(c => c.ExternalReferences)
+                .Include(c => c.Statuses)
+                .ToListAsync(cancellationToken);
+
+            return results;
         }
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -225,36 +225,36 @@ namespace Altinn.Correspondence.Persistence.Repositories
             return await query.ToListAsync(cancellationToken);
         }
 
-public async Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndCurrentStatus(
-    List<Guid> correspondenceIds,
-    ReferenceType referenceType,
-    List<CorrespondenceStatus> currentStatuses,
-    CancellationToken cancellationToken)
-{
-    if (correspondenceIds == null || correspondenceIds.Count == 0)
-    {
-        return new List<CorrespondenceEntity>();
-    }
+        public async Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndCurrentStatus(
+            List<Guid> correspondenceIds,
+            ReferenceType referenceType,
+            List<CorrespondenceStatus> currentStatuses,
+            CancellationToken cancellationToken)
+        {
+            if (correspondenceIds == null || correspondenceIds.Count == 0)
+            {
+                return new List<CorrespondenceEntity>();
+            }
 
-    if (currentStatuses == null || currentStatuses.Count == 0)
-    {
-        return new List<CorrespondenceEntity>();
-    }
+            if (currentStatuses == null || currentStatuses.Count == 0)
+            {
+                return new List<CorrespondenceEntity>();
+            }
 
-    return await _context.Correspondences
-        .AsNoTracking()
-        .AsSplitQuery()
-        .Where(c => correspondenceIds.Contains(c.Id))
-        .Where(c => c.ExternalReferences.Any(er => er.ReferenceType == referenceType))
-        .Where(c => currentStatuses.Contains(
-            c.Statuses
-                .OrderByDescending(s => s.StatusChanged)
-                .ThenByDescending(s => s.Id)
-                .Select(s => s.Status)
-                .FirstOrDefault()))
-        .Include(c => c.ExternalReferences)
-        .Include(c => c.Statuses)
-        .ToListAsync(cancellationToken);
-}
+            return await _context.Correspondences
+                .AsNoTracking()
+                .AsSplitQuery()
+                .Where(c => correspondenceIds.Contains(c.Id))
+                .Where(c => c.ExternalReferences.Any(er => er.ReferenceType == referenceType))
+                .Where(c => currentStatuses.Contains(
+                    c.Statuses
+                        .OrderByDescending(s => s.StatusChanged)
+                        .ThenByDescending(s => s.Id)
+                        .Select(s => s.Status)
+                        .FirstOrDefault()))
+                .Include(c => c.ExternalReferences)
+                .Include(c => c.Statuses)
+                .ToListAsync(cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The Dialog clenaup job failed in prod because the query to retrieve purged correspondences timedout desipite the batching. Production large number of correspondences but not a lot of them are purged. Previously the batching retrieved batches of purged correspondences. Because the number of purged is a small portion of the total correspondences each batch would process too many correspondences such that the query would timeout and fail.

This PR changes the processing to retrieve and process a window of correspondences instead of a number of purged correspondences. Another query to retireve and filter for externalreference and purged status is done after. Also added request parameter for windowsize to the cleanup dialog maintenance endpoint. 

## Related Issue(s)
- #1094 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maintenance cleanup endpoint now accepts a JSON body with WindowSize to control processing size (default 10,000; min 100).
  * Cleanup of orphaned dialogs runs in sliding windows and processes purge candidates more selectively for steadier, predictable runs.
  * Improved logging surfaces configured window size and scanning/purge counts for better observability.

* **Tests**
  * Tests refactored to use a fluent test-data builder and expanded to cover windowed paging and ID-based retrieval scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->