### PR TITLE
1325 added OverrideRegisteredContactInformation flag that decides if we send to default contact info. of corerspondence or only custom recipients for notification

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
@@ -219,9 +219,9 @@ namespace Altinn.Correspondence.Tests.Factories
             return this;
         }
 
-        public CorrespondenceBuilder WithOverrideKoFuVi(bool overrideKoFuVi)
+        public CorrespondenceBuilder WithOverrideRegisteredContactInformation(bool overrideRegisteredContactInformation)
         {
-            _correspondence.Correspondence.Notification!.OverrideKoFuVi = overrideKoFuVi;
+            _correspondence.Correspondence.Notification!.OverrideRegisteredContactInformation = overrideRegisteredContactInformation;
             return this;
         }
 

--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceBuilder.cs
@@ -219,6 +219,12 @@ namespace Altinn.Correspondence.Tests.Factories
             return this;
         }
 
+        public CorrespondenceBuilder WithOverrideKoFuVi(bool overrideKoFuVi)
+        {
+            _correspondence.Correspondence.Notification!.OverrideKoFuVi = overrideKoFuVi;
+            return this;
+        }
+
         public CorrespondenceBuilder WithIgnoreReservation(bool ignoreReservation)
         {
             _correspondence.Correspondence.IgnoreReservation = ignoreReservation;

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -929,5 +929,183 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             Assert.NotNull(initializedCorrespondence);
             Assert.Equal(CorrespondenceStatusExt.Published, correspondence.Status);
         }
