### PR TITLE
Changed auth slack test

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/SlackTest.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/SlackTest.cs
@@ -44,7 +44,7 @@ namespace Altinn.Correspondence.Tests.TestingFeature
             
             var result = await response.Content.ReadFromJsonAsync<dynamic>(_responseSerializerOptions);
             Assert.NotNull(result);
-            Assert.False(result.GetProperty("success").GetBoolean());
+            Assert.False(result!.GetProperty("success").GetBoolean());
             Assert.Contains("Failed to send simple test message", result.GetProperty("message").GetString());
         }
 
@@ -155,8 +155,10 @@ namespace Altinn.Correspondence.Tests.TestingFeature
             var response = await wrongIssuerClient.PostAsJsonAsync("api/slacktest/send-simple-message", testMessage);
 
             // Assert
-            // Now the test properly validates that wrong issuer fails, not missing scope
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            // ScopeAccessRequirement from Altinn.Common.PEP returns BadRequest for invalid issuer
+            // rather than letting the authorization system handle it as Forbidden
+            Assert.True(response.StatusCode == HttpStatusCode.Forbidden || response.StatusCode == HttpStatusCode.BadRequest, 
+                $"Expected Forbidden or BadRequest but got {response.StatusCode}");
         }
 
         #endregion
@@ -232,7 +234,7 @@ namespace Altinn.Correspondence.Tests.TestingFeature
             Assert.NotNull(result);
             
             // Verify response structure (even for failed requests)
-            var success = result.GetProperty("success").GetBoolean();
+            var success = result!.GetProperty("success").GetBoolean();
             var message = result.GetProperty("message").GetString();
             var channel = result.GetProperty("channel").GetString();
             

--- a/src/Altinn.Correspondence.API/Controllers/SlackTestController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/SlackTestController.cs
@@ -32,7 +32,7 @@ public class SlackTestController : ControllerBase
     /// <param name="message">The message to send</param>
     /// <returns>Result indicating success or failure</returns>
     [HttpPost("send-simple-message")]
-    [Authorize(Policy = AuthorizationConstants.Sender)]
+    [Authorize(Policy = AuthorizationConstants.Maintenance)]
     public async Task<IActionResult> SendSimpleMessage([FromBody] string message)
     {
         if (string.IsNullOrWhiteSpace(message))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed authentication role to "maintenance".

## Related Issue(s)
- #1183 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Slack test message endpoint now requires Maintenance-level access; requests without that permission will be denied.

- **Tests**
  - Test suite updated for Maintenance scope: renamed positive test, broadened accepted negative responses to include Bad Request alongside Unauthorized/Forbidden, and added/adjusted assertions to validate response body details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->