### PR TITLE
Use IdempotencyKey for activities when creating dialog for migrated correspondence

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -256,7 +256,8 @@ public class DialogportenTests
         using var scope = testFactory.Services.CreateScope();
         GetCorrespondenceOverviewRequest request = new GetCorrespondenceOverviewRequest()
         {
-            CorrespondenceId = testCorrespondence.Id
+            CorrespondenceId = testCorrespondence.Id,
+            OnlyGettingContent = true
         };
         var handler = scope.ServiceProvider.GetRequiredService<GetCorrespondenceOverviewHandler>();
         var result = await handler.Process(request, new(), CancellationToken.None);

--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -256,8 +256,7 @@ public class DialogportenTests
         using var scope = testFactory.Services.CreateScope();
         GetCorrespondenceOverviewRequest request = new GetCorrespondenceOverviewRequest()
         {
-            CorrespondenceId = testCorrespondence.Id,
-            OnlyGettingContent = true
+            CorrespondenceId = testCorrespondence.Id
         };
         var handler = scope.ServiceProvider.GetRequiredService<GetCorrespondenceOverviewHandler>();
         var result = await handler.Process(request, new(), CancellationToken.None);

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -82,7 +82,6 @@ public class GetCorrespondenceOverviewHandler(
                     StatusChanged = DateTimeOffset.UtcNow,
                     PartyUuid = partyUuid
                 }, cancellationToken);
-                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
                 if (request.OnlyGettingContent && !correspondence.StatusHasBeen(CorrespondenceStatus.Read))
                 {
                     await correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
@@ -93,6 +92,7 @@ public class GetCorrespondenceOverviewHandler(
                         StatusChanged = DateTimeOffset.UtcNow,
                         PartyUuid = partyUuid
                     }, cancellationToken);
+                    backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
                 }
             }
             var notificationsOverview = new List<CorrespondenceNotificationOverview>();

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -92,8 +92,8 @@ public class GetCorrespondenceOverviewHandler(
                         StatusChanged = DateTimeOffset.UtcNow,
                         PartyUuid = partyUuid
                     }, cancellationToken);
-                    backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
                 }
+                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
             }
             var notificationsOverview = new List<CorrespondenceNotificationOverview>();
             foreach (var notification in correspondence.Notifications)

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -82,7 +82,6 @@ public class GetCorrespondenceOverviewHandler(
                     StatusChanged = DateTimeOffset.UtcNow,
                     PartyUuid = partyUuid
                 }, cancellationToken);
-                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
                 if (request.OnlyGettingContent && !correspondence.StatusHasBeen(CorrespondenceStatus.Read))
                 {
                     await correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
@@ -94,6 +93,7 @@ public class GetCorrespondenceOverviewHandler(
                         PartyUuid = partyUuid
                     }, cancellationToken);
                 }
+                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
             }
             var notificationsOverview = new List<CorrespondenceNotificationOverview>();
             foreach (var notification in correspondence.Notifications)

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -92,8 +92,8 @@ public class GetCorrespondenceOverviewHandler(
                         StatusChanged = DateTimeOffset.UtcNow,
                         PartyUuid = partyUuid
                     }, cancellationToken);
+                    backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
                 }
-                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
             }
             var notificationsOverview = new List<CorrespondenceNotificationOverview>();
             foreach (var notification in correspondence.Notifications)

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -82,6 +82,7 @@ public class GetCorrespondenceOverviewHandler(
                     StatusChanged = DateTimeOffset.UtcNow,
                     PartyUuid = partyUuid
                 }, cancellationToken);
+                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
                 if (request.OnlyGettingContent && !correspondence.StatusHasBeen(CorrespondenceStatus.Read))
                 {
                     await correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
@@ -93,7 +94,6 @@ public class GetCorrespondenceOverviewHandler(
                         PartyUuid = partyUuid
                     }, cancellationToken);
                 }
-                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, operationTimestamp));
             }
             var notificationsOverview = new List<CorrespondenceNotificationOverview>();
             foreach (var notification in correspondence.Notifications)

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -187,12 +187,6 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
         }
 
-        if (correspondence.Statuses.Count(s => s.Status == CorrespondenceStatus.Fetched) >= 2)
-        {
-            logger.LogInformation("Correspondence with id {correspondenceId} already has a Fetched status, skipping activity creation on Dialogporten", correspondenceId);
-            return;
-        }
-
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -187,9 +187,9 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
         }
 
-        if (correspondence.Statuses.Count(s => s.Status == CorrespondenceStatus.Fetched) >= 2)
+        if (correspondence.Statuses.Count(s => s.Status == CorrespondenceStatus.Read) >= 2)
         {
-            logger.LogInformation("Correspondence with id {correspondenceId} already has a Fetched status, skipping activity creation on Dialogporten", correspondenceId);
+            logger.LogInformation("Correspondence with id {correspondenceId} already has a Read status, skipping activity creation on Dialogporten", correspondenceId);
             return;
         }
 

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -187,7 +187,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
         }
 