+
+        [Fact]
+        public async Task Correspondence_OverrideKoFuVi_WithoutCustomRecipients_GivesBadRequest()
+        {
+            // Arrange
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationChannel(NotificationChannelExt.Email)
+                .WithEmailContent()
+                .WithOverrideKoFuVi(true)
+                .Build();
+
+            // Act
+            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            var problemDetails = await initResponse.Content.ReadFromJsonAsync<ProblemDetails>(_responseSerializerOptions);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
+            Assert.Equal(NotificationErrors.OverrideKoFuViRequiresCustomRecipients.Message, problemDetails?.Detail);
+        }
+
+        [Fact]
+        public async Task Correspondence_OverrideKoFuVi_WithCustomRecipients_GivesOk()
+        {
+            // Arrange
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+            var customRecipients = new List<NotificationRecipientExt>
+            {
+                new()
+                {
+                    EmailAddress = "custom@example.com"
+                }
+            };
+
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationChannel(NotificationChannelExt.Email)
+                .WithEmailContent()
+                .WithCustomRecipients(customRecipients)
+                .WithOverrideKoFuVi(true)
+                .Build();
+
+            // Act
+            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            var content = await initResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, initResponse.StatusCode);
+            Assert.NotNull(content);
+        }
+
+        [Fact]
+        public async Task Correspondence_OverrideKoFuVi_WithCustomRecipients_OnlyCustomRecipientsUsed()
+        {
+            // Arrange
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+            var customRecipients = new List<NotificationRecipientExt>
+            {
+                new()
+                {
+                    EmailAddress = "custom@example.com"
+                }
+            };
+
+            var orderId = Guid.NewGuid();
+            using var testFactory = new UnitWebApplicationFactory((IServiceCollection services) =>
+            {
+                var mockNotificationService = new Mock<IAltinnNotificationService>();
+                mockNotificationService.Setup(x => x.CreateNotification(It.IsAny<NotificationOrderRequest>(), It.IsAny<CancellationToken>()))
+                    .Callback<NotificationOrderRequest, CancellationToken>((request, _) =>
+                    {
+                        // Should have only 1 recipient: custom recipient (default recipient should be excluded)
+                        Assert.Single(request.Recipients);
+                        Assert.Equal("custom@example.com", request.Recipients[0].EmailAddress);
+                        Assert.Null(request.Recipients[0].OrganizationNumber);
+                    })
+                    .ReturnsAsync(new NotificationOrderRequestResponse()
+                    {
+                        OrderId = orderId,
+                        RecipientLookup = new RecipientLookupResult()
+                        {
+                            Status = RecipientLookupStatus.Success,
+                            MissingContact = [],
+                            IsReserved = []
+                        }
+                    });
+                services.AddSingleton(mockNotificationService.Object);
+            });
+            var senderClient = testFactory.CreateSenderClient();
+
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationChannel(NotificationChannelExt.Email)
+                .WithEmailContent()
+                .WithCustomRecipients(customRecipients)
+                .WithOverrideKoFuVi(true)
+                .Build();
+
+            // Act
+            var initializedCorrespondence = await CorrespondenceHelper.GetInitializedCorrespondence(senderClient, _responseSerializerOptions, payload);
+            var correspondence = await CorrespondenceHelper.WaitForCorrespondenceStatusUpdate(senderClient, _responseSerializerOptions, initializedCorrespondence.CorrespondenceId, CorrespondenceStatusExt.Published);
+
+            // Assert
+            Assert.NotNull(initializedCorrespondence);
+            Assert.Equal(CorrespondenceStatusExt.Published, correspondence.Status);
+        }
+
+        [Fact]
+        public async Task Correspondence_OverrideKoFuVi_False_WithCustomRecipients_DefaultAndCustomRecipientsUsed()
+        {
+            // Arrange
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+            var customRecipients = new List<NotificationRecipientExt>
+            {
+                new()
+                {
+                    EmailAddress = "custom@example.com"
+                }
+            };
+
+            var orderId = Guid.NewGuid();
+            using var testFactory = new UnitWebApplicationFactory((IServiceCollection services) =>
+            {
+                var mockNotificationService = new Mock<IAltinnNotificationService>();
+                mockNotificationService.Setup(x => x.CreateNotification(It.IsAny<NotificationOrderRequest>(), It.IsAny<CancellationToken>()))
+                    .Callback<NotificationOrderRequest, CancellationToken>((request, _) =>
+                    {
+                        // Should have 2 recipients: default correspondence recipient + custom recipient
+                        Assert.Equal(2, request.Recipients.Count);
+
+                        // First recipient should be the default correspondence recipient (organization)
+                        Assert.Equal("991825827", request.Recipients[0].OrganizationNumber);
+                        Assert.Null(request.Recipients[0].EmailAddress);
+
+                        // Second recipient should be the custom recipient
+                        Assert.Equal("custom@example.com", request.Recipients[1].EmailAddress);
+                        Assert.Null(request.Recipients[1].OrganizationNumber);
+                    })
+                    .ReturnsAsync(new NotificationOrderRequestResponse()
+                    {
+                        OrderId = orderId,
+                        RecipientLookup = new RecipientLookupResult()
+                        {
+                            Status = RecipientLookupStatus.Success,
+                            MissingContact = [],
+                            IsReserved = []
+                        }
+                    });
+                services.AddSingleton(mockNotificationService.Object);
+            });
+            var senderClient = testFactory.CreateSenderClient();
+
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationChannel(NotificationChannelExt.Email)
+                .WithEmailContent()
+                .WithCustomRecipients(customRecipients)
+                .WithOverrideKoFuVi(false)
+                .Build();
+
+            // Act
+            var initializedCorrespondence = await CorrespondenceHelper.GetInitializedCorrespondence(senderClient, _responseSerializerOptions, payload);
+            var correspondence = await CorrespondenceHelper.WaitForCorrespondenceStatusUpdate(senderClient, _responseSerializerOptions, initializedCorrespondence.CorrespondenceId, CorrespondenceStatusExt.Published);
+
+            // Assert
+            Assert.NotNull(initializedCorrespondence);
+            Assert.Equal(CorrespondenceStatusExt.Published, correspondence.Status);
+        }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -931,7 +931,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
-        public async Task Correspondence_OverrideKoFuVi_WithoutCustomRecipients_GivesBadRequest()
+        public async Task Correspondence_OverrideRegisteredContactInformation_WithoutCustomRecipients_GivesBadRequest()
         {
             // Arrange
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
@@ -942,7 +942,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
                 .WithNotificationChannel(NotificationChannelExt.Email)
                 .WithEmailContent()
-                .WithOverrideKoFuVi(true)
+                .WithOverrideRegisteredContactInformation(true)
                 .Build();
 
             // Act
@@ -951,11 +951,11 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
-            Assert.Equal(NotificationErrors.OverrideKoFuViRequiresCustomRecipients.Message, problemDetails?.Detail);
+            Assert.Equal(NotificationErrors.OverrideRegisteredContactInformationRequiresCustomRecipients.Message, problemDetails?.Detail);
         }
 
         [Fact]
