### PR TITLE
Perform storage account deletion in background job

### DIFF
--- a/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/PurgeCorrespondence/PurgeCorrespondenceHelper.cs
@@ -66,7 +66,7 @@ public class PurgeCorrespondenceHelper(
                 continue;
             }
 
-            await storageRepository.PurgeAttachment(attachment.Id, attachment.StorageProvider, cancellationToken);
+            backgroundJobClient.Enqueue<IStorageRepository>(repository => repository.PurgeAttachment(attachment.Id, attachment.StorageProvider, cancellationToken));
             var attachmentStatus = new AttachmentStatusEntity
             {
                 AttachmentId = attachment.Id,


### PR DESCRIPTION
## Description
The call to Azure Storage to purge the blob can often take too long time. We have no guarantees. Hence do it in background job.

## Related Issue(s)
- #1291 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
