### PR TITLE
feat(flux): add syncroot configuration for bootstrapping applications in DIS

### DIFF
--- a/.github/workflows/publish-syncroot.yml
+++ b/.github/workflows/publish-syncroot.yml
@@ -18,7 +18,7 @@ permissions:
   id-token: write
 
 jobs:
-  latest:
+  build:
     name: Build latest from main
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-syncroot.yml
+++ b/.github/workflows/publish-syncroot.yml
@@ -1,0 +1,112 @@
+name: Build syncroot image
+
+env:
+  ARTIFACT_NAME: corr/syncroot
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'flux/syncroot/**'
+      - '.github/workflows/publish-syncroot.yml'
+    tags:
+      - 'syncroot-*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  latest:
+    name: Build latest from main
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - name: Validate syncroot image
+        uses: Altinn/altinn-platform/actions/flux/verify-syncroot@ef7bd56ddb11f200f1c388ed3dba399c7316b7ec # main
+        with:
+          workdir: ./flux/syncroot
+      - name: Build and push latest artifact
+        uses: Altinn/altinn-platform/actions/flux/build-push-image@ef7bd56ddb11f200f1c388ed3dba399c7316b7ec # main
+        with:
+          image_name: ${{ env.ARTIFACT_NAME }}
+          tag: at22
+          workdir: ./flux/syncroot
+          azure_subscription_id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+  release:
+    name: Build release from tag
+    if: startsWith(github.ref, 'refs/tags/syncroot-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - name: Get tag short sha
+        id: get_tags
+        run: |
+          echo "tag=${GITHUB_REF/refs\/tags\/syncroot-/}" >> $GITHUB_OUTPUT
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Re-tag existing image with semver
+        uses: Altinn/altinn-platform/actions/flux/retag-image@ef7bd56ddb11f200f1c388ed3dba399c7316b7ec # main
+        with:
+          image_name: ${{ env.ARTIFACT_NAME }}
+          from_tag: ${{ steps.get_tags.outputs.short_sha }}
+          tag: ${{ steps.get_tags.outputs.tag }}
+          workdir: ./flux/syncroot
+          azure_subscription_id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      - name: Re-tag existing image with at23
+        uses: Altinn/altinn-platform/actions/flux/retag-image@ef7bd56ddb11f200f1c388ed3dba399c7316b7ec # main
+        with:
+          image_name: ${{ env.ARTIFACT_NAME }}
+          from_tag: ${{ steps.get_tags.outputs.short_sha }}
+          tag: "at23"
+          workdir: ./flux/syncroot
+          azure_subscription_id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      - name: Re-tag existing image with at24
+        uses: Altinn/altinn-platform/actions/flux/retag-image@ef7bd56ddb11f200f1c388ed3dba399c7316b7ec # main
+        with:
+          image_name: ${{ env.ARTIFACT_NAME }}
+          from_tag: ${{ steps.get_tags.outputs.short_sha }}
+          tag: "at24"
+          workdir: ./flux/syncroot
+          azure_subscription_id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      - name: Re-tag existing image with tt02
+        uses: Altinn/altinn-platform/actions/flux/retag-image@ef7bd56ddb11f200f1c388ed3dba399c7316b7ec # main
+        with:
+          image_name: ${{ env.ARTIFACT_NAME }}
+          from_tag: ${{ steps.get_tags.outputs.short_sha }}
+          tag: "tt02"
+          workdir: ./flux/syncroot
+          azure_subscription_id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      - name: Re-tag existing image with yt01
+        uses: Altinn/altinn-platform/actions/flux/retag-image@ef7bd56ddb11f200f1c388ed3dba399c7316b7ec # main
+        with:
+          image_name: ${{ env.ARTIFACT_NAME }}
+          from_tag: ${{ steps.get_tags.outputs.short_sha }}
+          tag: "yt01"
+          workdir: ./flux/syncroot
+          azure_subscription_id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      - name: Re-tag existing image with prod
+        uses: Altinn/altinn-platform/actions/flux/retag-image@ef7bd56ddb11f200f1c388ed3dba399c7316b7ec # main
+        with:
+          image_name: ${{ env.ARTIFACT_NAME }}
+          from_tag: ${{ steps.get_tags.outputs.short_sha }}
+          tag: "prod"
+          workdir: ./flux/syncroot
+          azure_subscription_id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}

