### PR TITLE
Enabled live sync A2-A3-DP on a secondary queue

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -73,7 +73,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IDisp
             {
                 options.SchedulePollingInterval = TimeSpan.FromSeconds(1);
                 options.WorkerCount = 5;
-                options.Queues = new[] { HangfireQueues.Default, HangfireQueues.Sync, HangfireQueues.Migration };
+                options.Queues = new[] { HangfireQueues.Default, HangfireQueues.LiveMigration, HangfireQueues.Migration };
                 options.ServerTimeout = TimeSpan.FromSeconds(2);
                 options.ShutdownTimeout = TimeSpan.FromSeconds(1);
                 options.StopTimeout = TimeSpan.FromSeconds(1);

--- a/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -72,6 +72,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IDisp
             services.AddHangfireServer(options => 
             {
                 options.SchedulePollingInterval = TimeSpan.FromSeconds(1);
+                options.WorkerCount = 5;
                 options.Queues = new[] { HangfireQueues.Default, HangfireQueues.Sync, HangfireQueues.Migration };
                 options.ServerTimeout = TimeSpan.FromSeconds(2);
                 options.ShutdownTimeout = TimeSpan.FromSeconds(1);

--- a/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -73,7 +73,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IDisp
             {
                 options.SchedulePollingInterval = TimeSpan.FromSeconds(1);
                 options.WorkerCount = 1;
-                options.Queues = new[] { "default", "sync", "migration" };
+                options.Queues = new[] { HangfireQueues.Default, HangfireQueues.Sync, HangfireQueues.Migration };
                 options.ServerTimeout = TimeSpan.FromSeconds(2);
                 options.ShutdownTimeout = TimeSpan.FromSeconds(1);
                 options.StopTimeout = TimeSpan.FromSeconds(1);

--- a/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -73,7 +73,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IDisp
             {
                 options.SchedulePollingInterval = TimeSpan.FromSeconds(1);
                 options.WorkerCount = 1;
-                options.Queues = new[] { "default", "migration" };
+                options.Queues = new[] { "default", "sync", "migration" };
                 options.ServerTimeout = TimeSpan.FromSeconds(2);
                 options.ShutdownTimeout = TimeSpan.FromSeconds(1);
                 options.StopTimeout = TimeSpan.FromSeconds(1);

--- a/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -72,7 +72,6 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IDisp
             services.AddHangfireServer(options => 
             {
                 options.SchedulePollingInterval = TimeSpan.FromSeconds(1);
-                options.WorkerCount = 1;
                 options.Queues = new[] { HangfireQueues.Default, HangfireQueues.Sync, HangfireQueues.Migration };
                 options.ServerTimeout = TimeSpan.FromSeconds(2);
                 options.ShutdownTimeout = TimeSpan.FromSeconds(1);

--- a/Test/Altinn.Correspondence.Tests/Invariants/HangfireStorageCompatibilityTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Invariants/HangfireStorageCompatibilityTests.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.Correspondence.Core.Options;
+using Altinn.Correspondence.Integrations.Hangfire;
 using Altinn.Correspondence.Tests.Fixtures;
 using Altinn.Correspondence.Tests.Helpers;
 using Hangfire;
@@ -107,17 +108,33 @@ public class HangfireStorageCompatibilityTests
             var randomGen = new Random();
             var migrationJobs = new List<string>();
             var defaultJobs = new List<string>();
+            var syncJobs = new List<string>();
             for (int i = 1; i <= jobsCount; i++)
             {
                 bool scheduleAsMigrationJob = randomGen.Next(2) == 0;
-                if (scheduleAsMigrationJob)
+                int schedule = randomGen.Next(3);
+                switch (schedule)
                 {
-                    backgroundJobClient.Enqueue<TestJobTracker>("migration", (testJobTracker) => testJobTracker.ExecuteJob("migration-job-" + i));
-                    migrationJobs.Add(i.ToString());
-                } else
-                {
-                    backgroundJobClient.Enqueue<TestJobTracker>((testJobTracker) => testJobTracker.ExecuteJob("default-job-" + i));
-                    defaultJobs.Add(i.ToString());
+                    case 0:
+                        {
+                            backgroundJobClient.Enqueue<TestJobTracker>(HangfireQueues.Migration, (testJobTracker) => testJobTracker.ExecuteJob("migration-job-" + i));
+                            migrationJobs.Add(i.ToString());
+                            break;
+                        }
+                    case 1:
+                        {
+                            backgroundJobClient.Enqueue<TestJobTracker>((testJobTracker) => testJobTracker.ExecuteJob("default-job-" + i));
+                            defaultJobs.Add(i.ToString());
+                            break;
+                        }
+                    case 2:
+                        {
+                            backgroundJobClient.Enqueue<TestJobTracker>((testJobTracker) => testJobTracker.ExecuteJob("sync-job-" + i));
+                            syncJobs.Add(i.ToString());
+                            break;
+                        }
+                    default:
+                        throw new ArgumentOutOfRangeException();
                 }
             }
 
@@ -125,11 +142,15 @@ public class HangfireStorageCompatibilityTests
             var monitoringApi = jobStorage.GetMonitoringApi();
 
             // Check jobs in default queue
-            var defaultQueueJobs = monitoringApi.EnqueuedJobs("default", 0, jobsCount);
+            var defaultQueueJobs = monitoringApi.EnqueuedJobs(HangfireQueues.Default, 0, jobsCount);
             Assert.Equal(defaultJobs.Count, defaultQueueJobs.Count);
 
+            // Check jobs in sync queue
+            var syncQueueJobs = monitoringApi.EnqueuedJobs(HangfireQueues.Sync, 0, jobsCount);
+            Assert.Equal(syncQueueJobs.Count, syncQueueJobs.Count);
+
             // Check jobs in migration queue
-            var migrationQueueJobs = monitoringApi.EnqueuedJobs("migration", 0, jobsCount);
+            var migrationQueueJobs = monitoringApi.EnqueuedJobs(HangfireQueues.Migration, 0, jobsCount);
             Assert.Equal(migrationJobs.Count, migrationQueueJobs.Count);
 
             // Verify the specific job IDs are in the correct queues
@@ -144,7 +165,7 @@ public class HangfireStorageCompatibilityTests
             // Start background job server with queue priority
             var serverOptions = new BackgroundJobServerOptions
             {
-                Queues = new[] { "default", "migration" }, // default processed first
+                Queues = new[] { HangfireQueues.Default, HangfireQueues.Sync, HangfireQueues.Migration }, // default processed first
                 WorkerCount = 1, // Single worker for deterministic ordering
                 ServerTimeout = TimeSpan.FromSeconds(30),
                 SchedulePollingInterval = TimeSpan.FromSeconds(1)
@@ -164,22 +185,32 @@ public class HangfireStorageCompatibilityTests
 
             var defaultIndices = executionList
                 .Select((job, index) => new { job, index })
-                .Where(x => x.job.StartsWith("default"))
+                .Where(x => x.job.StartsWith(HangfireQueues.Default))
+                .Select(x => x.index)
+                .ToList();
+
+            var syncIndices = executionList
+                .Select((job, index) => new { job, index })
+                .Where(x => x.job.StartsWith(HangfireQueues.Sync))
                 .Select(x => x.index)
                 .ToList();
 
             var migrationIndices = executionList
                 .Select((job, index) => new { job, index })
-                .Where(x => x.job.StartsWith("migration"))
+                .Where(x => x.job.StartsWith(HangfireQueues.Migration))
                 .Select(x => x.index)
                 .ToList();
 
             Assert.Equal(defaultQueueJobs.Count + migrationQueueJobs.Count, executionList.Count);
             var maxDefaultIndex = defaultIndices.Max();
+            var maxSyncIndex = syncIndices.Max();
             var minMigrationIndex = migrationIndices.Min();
 
             Assert.True(maxDefaultIndex < minMigrationIndex,
                 $"Default queue jobs should execute before migration queue jobs. " +
+                $"Execution order: [{string.Join(", ", executionList)}]");
+            Assert.True(maxDefaultIndex < minMigrationIndex,
+                $"Sync queue jobs should execute before migration queue jobs. " +
                 $"Execution order: [{string.Join(", ", executionList)}]");
         }
         finally
@@ -229,8 +260,8 @@ public class HangfireStorageCompatibilityTests
         var serverOptions = (BackgroundJobServerOptions)optionsField.GetValue(hangfireServer);
 
         Assert.NotNull(serverOptions);
-        Assert.Equal(new[] { "default", "migration" }, serverOptions.Queues);
-        Assert.Equal("default", serverOptions.Queues[0]); // Should be highest priority
+        Assert.Equal(new[] { HangfireQueues.Default, HangfireQueues.Sync, HangfireQueues.Migration }, serverOptions.Queues);
+        Assert.Equal(HangfireQueues.Default, serverOptions.Queues[0]); // Should be highest priority
     }
 
     [Fact]
@@ -254,7 +285,7 @@ public class HangfireStorageCompatibilityTests
         var serverOptions = (BackgroundJobServerOptions)optionsField.GetValue(hangfireServer);
 
         Assert.NotNull(serverOptions);
-        Assert.Equal(new[] { "default" }, serverOptions.Queues);
+        Assert.Equal(new[] { HangfireQueues.Default }, serverOptions.Queues);
     }
 
     internal class DisabledMigrationWebApplicationFactory : WebApplicationFactory<Program>

--- a/Test/Altinn.Correspondence.Tests/Invariants/HangfireStorageCompatibilityTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Invariants/HangfireStorageCompatibilityTests.cs
@@ -147,7 +147,7 @@ public class HangfireStorageCompatibilityTests
 
             // Check jobs in sync queue
             var syncQueueJobs = monitoringApi.EnqueuedJobs(HangfireQueues.Sync, 0, jobsCount);
-            Assert.Equal(syncQueueJobs.Count, syncQueueJobs.Count);
+            Assert.Equal(syncJobs.Count, syncQueueJobs.Count);
 
             // Check jobs in migration queue
             var migrationQueueJobs = monitoringApi.EnqueuedJobs(HangfireQueues.Migration, 0, jobsCount);

--- a/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
@@ -202,7 +202,7 @@ namespace Altinn.Correspondence.Tests.TestingRepository
                 .WithRequestedPublishTime(t)
                 .WithExternalReference(ReferenceType.DialogportenDialogId, "dD")
                 .WithStatus(CorrespondenceStatus.Archived, t.AddMinutes(1), idA)
-                .WithStatus(CorrespondenceStatus.PurgedByRecipient, t.AddMinutes(1), idB)
+                .WithStatus(CorrespondenceStatus.PurgedByRecipient, t.AddMinutes(2), idB)
                 .WithStatus(CorrespondenceStatus.Initialized, t, idC)
                 .Build();
 

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -46,8 +46,8 @@ public class MigrateCorrespondenceHandler(
             string dialogId = "";
             if (request.MakeAvailable)
             {
-                var makeAvailableJob = backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.Sync, (handler) => handler.MakeCorrespondenceAvailableInDialogportenAndApi(correspondence.Id, CancellationToken.None, null, true));
-                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(makeAvailableJob, HangfireQueues.Sync, (helper) => helper.SchedulePublishAtPublishTime(correspondence.Id, CancellationToken.None));
+                var makeAvailableJob = backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.LiveMigration, (handler) => handler.MakeCorrespondenceAvailableInDialogportenAndApi(correspondence.Id, CancellationToken.None, null, true));
+                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(makeAvailableJob, HangfireQueues.LiveMigration, (helper) => helper.SchedulePublishAtPublishTime(correspondence.Id, CancellationToken.None));
             }
             
             return new MigrateCorrespondenceResponse()

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -4,7 +4,6 @@ using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Integrations.Hangfire;
-using Azure.Core;
 using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -47,8 +46,8 @@ public class MigrateCorrespondenceHandler(
             string dialogId = "";
             if (request.MakeAvailable)
             {
-                var makeAvailableJob = backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.Sync, (handler) => handler.MakeCorrespondenceAvailableInDialogportenAndApi(correspondence.Id, CancellationToken.None, correspondence, true));
-                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(makeAvailableJob, HangfireQueues.Sync, (helper) => helper.SchedulePublishAtPublishTime(correspondence, CancellationToken.None));;
+                var makeAvailableJob = backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.Sync, (handler) => handler.MakeCorrespondenceAvailableInDialogportenAndApi(correspondence.Id, CancellationToken.None, null, true));
+                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(makeAvailableJob, HangfireQueues.Sync, (helper) => helper.SchedulePublishAtPublishTime(correspondence.Id, CancellationToken.None));
             }
             
             return new MigrateCorrespondenceResponse()

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -173,7 +173,7 @@ public class MigrateCorrespondenceHandler(
         return await MakeCorrespondenceAvailableInDialogportenAndApi(correspondenceId, CancellationToken.None, null, false);
     }
 
-    private async Task<string> MakeCorrespondenceAvailableInDialogportenAndApi(Guid correspondenceId, CancellationToken cancellationToken, CorrespondenceEntity? correspondenceEntity = null, bool createEvents = false)
+    public async Task<string> MakeCorrespondenceAvailableInDialogportenAndApi(Guid correspondenceId, CancellationToken cancellationToken, CorrespondenceEntity? correspondenceEntity = null, bool createEvents = false)
     {
         var correspondence = correspondenceEntity ?? await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, false, cancellationToken, true);
         if (correspondence == null)

--- a/src/Altinn.Correspondence.Integrations/Hangfire/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Integrations/Hangfire/DependencyInjection.cs
@@ -34,7 +34,7 @@ public static class DependencyInjection
         services.AddHangfireServer(options =>
         {
             options.SchedulePollingInterval = TimeSpan.FromSeconds(2);
-            options.Queues = generalSettings.EnableMigrationQueue ? ["default", "migration"] : ["default"];
+            options.Queues = generalSettings.EnableMigrationQueue ? [HangfireQueues.Default, HangfireQueues.Sync, HangfireQueues.Migration] : [HangfireQueues.Default, HangfireQueues.Sync];
         });
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Hangfire/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Integrations/Hangfire/DependencyInjection.cs
@@ -34,7 +34,7 @@ public static class DependencyInjection
         services.AddHangfireServer(options =>
         {
             options.SchedulePollingInterval = TimeSpan.FromSeconds(2);
-            options.Queues = generalSettings.EnableMigrationQueue ? [HangfireQueues.Default, HangfireQueues.Sync, HangfireQueues.Migration] : [HangfireQueues.Default, HangfireQueues.Sync];
+            options.Queues = generalSettings.EnableMigrationQueue ? [HangfireQueues.Default, HangfireQueues.LiveMigration, HangfireQueues.Migration] : [HangfireQueues.Default, HangfireQueues.LiveMigration];
         });
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Hangfire/HangfireQueues.cs
+++ b/src/Altinn.Correspondence.Integrations/Hangfire/HangfireQueues.cs
@@ -3,6 +3,6 @@
 public static class HangfireQueues
 {
     public const string Default = "default";
-    public const string Sync = "sync";
+    public const string LiveMigration = "live-migration";
     public const string Migration = "migration";
 }

--- a/src/Altinn.Correspondence.Integrations/Hangfire/HangfireQueues.cs
+++ b/src/Altinn.Correspondence.Integrations/Hangfire/HangfireQueues.cs
@@ -1,0 +1,8 @@
+﻿namespace Altinn.Correspondence.Integrations.Hangfire;
+
+public static class HangfireQueues
+{
+    public const string Default = "default";
+    public const string Sync = "sync";
+    public const string Migration = "migration";
+}


### PR DESCRIPTION
## Description
Enabled live sync A2-A3-DP on a secondary queue. These will be prioritized over batch jobs, but below regular A3 traffic. Should result in all messages sent on A2 being immediately available in Dialogporten when enabled from A2 side.

## Related Issue(s)
- #1303 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Live migration" background queue alongside Default and Migration; background workers increased to improve throughput.

* **Improvements**
  * Heavy work moved to background processing for better API responsiveness.
  * Deterministic processing order: Default → Live migration → Migration; Migration queue remains optional.

* **Behavior Change**
  * Immediate responses may no longer include a populated dialog ID; it will be produced by background processing.

* **Tests**
  * Updated tests to validate three-queue semantics and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->