### PR TITLE
Render HTML without clean-up

### DIFF
--- a/src/Altinn.Correspondence.Application/Helpers/MessageBodyHelpers.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/MessageBodyHelpers.cs
@@ -24,25 +24,8 @@ public static class MessageBodyHelpers
 
         // Split by lines to handle mixed content properly
         string preprocessed = ConvertLinksToMarkdown(html);
-        var lines = preprocessed.Split('\n');
-        var result = new StringBuilder();
-
-        foreach (var line in lines)
-        {
-            if (ContainsHtmlTags(line))
-            {
-                // Convert HTML to markdown
-                var convertedLine = converter.Convert(line);
-                result.AppendLine(convertedLine);
-            }
-            else
-            {
-                // Keep markdown
-                result.AppendLine(line);
-            }
-        }
-
-        return CleanupResult(result.ToString());
+        var processed = converter.Convert(preprocessed);
+        return processed;
     }
 
     private static string ConvertLinksToMarkdown(string input)
@@ -63,20 +46,4 @@ public static class MessageBodyHelpers
 
         return result;
     }
-
-
-    private static bool ContainsHtmlTags(string line)
-    {
-        return Regex.IsMatch(line, @"<[^>]+>");
-    }
-
-    private static string CleanupResult(string input)
-    {
-        // Clean up excessive line breaks and spaces
-        string result = Regex.Replace(input, @"\n{3,}", "\n\n");
-        result = Regex.Replace(result, @"[ \t]+", " ");
-        result = result.Replace("\\", "");
-        return result.Trim();
-    }
-
 }

--- a/src/Altinn.Correspondence.Application/Helpers/TextValidation.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/TextValidation.cs
@@ -13,7 +13,7 @@ public class TextValidation
             .UseAdvancedExtensions()
             .UseYamlFrontMatter()
             .Build();
-        var html = Markdown.ToHtml(markdown, pipleline).Replace("\n", "");
+        var html = Markdown.ToHtml(markdown, pipleline);
         return html;
     }
 


### PR DESCRIPTION
## Description
We originally did a lot of modification here to try to make tables work properly, but it turns out we can get away with much easier logic. It also removed too many newlines.

## Related Issue(s)
- #1270 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves line breaks in HTML output, improving readability of messages.
  * Produces more consistent Markdown from mixed content, reducing formatting glitches.
  * Maintains correct link rendering when converting to Markdown.

* **Refactor**
  * Streamlined the Markdown conversion process for greater consistency and maintainability without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->