-        if (correspondence.Statuses.Count(s => s.Status == CorrespondenceStatus.Read) >= 2)
+        if (correspondence.Statuses.Any(s => s.Status == CorrespondenceStatus.Read))
         {
             logger.LogInformation("Correspondence with id {correspondenceId} already has a Read status, skipping activity creation on Dialogporten", correspondenceId);
             return;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -187,12 +187,6 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
         }
 
-        if (correspondence.Statuses.Any(s => s.Status == CorrespondenceStatus.Read))
-        {
-            logger.LogInformation("Correspondence with id {correspondenceId} already has a Read status, skipping activity creation on Dialogporten", correspondenceId);
-            return;
-        }
-
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -187,6 +187,12 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
         }
 
+        if (correspondence.Statuses.Count(s => s.Status == CorrespondenceStatus.Fetched) >= 2)
+        {
+            logger.LogInformation("Correspondence with id {correspondenceId} already has a Fetched status, skipping activity creation on Dialogporten", correspondenceId);
+            return;
+        }
+
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
@@ -225,7 +231,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         var response = await _httpClient.PostAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}/activities", createDialogActivityRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
-            if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
+            if (response.StatusCode == HttpStatusCode.UnprocessableEntity)
             {
                 var errorContent = await response.Content.ReadAsStringAsync();
                 if (errorContent.Contains("already exists"))
@@ -425,7 +431,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         return dialogRequest;
     }
 
