### PR TITLE
1322 added condition endpoint while sending Notification Order V2 to Core

### DIFF
--- a/src/Altinn.Correspondence.Application/CheckNotification/CheckNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Application/CheckNotification/CheckNotificationHandler.cs
@@ -3,7 +3,6 @@ using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Hangfire;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Security.Claims;

--- a/src/Altinn.Correspondence.Application/CreateNotification/CreateNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Application/CreateNotification/CreateNotificationHandler.cs
@@ -292,6 +292,7 @@ public class CreateNotificationHandler(
                     {
                         SendersReference = correspondence.SendersReference,
                         DelayDays = hostEnvironment.IsProduction() ? 7 : 1,
+                        ConditionEndpoint = CreateConditionEndpoint(correspondence.Id.ToString())?.ToString(),
                         Recipient = CreateRecipientOrderV2FromRecipient(recipient, notificationRequest, contents.First(), correspondence, isReminder: true)
                     }
                 ];

--- a/src/Altinn.Correspondence.Core/Models/Notifications/NotificationOrderRequestV2.cs
+++ b/src/Altinn.Correspondence.Core/Models/Notifications/NotificationOrderRequestV2.cs
@@ -124,6 +124,8 @@ namespace Altinn.Correspondence.Core.Models.Notifications
 
         public int DelayDays { get; set; }
 
+        public string? ConditionEndpoint { get; set; }
+
         public RecipientV2 Recipient { get; set; } = null!;
     }
 } 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
added condition endpoint while sending Notification Order V2 to Core

## Related Issue(s)
- #1322 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Reminders in V2 notifications can now include an optional condition check endpoint, enabling external verification before a reminder is sent. This is backward compatible and omitted when not configured.
- Tests
  - Added tests to ensure the condition endpoint is set correctly for reminders and aligns with the associated correspondence reference.
- Chores
  - Minor internal cleanup with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->