--- a/flux/syncroot/at22/kustomization.yaml
+++ b/flux/syncroot/at22/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/flux/syncroot/at23/kustomization.yaml
+++ b/flux/syncroot/at23/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/flux/syncroot/at24/kustomization.yaml
+++ b/flux/syncroot/at24/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/flux/syncroot/base/broker-flux-kustomize.yaml
+++ b/flux/syncroot/base/broker-flux-kustomize.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: broker-app-sync
+  namespace: broker
+spec:
+  force: false
+  interval: 5m0s
+  path: ./
+  prune: false
+  retryInterval: 5m0s
+  sourceRef:
+    kind: OCIRepository
+    name: broker-app-sync
+    namespace: broker
+  targetNamespace: broker
+  timeout: 5m0s
+  wait: true

--- a/flux/syncroot/base/broker-namespace.yaml
+++ b/flux/syncroot/base/broker-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: broker

--- a/flux/syncroot/base/broker-namespace.yaml
+++ b/flux/syncroot/base/broker-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: broker
+  annotations:
+    "linkerd.io/inject": "enabled"

--- a/flux/syncroot/base/broker-oci-repository.yaml
+++ b/flux/syncroot/base/broker-oci-repository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: broker-app-sync
+  namespace: broker
+spec:
+  interval: 5m0s
+  provider: azure
+  ref:
+    tag: main
+  timeout: 5m0s
+  url: oci://altinncr.azurecr.io/corr/broker-sync

--- a/flux/syncroot/base/correspondence-flux-kustomize.yaml
+++ b/flux/syncroot/base/correspondence-flux-kustomize.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: correspondence-app-sync
+  namespace: correspondence
+spec:
+  force: false
+  interval: 5m0s
+  path: ./
+  prune: false
+  retryInterval: 5m0s
+  sourceRef:
+    kind: OCIRepository
+    name: correspondence-app-sync
+    namespace: correspondence
+  targetNamespace: correspondence
+  timeout: 5m0s
+  wait: true

--- a/flux/syncroot/base/correspondence-namespace.yaml
+++ b/flux/syncroot/base/correspondence-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: correspondence
+  annotations:
+    "linkerd.io/inject": "enabled"

--- a/flux/syncroot/base/correspondence-namespace.yaml
+++ b/flux/syncroot/base/correspondence-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: correspondence

--- a/flux/syncroot/base/correspondence-oci-repository.yaml
+++ b/flux/syncroot/base/correspondence-oci-repository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: correspondence-app-sync
+  namespace: correspondence
+spec:
+  interval: 5m0s
+  provider: azure
+  ref:
+    tag: main
+  timeout: 5m0s
+  url: oci://altinncr.azurecr.io/corr/correspondence-sync

--- a/flux/syncroot/base/kustomization.yaml
+++ b/flux/syncroot/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - correspondence-namespace.yaml
+  - correspondence-oci-repository.yaml
+  - correspondence-flux-kustomize.yaml
+  - broker-namespace.yaml
+  - broker-oci-repository.yaml
+  - broker-flux-kustomize.yaml

--- a/flux/syncroot/prod/kustomization.yaml
+++ b/flux/syncroot/prod/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: OCIRepository
+      name: broker-app-sync
+    patch: |-
+      - op: replace
+        path: /spec/ref/tag
+        value: prod
+  - target:
+      kind: OCIRepository
+      name: correspondence-app-sync
+    patch: |-
+      - op: replace
+        path: /spec/ref/tag
+        value: prod

--- a/flux/syncroot/tt02/kustomization.yaml
+++ b/flux/syncroot/tt02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/flux/syncroot/yt01/kustomization.yaml
+++ b/flux/syncroot/yt01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
## Description

This introduces the FluxCD Kustomization setup for the 'correspondence' and 'broker' applications. This configuration, located under `flux/syncroot`, will be built into an OCI image that serves as the single source of truth for Flux to bootstrap and manage the applications in a Kubernetes cluster.

The structure uses Kustomize overlays:
- A `base` configuration defines the core resources, including namespaces, OCIRepository sources, and Kustomization objects for both applications. By default, it tracks the `main` tag of the application configuration repositories.

- Environment-specific overlays for `at22`, `at23`, `at24`, `tt02`, and `yt01` inherit directly from the base, using the `main` tag for continuous delivery from the main branch.

- The `prod` overlay patches the OCIRepository sources to use the `prod` tag, ensuring the production environment only deploys stable, tagged releases.

## Related Issue(s)
- #1097 
- https://github.com/Altinn/altinn-platform/issues/1900

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Flux syncroot with a base and environment overlays (at22, at23, at24, tt02, yt01, prod).
  - Created Correspondence and Broker namespaces, OCI sources, and Flux Kustomizations to reconcile those images on a 5‑minute interval; prod overlay pins prod image tags.

- **Chores**
  - Added CI workflow to build, publish, and retag syncroot container images from main and release tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->