-        public async Task Correspondence_OverrideKoFuVi_WithCustomRecipients_GivesOk()
+        public async Task Correspondence_OverrideRegisteredContactInformation_WithCustomRecipients_GivesOk()
         {
             // Arrange
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
@@ -974,7 +974,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithNotificationChannel(NotificationChannelExt.Email)
                 .WithEmailContent()
                 .WithCustomRecipients(customRecipients)
-                .WithOverrideKoFuVi(true)
+                .WithOverrideRegisteredContactInformation(true)
                 .Build();
 
             // Act
@@ -987,7 +987,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
-        public async Task Correspondence_OverrideKoFuVi_WithCustomRecipients_OnlyCustomRecipientsUsed()
+        public async Task Correspondence_OverrideRegisteredContactInformation_WithCustomRecipients_OnlyCustomRecipientsUsed()
         {
             // Arrange
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
@@ -1032,7 +1032,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithNotificationChannel(NotificationChannelExt.Email)
                 .WithEmailContent()
                 .WithCustomRecipients(customRecipients)
-                .WithOverrideKoFuVi(true)
+                .WithOverrideRegisteredContactInformation(true)
                 .Build();
 
             // Act
@@ -1045,7 +1045,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
-        public async Task Correspondence_OverrideKoFuVi_False_WithCustomRecipients_DefaultAndCustomRecipientsUsed()
+        public async Task Correspondence_OverrideRegisteredContactInformation_False_WithCustomRecipients_DefaultAndCustomRecipientsUsed()
         {
             // Arrange
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
@@ -1096,7 +1096,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithNotificationChannel(NotificationChannelExt.Email)
                 .WithEmailContent()
                 .WithCustomRecipients(customRecipients)
-                .WithOverrideKoFuVi(false)
+                .WithOverrideRegisteredContactInformation(false)
                 .Build();
 
             // Act

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceNotificationMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceNotificationMapper.cs
@@ -81,7 +81,7 @@ internal static class InitializeCorrespondenceNotificationMapper
             SmsBody = correspondenceNotificationExt.SmsBody,
             SendReminder = correspondenceNotificationExt.SendReminder,
             CustomRecipients = customRecipients,
-            OverrideKoFuVi = correspondenceNotificationExt.OverrideKoFuVi
+            OverrideRegisteredContactInformation = correspondenceNotificationExt.OverrideRegisteredContactInformation
         };
         return notification;
     }

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceNotificationMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceNotificationMapper.cs
@@ -80,7 +80,8 @@ internal static class InitializeCorrespondenceNotificationMapper
             ReminderNotificationChannel = (NotificationChannel?)correspondenceNotificationExt.ReminderNotificationChannel,
             SmsBody = correspondenceNotificationExt.SmsBody,
             SendReminder = correspondenceNotificationExt.SendReminder,
-            CustomRecipients = customRecipients
+            CustomRecipients = customRecipients,
+            OverrideKoFuVi = correspondenceNotificationExt.OverrideKoFuVi
         };
         return notification;
     }

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
@@ -120,6 +120,14 @@ namespace Altinn.Correspondence.API.Models
         [JsonPropertyName("customNotificationRecipients")]
         [Obsolete("This property is deprecated. Use customRecipients instead.")]
         public List<CustomNotificationRecipientExt>? CustomNotificationRecipients { get; set; }
+
+        /// <summary>
+        /// When set to true, only CustomRecipients will be used for notifications, overriding the default correspondence recipient.
+        /// This flag can only be used when CustomRecipients is provided.
+        /// Default value is false (use default contact info + custom recipients).
+        /// </summary>
+        [JsonPropertyName("overrideKoFuVi")]
+        public bool OverrideKoFuVi { get; set; } = false;
     }
 
     /// <summary>

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
@@ -126,8 +126,8 @@ namespace Altinn.Correspondence.API.Models
         /// This flag can only be used when CustomRecipients is provided.
         /// Default value is false (use default contact info + custom recipients).
         /// </summary>
-        [JsonPropertyName("overrideKoFuVi")]
-        public bool OverrideKoFuVi { get; set; } = false;
+        [JsonPropertyName("overrideRegisteredContactInformation")]
+        public bool OverrideRegisteredContactInformation { get; set; } = false;
     }
 
     /// <summary>

