### PR TITLE
Clean-up dialogs set with expiresAt ⚠️

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
@@ -195,5 +195,11 @@ namespace Altinn.Correspondence.Tests.Factories
             _correspondenceEntity.ServiceOwnerId = serviceOwnerId;
             return this;
         }
+
+        public CorrespondenceEntityBuilder WithAllowSystemDeleteAfter(DateTimeOffset? allowSystemDeleteAfter)
+        {
+            _correspondenceEntity.AllowSystemDeleteAfter = allowSystemDeleteAfter;
+            return this;
+        }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CleanupPerishingDialogsHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CleanupPerishingDialogsHandlerTests.cs
@@ -1,0 +1,113 @@
+using Altinn.Correspondence.Application.CleanupPerishingDialogs;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Altinn.Correspondence.Tests.Factories;
+
+namespace Altinn.Correspondence.Tests.TestingHandler;
+
+public class CleanupPerishingDialogsHandlerTests
+{
+    [Fact]
+    public async Task ExecuteCleanupInBackground_RemovesExpiresAtAndCountsAlreadyOk()
+    {
+        // Arrange
+        var now = DateTimeOffset.UtcNow;
+        var c1 = new CorrespondenceEntityBuilder()
+            .WithCreated(now.UtcDateTime.AddMinutes(-2))
+            .WithRequestedPublishTime(now.AddMinutes(-2))
+            .WithExternalReference(ReferenceType.DialogportenDialogId, "d1")
+            .WithAllowSystemDeleteAfter(now.AddDays(30))
+            .Build();
+        var c2 = new CorrespondenceEntityBuilder()
+            .WithCreated(now.UtcDateTime.AddMinutes(-1))
+            .WithRequestedPublishTime(now.AddMinutes(-1))
+            .WithExternalReference(ReferenceType.DialogportenDialogId, "d2")
+            .WithAllowSystemDeleteAfter(now.AddDays(30))
+            .Build();
+
+        var repo = new Mock<ICorrespondenceRepository>();
+        repo.SetupSequence(r => r.GetCorrespondencesWindowAfter(It.IsAny<int>(), It.IsAny<DateTimeOffset?>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CorrespondenceEntity> { c1, c2 })
+            .ReturnsAsync(new List<CorrespondenceEntity>());
+        repo.Setup(r => r.GetCorrespondencesByIdsWithExternalReferenceAndAllowSystemDeleteAfter(
+                It.IsAny<List<Guid>>(),
+                It.IsAny<ReferenceType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<Guid> ids, ReferenceType _, CancellationToken __) =>
+                new List<CorrespondenceEntity> { c1, c2 }.Where(x => ids.Contains(x.Id)).ToList());
+
+        var dialog = new Mock<IDialogportenService>();
+        dialog.Setup(s => s.TryRemoveDialogExpiresAt("d1", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        dialog.Setup(s => s.TryRemoveDialogExpiresAt("d2", It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var bg = new Mock<IBackgroundJobClient>();
+        var logger = new Mock<ILogger<CleanupPerishingDialogsHandler>>();
+
+        var handler = new CleanupPerishingDialogsHandler(repo.Object, dialog.Object, bg.Object, logger.Object);
+
+        // Act
+        await handler.ExecuteCleanupInBackground(100, CancellationToken.None);
+
+        // Assert
+        dialog.Verify(s => s.TryRemoveDialogExpiresAt("d1", It.IsAny<CancellationToken>()), Times.Once);
+        dialog.Verify(s => s.TryRemoveDialogExpiresAt("d2", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteCleanupInBackground_DoesNotReprocessOrSkipItemsBetweenBatches()
+    {
+        // Arrange
+        var baseTime = new DateTimeOffset(2001, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var all = new List<CorrespondenceEntity>();
+        for (int i = 0; i < 5; i++)
+        {
+            all.Add(new CorrespondenceEntityBuilder()
+                .WithCreated(baseTime.AddSeconds(i).UtcDateTime)
+                .WithRequestedPublishTime(baseTime.AddSeconds(i))
+                .WithExternalReference(ReferenceType.DialogportenDialogId, $"d{i}")
+                .WithAllowSystemDeleteAfter(baseTime.AddDays(30))
+                .Build());
+        }
+
+        var repo = new Mock<ICorrespondenceRepository>();
+        repo.Setup(r => r.GetCorrespondencesWindowAfter(It.IsAny<int>(), It.IsAny<DateTimeOffset?>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((int limit, DateTimeOffset? lastCreated, Guid? lastId, bool _, CancellationToken __) =>
+            {
+                var query = all
+                    .Where(c => !lastCreated.HasValue
+                        || c.Created > lastCreated.Value
+                        || (c.Created == lastCreated.Value && lastId.HasValue && c.Id.CompareTo(lastId.Value) > 0))
+                    .OrderBy(c => c.Created).ThenBy(c => c.Id)
+                    .Take(limit)
+                    .ToList();
+                return query;
+            });
+        repo.Setup(r => r.GetCorrespondencesByIdsWithExternalReferenceAndAllowSystemDeleteAfter(
+                It.IsAny<List<Guid>>(),
+                It.IsAny<ReferenceType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<Guid> ids, ReferenceType _, CancellationToken ___) =>
+                all.Where(x => ids.Contains(x.Id)).ToList());
+
+        var processed = new HashSet<string>();
+        var dialog = new Mock<IDialogportenService>();
+        dialog.Setup(s => s.TryRemoveDialogExpiresAt(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync((string id, CancellationToken _) => { processed.Add(id); return true; });
+
+        var bg = new Mock<IBackgroundJobClient>();
+        var logger = new Mock<ILogger<CleanupPerishingDialogsHandler>>();
+
+        var handler = new CleanupPerishingDialogsHandler(repo.Object, dialog.Object, bg.Object, logger.Object);
+
+        // Act
+        await handler.ExecuteCleanupInBackground(2, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(all.Count, processed.Count);
+    }
+} 

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/RestoreSoftDeletedDialogsHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/RestoreSoftDeletedDialogsHandlerTests.cs
@@ -1,0 +1,115 @@
+using Altinn.Correspondence.Application.RestoreSoftDeletedDialogs;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Altinn.Correspondence.Tests.Factories;
+
+namespace Altinn.Correspondence.Tests.TestingHandler;
+
+public class RestoreSoftDeletedDialogsHandlerTests
+{
+    [Fact]
+    public async Task ExecuteRestoreInBackground_RestoresAndCountsAlreadyActive()
+    {
+        // Arrange
+        var now = DateTimeOffset.UtcNow;
+        var c1 = new CorrespondenceEntityBuilder()
+            .WithCreated(now.UtcDateTime.AddMinutes(-2))
+            .WithRequestedPublishTime(now.AddMinutes(-2))
+            .WithExternalReference(ReferenceType.DialogportenDialogId, "d1")
+            .WithStatus(CorrespondenceStatus.Published, now.UtcDateTime, Guid.NewGuid())
+            .Build();
+        var c2 = new CorrespondenceEntityBuilder()
+            .WithCreated(now.UtcDateTime.AddMinutes(-1))
+            .WithRequestedPublishTime(now.AddMinutes(-1))
+            .WithExternalReference(ReferenceType.DialogportenDialogId, "d2")
+            .WithStatus(CorrespondenceStatus.Read, now.UtcDateTime, Guid.NewGuid())
+            .Build();
+
+        var repo = new Mock<ICorrespondenceRepository>();
+        repo.SetupSequence(r => r.GetCorrespondencesWindowAfter(It.IsAny<int>(), It.IsAny<DateTimeOffset?>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CorrespondenceEntity> { c1, c2 })
+            .ReturnsAsync(new List<CorrespondenceEntity>());
+        repo.Setup(r => r.GetCorrespondencesByIdsWithExternalReferenceAndNotCurrentStatuses(
+                It.IsAny<List<Guid>>(),
+                It.IsAny<ReferenceType>(),
+                It.IsAny<List<CorrespondenceStatus>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<Guid> ids, ReferenceType _, List<CorrespondenceStatus> __, CancellationToken ___) =>
+                new List<CorrespondenceEntity> { c1, c2 }.Where(x => ids.Contains(x.Id)).ToList());
+
+        var dialog = new Mock<IDialogportenService>();
+        dialog.Setup(s => s.TryRestoreSoftDeletedDialog("d1", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        dialog.Setup(s => s.TryRestoreSoftDeletedDialog("d2", It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var bg = new Mock<IBackgroundJobClient>();
+        var logger = new Mock<ILogger<RestoreSoftDeletedDialogsHandler>>();
+
+        var handler = new RestoreSoftDeletedDialogsHandler(repo.Object, dialog.Object, bg.Object, logger.Object);
+
+        // Act
+        await handler.ExecuteRestoreInBackground(100, CancellationToken.None);
+
+        // Assert
+        dialog.Verify(s => s.TryRestoreSoftDeletedDialog("d1", It.IsAny<CancellationToken>()), Times.Once);
+        dialog.Verify(s => s.TryRestoreSoftDeletedDialog("d2", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteRestoreInBackground_DoesNotReprocessOrSkipItemsBetweenBatches()
+    {
+        // Arrange
+        var baseTime = new DateTimeOffset(2001, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var all = new List<CorrespondenceEntity>();
+        for (int i = 0; i < 5; i++)
+        {
+            all.Add(new CorrespondenceEntityBuilder()
+                .WithCreated(baseTime.AddSeconds(i).UtcDateTime)
+                .WithRequestedPublishTime(baseTime.AddSeconds(i))
+                .WithExternalReference(ReferenceType.DialogportenDialogId, $"d{i}")
+                .WithStatus(CorrespondenceStatus.Published, baseTime.AddSeconds(i).UtcDateTime, Guid.NewGuid())
+                .Build());
+        }
+
+        var repo = new Mock<ICorrespondenceRepository>();
+        repo.Setup(r => r.GetCorrespondencesWindowAfter(It.IsAny<int>(), It.IsAny<DateTimeOffset?>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((int limit, DateTimeOffset? lastCreated, Guid? lastId, bool _, CancellationToken __) =>
+            {
+                var query = all
+                    .Where(c => !lastCreated.HasValue
+                        || c.Created > lastCreated.Value
+                        || (c.Created == lastCreated.Value && lastId.HasValue && c.Id.CompareTo(lastId.Value) > 0))
+                    .OrderBy(c => c.Created).ThenBy(c => c.Id)
+                    .Take(limit)
+                    .ToList();
+                return query;
+            });
+        repo.Setup(r => r.GetCorrespondencesByIdsWithExternalReferenceAndNotCurrentStatuses(
+                It.IsAny<List<Guid>>(),
+                It.IsAny<ReferenceType>(),
+                It.IsAny<List<CorrespondenceStatus>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<Guid> ids, ReferenceType _, List<CorrespondenceStatus> __, CancellationToken ___) =>
+                all.Where(x => ids.Contains(x.Id)).ToList());
+
+        var processed = new HashSet<string>();
+        var dialog = new Mock<IDialogportenService>();
+        dialog.Setup(s => s.TryRestoreSoftDeletedDialog(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync((string id, CancellationToken _) => { processed.Add(id); return true; });
+
+        var bg = new Mock<IBackgroundJobClient>();
+        var logger = new Mock<ILogger<RestoreSoftDeletedDialogsHandler>>();
+
+        var handler = new RestoreSoftDeletedDialogsHandler(repo.Object, dialog.Object, bg.Object, logger.Object);
+
+        // Act
+        await handler.ExecuteRestoreInBackground(2, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(all.Count, processed.Count);
+    }
+} 

--- a/src/Altinn.Correspondence.Application/CleanupPerishingDialogs/CleanupPerishingDialogsHandler.cs
+++ b/src/Altinn.Correspondence.Application/CleanupPerishingDialogs/CleanupPerishingDialogsHandler.cs
@@ -1,0 +1,156 @@
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using Microsoft.Extensions.Logging;
+using OneOf;
+using System.Security.Claims;
+using Hangfire;
+
+namespace Altinn.Correspondence.Application.CleanupPerishingDialogs;
+
+public class CleanupPerishingDialogsHandler(
+    ICorrespondenceRepository correspondenceRepository,
+    IDialogportenService dialogportenService,
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<CleanupPerishingDialogsHandler> logger) : IHandler<CleanupPerishingDialogsRequest, CleanupPerishingDialogsResponse>
+{
+    public Task<OneOf<CleanupPerishingDialogsResponse, Error>> Process(CleanupPerishingDialogsRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Starting cleanup of perishing dialogs (removing expiresAt) with window size {windowSize}", request.WindowSize);
+
+        var jobId = backgroundJobClient.Enqueue(() => ExecuteCleanupInBackground(request.WindowSize, CancellationToken.None));
+
+        logger.LogInformation("Cleanup job {jobId} has been enqueued", jobId);
+
+        return Task.FromResult<OneOf<CleanupPerishingDialogsResponse, Error>>(new CleanupPerishingDialogsResponse
+        {
+            JobId = jobId,
+            Message = "Cleanup job has been Enqueued"
+        });
+    }
+
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(timeoutInSeconds: 1800)]
+    public async Task ExecuteCleanupInBackground(int windowSize, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Executing cleanup of perishing dialogs in background job");
+        
+        var totalProcessed = 0;
+        var totalPatched = 0;
+        var totalAlreadyOk = 0;
+        var totalErrors = 0;
+        var allErrors = new List<string>();
+
+        try
+        {
+            DateTimeOffset? lastCreated = null;
+            Guid? lastId = null;
+            bool isMoreCorrespondences = true;
+            
+            while (isMoreCorrespondences)
+            {
+                logger.LogInformation("Processing batch starting after cursor {lastCreated} / {lastId}", lastCreated, lastId);
+                
+                var correspondencesWindow = await correspondenceRepository.GetCorrespondencesWindowAfter(
+                    windowSize + 1,
+                    lastCreated,
+                    lastId,
+                    true,
+                    cancellationToken);
+                    
+                isMoreCorrespondences = correspondencesWindow.Count > windowSize;
+                if (isMoreCorrespondences)
+                {
+                    correspondencesWindow = correspondencesWindow.Take(windowSize).ToList();
+                }
+
+                if (correspondencesWindow.Count > 0)
+                {
+                    var last = correspondencesWindow[^1];
+                    lastCreated = last.Created;
+                    lastId = last.Id;
+                }
+                
+                var windowIds = correspondencesWindow.Select(c => c.Id).ToList();
+                var candidates = await correspondenceRepository.GetCorrespondencesByIdsWithExternalReferenceAndAllowSystemDeleteAfter(
+                    windowIds,
+                    ReferenceType.DialogportenDialogId,
+                    cancellationToken);
+
+                logger.LogInformation(
+                    "Scanned {scanned} correspondences, {candidates} to remove expiresAt for (IsMore: {isMore})",
+                    correspondencesWindow.Count,
+                    candidates.Count,
+                    isMoreCorrespondences);
+
+                foreach (var correspondence in candidates)
+                {
+                    try
+                    {
+                        var (patched, alreadyOk) = await ProcessSingleCorrespondence(correspondence);
+                        if (patched) totalPatched++;
+                        if (alreadyOk) totalAlreadyOk++;
+                    }
+                    catch (Exception ex)
+                    {
+                        totalErrors++;
+                        var errorMessage = $"Failed to process correspondence {correspondence.Id}: {ex.Message}";
+                        allErrors.Add(errorMessage);
+                        logger.LogError(ex, "Failed to process correspondence {correspondenceId}", correspondence.Id);
+                    }
+                }
+
+                totalProcessed += candidates.Count;
+
+                if (correspondencesWindow.Count == 0)
+                {
+                    isMoreCorrespondences = false;
+                }
+            }
+
+            logger.LogInformation("Background cleanup completed. Total processed: {processedCount}, Total patched: {patchedCount}, Already ok: {alreadyOkCount}, Total errors: {errorCount}", 
+                totalProcessed, totalPatched, totalAlreadyOk, totalErrors);
+                
+            if (allErrors.Count > 0)
+            {
+                logger.LogWarning("Cleanup completed with {errorCount} errors: {errors}", totalErrors, string.Join("; ", allErrors));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to execute background cleanup of perishing dialogs");
+            throw;
+        }
+    }
+
+    private async Task<(bool patched, bool alreadyOk)> ProcessSingleCorrespondence(CorrespondenceEntity correspondence)
+    {
+        var dialogId = correspondence.ExternalReferences
+            .FirstOrDefault(er => er.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
+
+        if (dialogId == null)
+        {
+            if (correspondence.IsMigrating)
+            {
+                logger.LogWarning("Skipping correspondence {correspondenceId} as it is an Altinn2 correspondence without Dialogporten dialog",
+                    correspondence.Id);
+                return (false, false);
+            }
+            logger.LogError("Correspondence {correspondenceId} has no dialog reference", correspondence.Id);
+            return (false, false);
+        }
+
+        logger.LogInformation("Attempting to remove expiresAt on dialog {dialogId} for correspondence {correspondenceId}", 
+            dialogId, correspondence.Id);
+
+        var removed = await dialogportenService.TryRemoveDialogExpiresAt(dialogId);
+        if (removed)
+        {
+            logger.LogInformation("Successfully removed expiresAt on dialog {dialogId} for correspondence {correspondenceId}", dialogId, correspondence.Id);
+            return (true, false);
+        }
+        logger.LogInformation("Dialog {dialogId} already has no expiresAt in Dialogporten for correspondence {correspondenceId}", dialogId, correspondence.Id);
+        return (false, true);
+    }
+} 

--- a/src/Altinn.Correspondence.Application/CleanupPerishingDialogs/CleanupPerishingDialogsRequest.cs
+++ b/src/Altinn.Correspondence.Application/CleanupPerishingDialogs/CleanupPerishingDialogsRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Correspondence.Application.CleanupPerishingDialogs;
+
+public class CleanupPerishingDialogsRequest
+{
+    [Range(100, int.MaxValue)]
+    public int WindowSize { get; set; } = 10000;
+} 

--- a/src/Altinn.Correspondence.Application/CleanupPerishingDialogs/CleanupPerishingDialogsResponse.cs
+++ b/src/Altinn.Correspondence.Application/CleanupPerishingDialogs/CleanupPerishingDialogsResponse.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Correspondence.Application.CleanupPerishingDialogs;
+
+public class CleanupPerishingDialogsResponse
+{
+    public string? JobId { get; set; }
+    public string? Message { get; set; }
+} 

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -65,6 +65,7 @@ public static class DependencyInjection
 
         // Maintenance
         services.AddScoped<CleanupOrphanedDialogsHandler>();
+        services.AddScoped<CleanupPerishingDialogs.CleanupPerishingDialogsHandler>();
 
         // Statistics & Reporting
         services.AddScoped<GenerateDailySummaryReportHandler>();

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -28,6 +28,7 @@ using Altinn.Correspondence.Application.CleanupOrphanedDialogs;
 using Altinn.Correspondence.Application.SyncCorrespondenceEvent;
 using Altinn.Correspondence.Application.LegacyUpdateCorrespondenceStatus;
 using Altinn.Correspondence.Application.GenerateReport;
+using Altinn.Correspondence.Application.RestoreSoftDeletedDialogs;
 
 namespace Altinn.Correspondence.Application;
 
@@ -66,6 +67,7 @@ public static class DependencyInjection
         // Maintenance
         services.AddScoped<CleanupOrphanedDialogsHandler>();
         services.AddScoped<CleanupPerishingDialogs.CleanupPerishingDialogsHandler>();
+        services.AddScoped<RestoreSoftDeletedDialogsHandler>();
 
         // Statistics & Reporting
         services.AddScoped<GenerateDailySummaryReportHandler>();

--- a/src/Altinn.Correspondence.Application/RestoreSoftDeletedDialogs/RestoreSoftDeletedDialogsHandler.cs
+++ b/src/Altinn.Correspondence.Application/RestoreSoftDeletedDialogs/RestoreSoftDeletedDialogsHandler.cs
@@ -1,0 +1,157 @@
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using Microsoft.Extensions.Logging;
+using OneOf;
+using System.Security.Claims;
+using Hangfire;
+
+namespace Altinn.Correspondence.Application.RestoreSoftDeletedDialogs;
+
+public class RestoreSoftDeletedDialogsHandler(
+    ICorrespondenceRepository correspondenceRepository,
+    IDialogportenService dialogportenService,
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<RestoreSoftDeletedDialogsHandler> logger) : IHandler<RestoreSoftDeletedDialogsRequest, RestoreSoftDeletedDialogsResponse>
+{
+    public Task<OneOf<RestoreSoftDeletedDialogsResponse, Error>> Process(RestoreSoftDeletedDialogsRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Starting restore of soft-deleted dialogs with window size {windowSize}", request.WindowSize);
+
+        var jobId = backgroundJobClient.Enqueue(() => ExecuteRestoreInBackground(request.WindowSize, CancellationToken.None));
+
+        logger.LogInformation("Restore job {jobId} has been enqueued", jobId);
+
+        return Task.FromResult<OneOf<RestoreSoftDeletedDialogsResponse, Error>>(new RestoreSoftDeletedDialogsResponse
+        {
+            JobId = jobId,
+            Message = "Restore job has been Enqueued"
+        });
+    }
+
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(timeoutInSeconds: 1800)]
+    public async Task ExecuteRestoreInBackground(int windowSize, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Executing restore of soft-deleted dialogs in background job");
+        
+        var totalProcessed = 0;
+        var totalRestored = 0;
+        var totalAlreadyActive = 0;
+        var totalErrors = 0;
+        var allErrors = new List<string>();
+
+        try
+        {
+            DateTimeOffset? lastCreated = null;
+            Guid? lastId = null;
+            bool isMoreCorrespondences = true;
+            
+            while (isMoreCorrespondences)
+            {
+                logger.LogInformation("Processing batch starting after cursor {lastCreated} / {lastId}", lastCreated, lastId);
+                
+                var correspondencesWindow = await correspondenceRepository.GetCorrespondencesWindowAfter(
+                    windowSize + 1,
+                    lastCreated,
+                    lastId,
+                    true,
+                    cancellationToken);
+                    
+                isMoreCorrespondences = correspondencesWindow.Count > windowSize;
+                if (isMoreCorrespondences)
+                {
+                    correspondencesWindow = correspondencesWindow.Take(windowSize).ToList();
+                }
+
+                if (correspondencesWindow.Count > 0)
+                {
+                    var last = correspondencesWindow[^1];
+                    lastCreated = last.Created;
+                    lastId = last.Id;
+                }
+                
+                var windowIds = correspondencesWindow.Select(c => c.Id).ToList();
+                var nonPurgedWithDialog = await correspondenceRepository.GetCorrespondencesByIdsWithExternalReferenceAndNotCurrentStatuses(
+                    windowIds,
+                    ReferenceType.DialogportenDialogId,
+                    new List<CorrespondenceStatus> { CorrespondenceStatus.PurgedByAltinn, CorrespondenceStatus.PurgedByRecipient },
+                    cancellationToken);
+
+                logger.LogInformation(
+                    "Scanned {scanned} correspondences, {candidates} to restore dialogs for (IsMore: {isMore})",
+                    correspondencesWindow.Count,
+                    nonPurgedWithDialog.Count,
+                    isMoreCorrespondences);
+
+                foreach (var correspondence in nonPurgedWithDialog)
+                {
+                    try
+                    {
+                        var (restored, alreadyActive) = await ProcessSingleCorrespondence(correspondence);
+                        if (restored) totalRestored++;
+                        if (alreadyActive) totalAlreadyActive++;
+                    }
+                    catch (Exception ex)
+                    {
+                        totalErrors++;
+                        var errorMessage = $"Failed to process correspondence {correspondence.Id}: {ex.Message}";
+                        allErrors.Add(errorMessage);
+                        logger.LogError(ex, "Failed to process correspondence {correspondenceId}", correspondence.Id);
+                    }
+                }
+
+                totalProcessed += nonPurgedWithDialog.Count;
+
+                if (correspondencesWindow.Count == 0)
+                {
+                    isMoreCorrespondences = false;
+                }
+            }
+
+            logger.LogInformation("Background restore completed. Total processed: {processedCount}, Total restored: {restoredCount}, Already active: {alreadyActiveCount}, Total errors: {errorCount}", 
+                totalProcessed, totalRestored, totalAlreadyActive, totalErrors);
+                
+            if (allErrors.Count > 0)
+            {
+                logger.LogWarning("Restore completed with {errorCount} errors: {errors}", totalErrors, string.Join("; ", allErrors));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to execute background restore of soft-deleted dialogs");
+            throw;
+        }
+    }
+
+    private async Task<(bool restored, bool alreadyActive)> ProcessSingleCorrespondence(CorrespondenceEntity correspondence)
+    {
+        var dialogId = correspondence.ExternalReferences
+            .FirstOrDefault(er => er.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
+
+        if (dialogId == null)
+        {
+            if (correspondence.IsMigrating)
+            {
+                logger.LogWarning("Skipping correspondence {correspondenceId} as it is an Altinn2 correspondence without Dialogporten dialog",
+                    correspondence.Id);
+                return (false, false);
+            }
+            logger.LogError("Correspondence {correspondenceId} has no dialog reference", correspondence.Id);
+            return (false, false);
+        }
+
+        logger.LogInformation("Attempting to restore soft-deleted dialog {dialogId} for correspondence {correspondenceId}", 
+            dialogId, correspondence.Id);
+
+        var restored = await dialogportenService.TryRestoreSoftDeletedDialog(dialogId);
+        if (restored)
+        {
+            logger.LogInformation("Successfully restored dialog {dialogId} for correspondence {correspondenceId}", dialogId, correspondence.Id);
+            return (true, false);
+        }
+        logger.LogInformation("Dialog {dialogId} was not restored (possibly already active) for correspondence {correspondenceId}", dialogId, correspondence.Id);
+        return (false, true);
+    }
+} 

--- a/src/Altinn.Correspondence.Application/RestoreSoftDeletedDialogs/RestoreSoftDeletedDialogsRequest.cs
+++ b/src/Altinn.Correspondence.Application/RestoreSoftDeletedDialogs/RestoreSoftDeletedDialogsRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Correspondence.Application.RestoreSoftDeletedDialogs;
+
+public class RestoreSoftDeletedDialogsRequest
+{
+    [Range(100, int.MaxValue)]
+    public int WindowSize { get; set; } = 1000;
+} 

--- a/src/Altinn.Correspondence.Application/RestoreSoftDeletedDialogs/RestoreSoftDeletedDialogsResponse.cs
+++ b/src/Altinn.Correspondence.Application/RestoreSoftDeletedDialogs/RestoreSoftDeletedDialogsResponse.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Correspondence.Application.RestoreSoftDeletedDialogs;
+
+public class RestoreSoftDeletedDialogsResponse
+{
+    public string? JobId { get; set; }
+    public string? Message { get; set; }
+} 

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -68,6 +68,11 @@ namespace Altinn.Correspondence.Core.Repositories
             List<CorrespondenceStatus> currentStatuses,
             CancellationToken cancellationToken);
 
+        Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndAllowSystemDeleteAfter(
+            List<Guid> correspondenceIds,
+            ReferenceType referenceType,
+            CancellationToken cancellationToken);
+        
         Task<List<CorrespondenceEntity>> GetCorrespondencesForReport(bool includeAltinn2, CancellationToken cancellationToken);
         
         Task<CorrespondenceEntity?> GetCorrespondenceByIdempotentKey(Guid idempotentKey, CancellationToken cancellationToken);

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -67,6 +67,12 @@ namespace Altinn.Correspondence.Core.Repositories
             ReferenceType referenceType,
             List<CorrespondenceStatus> currentStatuses,
             CancellationToken cancellationToken);
+        
+        Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndNotCurrentStatuses(
+            List<Guid> correspondenceIds,
+            ReferenceType referenceType,
+            List<CorrespondenceStatus> excludedCurrentStatuses,
+            CancellationToken cancellationToken);
 
         Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndAllowSystemDeleteAfter(
             List<Guid> correspondenceIds,

--- a/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
@@ -15,6 +15,7 @@ public interface IDialogportenService
     Task PurgeCorrespondenceDialog(Guid correspondenceId);
     Task SoftDeleteDialog(string dialogId);
     Task<bool> TrySoftDeleteDialog(string dialogId);
+    Task<bool> TryRemoveDialogExpiresAt(string dialogId, CancellationToken cancellationToken = default);
     Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName, DateTimeOffset activityTimestamp);
     Task UpdateSystemLabelsOnDialog(Guid correspondenceId, string enduserId, List<DialogPortenSystemLabel>? systemLabelsToAdd, List<DialogPortenSystemLabel>? systemLabelsToRemove);
 }

--- a/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
@@ -16,6 +16,7 @@ public interface IDialogportenService
     Task SoftDeleteDialog(string dialogId);
     Task<bool> TrySoftDeleteDialog(string dialogId);
     Task<bool> TryRemoveDialogExpiresAt(string dialogId, CancellationToken cancellationToken = default);
+    Task<bool> TryRestoreSoftDeletedDialog(string dialogId, CancellationToken cancellationToken = default);
     Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName, DateTimeOffset activityTimestamp);
     Task UpdateSystemLabelsOnDialog(Guid correspondenceId, string enduserId, List<DialogPortenSystemLabel>? systemLabelsToAdd, List<DialogPortenSystemLabel>? systemLabelsToRemove);
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
@@ -49,6 +49,11 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
             return Task.FromResult(true);
         }
 
+        public Task<bool> TryRemoveDialogExpiresAt(string dialogId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(true);
+        }
+
         public Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType,  string actorName, DateTimeOffset activityTimestamp)
         {
             return Task.CompletedTask;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
@@ -54,6 +54,11 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
             return Task.FromResult(true);
         }
 
+        public Task<bool> TryRestoreSoftDeletedDialog(string dialogId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(true);
+        }
+
         public Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType,  string actorName, DateTimeOffset activityTimestamp)
         {
             return Task.CompletedTask;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -619,4 +619,20 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         }
     }
     #endregion
+
+    public async Task<bool> TryRestoreSoftDeletedDialog(string dialogId, CancellationToken cancellationToken = default)
+    {
+        // We assume Dialogporten exposes a restore endpoint for soft-deleted dialogs
+        var response = await _httpClient.PostAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}/actions/restore", null, cancellationToken);
+        if (response.IsSuccessStatusCode)
+        {
+            return true;
+        }
+        if (response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == HttpStatusCode.Gone)
+        {
+            // Treat as already restored or not applicable
+            return false;
+        }
+        throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+    }
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -369,6 +369,28 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
     }
 
+    public async Task<bool> TryRemoveDialogExpiresAt(string dialogId, CancellationToken cancellationToken = default)
+    {
+        var dialog = await GetDialog(dialogId);
+        if (dialog is null)
+        {
+            throw new Exception($"Dialog {dialogId} not found when attempting to remove expiresAt");
+        }
+        if (dialog.ExpiresAt == null)
+        {
+            return false;
+        }
+        var patchRequestBuilder = new DialogPatchRequestBuilder()
+            .WithRemoveExpiresAtOperation();
+        var patchRequest = patchRequestBuilder.Build();
+        var response = await _httpClient.PatchAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}", patchRequest, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+        }
+        return true;
+    }
+
     public async Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName, DateTimeOffset activityTimestamp)
     {
         logger.LogInformation("CreateCorrespondencePurgedActivity by {actorType}: for correspondence {correspondenceId}",

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Factories/PatchDialogRequestBuilder.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Factories/PatchDialogRequestBuilder.cs
@@ -45,5 +45,17 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
             );
             return this;
         }
+
+        internal DialogPatchRequestBuilder WithRemoveExpiresAtOperation()
+        {
+            _PatchDialogRequest.Add(
+                new
+                {
+                    op = "remove",
+                    path = "/expiresAt"
+                }
+            );
+            return this;
+        }
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -37,7 +37,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     UpdatedAt = (correspondence.Statuses ?? []).Select(s => s.StatusChanged).Concat([correspondence.Created]).Max(),
                     VisibleFrom = correspondence.RequestedPublishTime < DateTime.UtcNow.AddMinutes(1) ? null : correspondence.RequestedPublishTime,
                     Process = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenProcessId)?.ReferenceValue,
-                    ExpiresAt = correspondence.AllowSystemDeleteAfter,
                     DueAt = dueAt,
                     Status = GetDialogStatusForCorrespondence(correspondence),
                     ExternalReference = correspondence.SendersReference,

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -260,6 +260,26 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .ToListAsync(cancellationToken);
         }
 
+        public async Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndAllowSystemDeleteAfter(
+            List<Guid> correspondenceIds,
+            ReferenceType referenceType,
+            CancellationToken cancellationToken)
+        {
+            if (correspondenceIds == null || correspondenceIds.Count == 0)
+            {
+                return new List<CorrespondenceEntity>();
+            }
+
+            return await _context.Correspondences
+                .AsNoTracking()
+                .AsSplitQuery()
+                .Where(c => correspondenceIds.Contains(c.Id))
+                .Where(c => c.AllowSystemDeleteAfter != null)
+                .Where(c => c.ExternalReferences.Any(er => er.ReferenceType == referenceType))
+                .Include(c => c.ExternalReferences)
+                .ToListAsync(cancellationToken);
+        }
+        
         public async Task<List<CorrespondenceEntity>> GetCorrespondencesForReport(bool includeAltinn2, CancellationToken cancellationToken)
         {
             var query = _context.Correspondences.AsQueryable();


### PR DESCRIPTION
## Description
We set expiresAt to allowSystemDeleteAfter, but this leads to them being purged which is unfortunate.

Post-deploy:
Call the new endpoint in MaintenanceController

## Related Issue(s)
- #1349

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two maintenance endpoints to enqueue background jobs for cleaning perishing dialogs and restoring soft-deleted dialogs; each returns a job ID and message.
  * Both jobs run batched, resilient background workflows with progress reporting and per-item error handling.

* **Chores**
  * Added integration support for removing expiries and restoring soft-deleted dialogs and registered new maintenance handlers.
  * New request/response contracts and repository/service operations to support batching and filtering.

* **Tests**
  * Unit tests covering batching, paging, and per-item handling for both cleanup and restore workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->