### PR TITLE
High availability for production database

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -140,6 +140,7 @@ module postgresql '../modules/postgreSql/create.bicep' = {
     tenantId: tenantId
     prodLikeEnvironment: prodLikeEnvironment
     logAnalyticsWorkspaceId: containerAppEnv.outputs.logAnalyticsWorkspaceId
+    environment: environment
   }
 }
 

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -7,7 +7,7 @@ param tenantId string
 
 param prodLikeEnvironment bool
 param logAnalyticsWorkspaceId string = ''
-
+param environment string
 
 var databaseName = 'correspondence'
 var poolSize = prodLikeEnvironment ? 100 : 25
@@ -28,6 +28,10 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
       passwordAuth: 'Disabled'
       tenantId: tenantId
     }
+    highAvailability: environment == 'production' ? {
+      mode: 'ZoneRedundant'
+      standbyAvailabilityZone: '1'
+    } : null
   }
   sku: prodLikeEnvironment
     ? {


### PR DESCRIPTION
## Description
Run a mirrored database server in another datacenter with automatic failover. Activated for prod only.

## Related Issue(s)
- #1318 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Production now uses zone-redundant high availability for PostgreSQL, improving uptime and failover resilience. Non‑production environments remain unchanged.

- Chores
  - Introduced environment-aware configuration across infrastructure modules to consistently pass environment context to database provisioning.
  - Aligns deployments to apply HA settings automatically in production without affecting development or testing workflows.
  - No downtime expected; changes take effect on new or updated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->