### PR TITLE
Added sync-endpoints to telemetry

### DIFF
--- a/src/Altinn.Correspondence.Core/Options/GeneralSettings.cs
+++ b/src/Altinn.Correspondence.Core/Options/GeneralSettings.cs
@@ -13,5 +13,6 @@ public class GeneralSettings
     public string BrregBaseUrl { get; set; } = string.Empty;
     public string ApplicationInsightsConnectionString { get; set; } = string.Empty;
     public bool DisableTelemetryForMigration { get; set; } = true;
+    public bool DisableTelemetryForSync { get; set; } = false;
     public bool EnableMigrationQueue { get; set; } = true;
 }

--- a/src/Altinn.Correspondence.Integrations/OpenTelemetry/RequestFilterProcessor.cs
+++ b/src/Altinn.Correspondence.Integrations/OpenTelemetry/RequestFilterProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using Altinn.AccessManagement.Core.Models;
 using Altinn.Correspondence.Core.Options;
 using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Primitives;
 using OpenTelemetry;
 using System.Collections.Frozen;
@@ -128,6 +129,10 @@ public class RequestFilterProcessor : BaseProcessor<Activity>
         {
             return true;
         }
+        if (_generalSettings.DisableTelemetryForSync)
+        {
+            return pathSpan.Contains("/correspondence/api/v1/migration/correspondence/sync".AsSpan(), StringComparison.InvariantCultureIgnoreCase);
+        }        
         if (_generalSettings.DisableTelemetryForMigration)
         {
             return pathSpan.Contains("/correspondence/api/v1/migration/correspondence".AsSpan(), StringComparison.InvariantCultureIgnoreCase)


### PR DESCRIPTION
Added a property to disable telemetry for sync endpoints disctint from migration endpoints, and set this default so that telemetry is enabled for sync.

## Related Issue(s)
- #1301 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to disable telemetry for synchronization operations.
  * Sync-specific telemetry exclusion takes precedence over other telemetry settings when enabled.
  * Default behavior remains unchanged (telemetry for sync stays enabled unless explicitly turned off).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->