--- a/src/Altinn.Correspondence.Application/CreateNotification/CreateNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Application/CreateNotification/CreateNotificationHandler.cs
@@ -248,11 +248,11 @@ public class CreateNotificationHandler(
     { 
         logger.LogInformation("Creating notification request V2 for correspondence {CorrespondenceId}", correspondence.Id);
         
-        // Determine recipients to process - behavior depends on OverrideKoFuVi flag
+        // Determine recipients to process - behavior depends on OverrideRegisteredContactInformation flag
         List<Recipient> recipientsToProcess = new List<Recipient>();
         
-        // If OverrideKoFuVi is false (default), add the default correspondence recipient
-        if (!notificationRequest.OverrideKoFuVi)
+        // If OverrideRegisteredContactInformation is false (default), add the default correspondence recipient
+        if (!notificationRequest.OverrideRegisteredContactInformation)
         {
             string recipientWithoutPrefix = correspondence.Recipient.WithoutPrefix();
             bool isOrganization = recipientWithoutPrefix.IsOrganizationNumber();
@@ -265,7 +265,7 @@ public class CreateNotificationHandler(
             });
         }
         
-        // Add custom recipients if they exist (in addition to default recipient when OverrideKoFuVi is false)
+        // Add custom recipients if they exist (in addition to default recipient when OverrideRegisteredContactInformation is false)
         if (notificationRequest.CustomRecipients != null && notificationRequest.CustomRecipients.Any())
         {
             recipientsToProcess.AddRange(notificationRequest.CustomRecipients);

--- a/src/Altinn.Correspondence.Application/CreateNotification/CreateNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Application/CreateNotification/CreateNotificationHandler.cs
@@ -248,22 +248,24 @@ public class CreateNotificationHandler(
     { 
         logger.LogInformation("Creating notification request V2 for correspondence {CorrespondenceId}", correspondence.Id);
         
-        // Determine recipients to process - custom recipients are in addition to the default correspondence recipient
+        // Determine recipients to process - behavior depends on OverrideKoFuVi flag
         List<Recipient> recipientsToProcess = new List<Recipient>();
         
-        // Always add the default correspondence recipient
-        string recipientWithoutPrefix = correspondence.Recipient.WithoutPrefix();
-        bool isOrganization = recipientWithoutPrefix.IsOrganizationNumber();
-        bool isPerson = recipientWithoutPrefix.IsSocialSecurityNumber();
-        
-        
-        recipientsToProcess.Add(new Recipient
+        // If OverrideKoFuVi is false (default), add the default correspondence recipient
+        if (!notificationRequest.OverrideKoFuVi)
         {
-            OrganizationNumber = isOrganization ? recipientWithoutPrefix : null,
-            NationalIdentityNumber = isPerson ? recipientWithoutPrefix : null
-        });
+            string recipientWithoutPrefix = correspondence.Recipient.WithoutPrefix();
+            bool isOrganization = recipientWithoutPrefix.IsOrganizationNumber();
+            bool isPerson = recipientWithoutPrefix.IsSocialSecurityNumber();
+            
+            recipientsToProcess.Add(new Recipient
+            {
+                OrganizationNumber = isOrganization ? recipientWithoutPrefix : null,
+                NationalIdentityNumber = isPerson ? recipientWithoutPrefix : null
+            });
+        }
         
-        // Add custom recipients if they exist (in addition to the default recipient)
+        // Add custom recipients if they exist (in addition to default recipient when OverrideKoFuVi is false)
         if (notificationRequest.CustomRecipients != null && notificationRequest.CustomRecipients.Any())
         {
             recipientsToProcess.AddRange(notificationRequest.CustomRecipients);

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -87,7 +87,7 @@ public static class NotificationErrors
     public static Error CustomRecipientWithoutIdentifierNotAllowed = new Error(3019, "Custom recipient without identifier is not allowed", HttpStatusCode.BadRequest);
     public static Error NotificationNotFound = new Error(3020, "Notification not found in the database", HttpStatusCode.NotFound);
     public static Error NotificationDetailsNotFound = new Error(3021, "Cannot retrieve notification details from Altinn Notification API", HttpStatusCode.NotFound);
-    public static Error OverrideKoFuViRequiresCustomRecipients = new Error(3022, "OverrideKoFuVi flag can only be used when CustomRecipients is provided", HttpStatusCode.BadRequest);
+    public static Error OverrideRegisteredContactInformationRequiresCustomRecipients = new Error(3022, "OverrideRegisteredContactInformation flag can only be used when CustomRecipients is provided", HttpStatusCode.BadRequest);
 }
 public static class AuthorizationErrors
 {

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -86,6 +86,7 @@ public static class NotificationErrors
     public static Error CustomRecipientWithoutIdentifierNotAllowed = new Error(3019, "Custom recipient without identifier is not allowed", HttpStatusCode.BadRequest);
     public static Error NotificationNotFound = new Error(3020, "Notification not found in the database", HttpStatusCode.NotFound);
     public static Error NotificationDetailsNotFound = new Error(3021, "Cannot retrieve notification details from Altinn Notification API", HttpStatusCode.NotFound);
+    public static Error OverrideKoFuViRequiresCustomRecipients = new Error(3022, "OverrideKoFuVi flag can only be used when CustomRecipients is provided", HttpStatusCode.BadRequest);
 }
 public static class AuthorizationErrors
 {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -173,6 +173,16 @@ namespace Altinn.Correspondence.Application.Helpers
         /// </summary>
         public Error? ValidateCustomRecipient(NotificationRequest notification, List<string> recipients)
         {
+            // Validate OverrideKoFuVi flag usage
+            if (notification.OverrideKoFuVi)
+            {
+                // OverrideKoFuVi can only be used when CustomRecipients is provided
+                if (notification.CustomRecipients == null || !notification.CustomRecipients.Any())
+                {
+                    return NotificationErrors.OverrideKoFuViRequiresCustomRecipients;
+                }
+            }
+
             // Check if we have custom recipients
             if (notification.CustomRecipients != null && notification.CustomRecipients.Any())
             {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -178,13 +178,13 @@ namespace Altinn.Correspondence.Application.Helpers
         /// </summary>
         public Error? ValidateCustomRecipient(NotificationRequest notification, List<string> recipients)
         {
-            // Validate OverrideKoFuVi flag usage
-            if (notification.OverrideKoFuVi)
+            // Validate OverrideRegisteredContactInformation flag usage
+            if (notification.OverrideRegisteredContactInformation)
             {
-                // OverrideKoFuVi can only be used when CustomRecipients is provided
+                // OverrideRegisteredContactInformation can only be used when CustomRecipients is provided
                 if (notification.CustomRecipients == null || !notification.CustomRecipients.Any())
                 {
-                    return NotificationErrors.OverrideKoFuViRequiresCustomRecipients;
+                    return NotificationErrors.OverrideRegisteredContactInformationRequiresCustomRecipients;
                 }
             }
 

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/NotificationRequest.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/NotificationRequest.cs
@@ -37,6 +37,6 @@ namespace Altinn.Correspondence.Application.InitializeCorrespondences
         /// This flag can only be used when CustomRecipients is provided.
         /// Default value is false (use default contact info + custom recipients).
         /// </summary>
-        public bool OverrideKoFuVi { get; set; } = false;
+        public bool OverrideRegisteredContactInformation { get; set; } = false;
     }
 }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/NotificationRequest.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/NotificationRequest.cs
@@ -31,5 +31,12 @@ namespace Altinn.Correspondence.Application.InitializeCorrespondences
         public DateTimeOffset? RequestedSendTime { get; set; }
 
         public List<Recipient>? CustomRecipients { get; set; }
+
+        /// <summary>
+        /// When set to true, only CustomRecipients will be used for notifications, overriding the default correspondence recipient.
+        /// This flag can only be used when CustomRecipients is provided.
+        /// Default value is false (use default contact info + custom recipients).
+        /// </summary>
+        public bool OverrideKoFuVi { get; set; } = false;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
added OverrideRegisteredContactInformation flag.
The docs in Altinn Studio will be updated in a saparate PR.

## Related Issue(s)
- #1325 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OverrideRegisteredContactInformation flag for notifications: when enabled, only supplied custom recipients are used instead of the default recipient.

- **Validation**
  - Using OverrideRegisteredContactInformation requires CustomRecipients; otherwise the API returns BadRequest with a clear error.

- **Tests**
  - Added tests covering OverrideRegisteredContactInformation true/false with and without custom recipients, verifying responses and resulting recipient composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->