-    private async Task CreateIdempotencyKeysForCorrespondence(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
+    private async Task<(Guid OpenedId, Guid? ConfirmedId, Dictionary<Guid, Guid> AttachmentDownloadIds)> CreateIdempotencyKeysForCorrespondence(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
     {
         // Create idempotency key for open dialog activity
         var openActivityId = Uuid.NewDatabaseFriendly(Database.PostgreSql);
@@ -440,12 +446,13 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         await _idempotencyKeyRepository.CreateAsync(openIdempotencyKey, cancellationToken);
 
         // Create idempotency key for confirm activity if confirmation is needed
+        Guid? confirmActivityId = null;
         if (correspondence.IsConfirmationNeeded)
         {
-            var confirmActivityId = Uuid.NewDatabaseFriendly(Database.PostgreSql);
+            confirmActivityId = Uuid.NewDatabaseFriendly(Database.PostgreSql);
             var confirmIdempotencyKey = new IdempotencyKeyEntity
             {
-                Id = confirmActivityId,
+                Id = confirmActivityId.Value,
                 CorrespondenceId = correspondence.Id,
                 AttachmentId = null,
                 StatusAction = StatusAction.Confirmed,
@@ -456,9 +463,10 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
 
         // Create idempotency keys for each attachment's download activity
         var attachmentIdempotencyKeys = new List<IdempotencyKeyEntity>();
+        var attachmentDownloadIds = new Dictionary<Guid, Guid>();
         foreach (var attachment in correspondence.Content?.Attachments ?? Enumerable.Empty<CorrespondenceAttachmentEntity>())
         {
-            var downloadActivityId = Uuid.NewDatabaseFriendly(UUIDNext.Database.PostgreSql);
+            var downloadActivityId = Uuid.NewDatabaseFriendly(Database.PostgreSql);
             var downloadIdempotencyKey = new IdempotencyKeyEntity
             {
                 Id = downloadActivityId,
@@ -467,8 +475,11 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
                 StatusAction = StatusAction.AttachmentDownloaded
             };
             attachmentIdempotencyKeys.Add(downloadIdempotencyKey);
+            attachmentDownloadIds[attachment.AttachmentId] = downloadActivityId;
         }
         await _idempotencyKeyRepository.CreateRangeAsync(attachmentIdempotencyKeys, cancellationToken);
+
+        return (openActivityId, confirmActivityId, attachmentDownloadIds);
     }
 
 
@@ -490,9 +501,15 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             return correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue ?? string.Empty;
         }
 
-        await CreateIdempotencyKeysForCorrespondence(correspondence, cancellationToken);
+        var (OpenedId, ConfirmedId, AttachmentDownloadIds) = await CreateIdempotencyKeysForCorrespondence(correspondence, cancellationToken);
 
-        var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, generalSettings.Value.CorrespondenceBaseUrl, true, logger);
+        var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(
+            correspondence,
+            generalSettings.Value.CorrespondenceBaseUrl,
+            true,
+            logger,
+            OpenedId.ToString(),
+            ConfirmedId?.ToString());
         string updateType = enableEvents ? "" : "?IsSilentUpdate=true";
         var response = await _httpClient.PostAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs{updateType}", createDialogRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -165,12 +165,12 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             return activities.OrderBy(a => a.CreatedAt).ToList();
         }
 
-        private static Activity GetActivityFromStatus(CorrespondenceEntity correspondence, CorrespondenceStatusEntity status, string? idOverride = null)
+        private static Activity GetActivityFromStatus(CorrespondenceEntity correspondence, CorrespondenceStatusEntity status, string? activityId = null)
         {
             bool isConfirmation = status.Status == CorrespondenceStatus.Confirmed;
 
             Activity activity = new Activity();
-            activity.Id = string.IsNullOrWhiteSpace(idOverride) ? Uuid.NewDatabaseFriendly(Database.PostgreSql).ToString() : idOverride;
+            activity.Id = string.IsNullOrWhiteSpace(activityId) ? Uuid.NewDatabaseFriendly(Database.PostgreSql).ToString() : activityId;
             activity.PerformedBy = new PerformedBy()
             {
                 ActorId = correspondence.GetRecipientUrn(),

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -17,7 +17,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
     internal static class CreateDialogRequestMapper
     {
-        internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl, bool includeActivities = false, ILogger? logger = null, string? openedActivityIdOverride = null, string? confirmedActivityIdOverride = null)
+        internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl, bool includeActivities = false, ILogger? logger = null, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null)
         {
             var dialogId = Guid.CreateVersion7().ToString(); // Dialogporten requires time-stamped GUIDs
             bool isArchived = correspondence.Statuses.Any(s => s.Status == CorrespondenceStatus.Archived);
@@ -47,7 +47,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     ApiActions = GetApiActionsForCorrespondence(baseUrl, correspondence),
                     GuiActions = GetGuiActionsForCorrespondence(baseUrl, correspondence),
                     Attachments = GetAttachmentsForCorrespondence(baseUrl, correspondence),
-                    Activities = includeActivities ? GetActivitiesForCorrespondence(correspondence, openedActivityIdOverride, confirmedActivityIdOverride) : new List<Activity>(),
+                    Activities = includeActivities ? GetActivitiesForCorrespondence(correspondence, openedActivityIdempotencyKey, confirmedActivityIdempotencyKey) : new List<Activity>(),
                     Transmissions = new List<Transmission>(),
                     SystemLabel = isArchived ? SystemLabel.Archived : SystemLabel.Default
                 };

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -148,10 +148,10 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             List<Activity> activities = new();
             var orderedStatuses = correspondence.Statuses.OrderBy(s => s.StatusChanged);
 
-            var firstReadStatus = orderedStatuses.FirstOrDefault(s => s.Status == CorrespondenceStatus.Read);
-            if (firstReadStatus != null && !string.IsNullOrWhiteSpace(openedActivityIdempotencyKey))
+            var readStatus = orderedStatuses.FirstOrDefault(s => s.Status == CorrespondenceStatus.Read);
+            if (readStatus != null && !string.IsNullOrWhiteSpace(openedActivityIdempotencyKey))
             {
-                activities.Add(GetActivityFromStatus(correspondence, firstReadStatus, openedActivityIdempotencyKey));
+                activities.Add(GetActivityFromStatus(correspondence, readStatus, openedActivityIdempotencyKey));
             }
 
             var confirmedStatus = orderedStatuses.FirstOrDefault(s => s.Status == CorrespondenceStatus.Confirmed);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Correspondences migrated from A2 gets duplicate opened activities in arbeidsflate when opened if they had already read in A2. When a dialog is created for a migrated correspondence they include they also create activites on the dialog, but these activities do not use the idempotencyKey for opened and confirmed currently. The idempotencyKey prevents duplicates from being possible.

This PR ensures that the activites added through createCorrespondenceDialog will use the idempotencyKey created when creating the dialog for migrated correspondence as activityId. This fixes both the confirm and opened activities to use the idempotencykey as activityId for dialogs belonging to migrated correspondence.

This PR also removes the check for less than two fetch satuses on the correspondence before creating an opened activity request. It was inconsistent, if the correspondence somehow had two fetch statuses before the job ran, no opened activity would be created. Instead I changed the overview handler to enqueue the job to create the opened activity when setting read status, which happens on the first /content call (But not from the /overview endpoint).

## Related Issue(s)
- #1265

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic idempotency keys for opened/confirmed activities and attachment downloads to stabilize retries.

* **Bug Fixes**
  * Prevent duplicate Read/Confirmed activities by gating creation on presence of idempotency keys.
  * Only enqueue opened-activity creation when fetching content and when needed.

* **Refactor**
  * Idempotency flow reworked to thread open/confirm IDs through dialog creation.

* **Chores**
  * Public mapper signature updated to accept idempotency key parameters.

* **Tests**
  * Content-only test updated to assert single opened-activity enqueue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->