### PR TITLE
Improved legacy search

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Legacy/LegacySearchTests.cs
@@ -323,7 +323,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
         }
 
         [Fact]
-        public async Task LegacyGetCorrespondences_NoAuthorizedParties_Fails()
+        public async Task LegacyGetCorrespondences_NoAuthorizedParties_NoResults()
         {
             using var factory = new UnitWebApplicationFactory((IServiceCollection services) =>
             {
@@ -348,7 +348,9 @@ namespace Altinn.Correspondence.Tests.TestingController.Legacy
             listPayload.From = DateTimeOffset.UtcNow.AddDays(-1);
             listPayload.To = DateTimeOffset.UtcNow;
             var correspondenceList = await client.PostAsJsonAsync($"correspondence/api/v1/legacy/correspondence", listPayload);
-            Assert.Equal(HttpStatusCode.Unauthorized, correspondenceList.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, correspondenceList.StatusCode);
+            var response = await correspondenceList.Content.ReadFromJsonAsync<LegacyGetCorrespondencesResponse>(_serializerOptions);
+            Assert.Empty(response?.Items);
         }
         [Fact]
         public async Task LegacyGetCorrespondences_ForSubUnitAndAccessToOnlySubunit_Succeeds()

--- a/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
@@ -58,7 +58,7 @@ namespace Altinn.Correspondence.Tests.TestingRepository
             var addedCorrespondence = await correspondenceRepository.CreateCorrespondence(entity, CancellationToken.None);
 
             // Act
-            var correspondences = await correspondenceRepository.GetCorrespondencesForParties(1000, from, to, null, [recipient], [resource], true, false, "", CancellationToken.None);
+            var correspondences = await correspondenceRepository.GetCorrespondencesForParties(1000, from, to, null, [recipient], true, false, "", CancellationToken.None);
 
             // Assert
             Assert.NotNull(correspondences);

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -56,7 +56,7 @@ public class LegacyGetCorrespondencesHandler(
         var recipients = new List<string>();
         if (request.InstanceOwnerPartyIdList != null && request.InstanceOwnerPartyIdList.Length > 0)
         {
-            var authorizedParties = await altinnAccessManagementService.GetAuthorizedParties(userParty, cancellationToken);
+            var authorizedParties = await altinnAccessManagementService.GetAuthorizedParties(userParty, userClaimsHelper.GetUserId(), cancellationToken);
             authorizedParties = authorizedParties.DistinctBy(party => party.PartyId).ToList();
             var authorizedPartiesDict = authorizedParties.ToDictionary(p => p.PartyId, p => p);
             foreach (int instanceOwnerPartyId in request.InstanceOwnerPartyIdList)

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -86,7 +86,6 @@ public class LegacyGetCorrespondencesHandler(
             if (!string.IsNullOrEmpty(userParty.SSN)) recipients.Add(GetPrefixedForPerson(userParty.SSN));
             if (!string.IsNullOrEmpty(userParty.OrgNumber)) recipients.Add(GetPrefixedForOrg(userParty.OrgNumber));
         }
-        List<string> resourcesToSearch = new List<string>();
 
         // Get all correspondences owned by Recipients
         // request.IncludeDeleted is not used as this is for soft deleted correspondences only, which are not relevant in legacy
@@ -95,7 +94,6 @@ public class LegacyGetCorrespondencesHandler(
                                                                                           to: to,
                                                                                           status: request.Status,
                                                                                           recipientIds: recipients,
-                                                                                          resourceIds: resourcesToSearch,
                                                                                           includeActive: request.IncludeActive,
                                                                                           includeArchived: request.IncludeArchived,
                                                                                           searchString: request.SearchString,

--- a/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/LegacyGetCorrespondencesHandler.cs
@@ -56,17 +56,7 @@ public class LegacyGetCorrespondencesHandler(
         var recipients = new List<string>();
         if (request.InstanceOwnerPartyIdList != null && request.InstanceOwnerPartyIdList.Length > 0)
         {
-            var authorizedPartiesResponse = await altinnAccessManagementService.GetAuthorizedParties(userParty, cancellationToken);
-            var authorizedParties = new List<PartyWithSubUnits>();
-            foreach(var authorizedParty in authorizedPartiesResponse)
-            {
-                if (!authorizedParty.OnlyHierarchyElementWithNoAccess)
-                {
-                    authorizedParties.Add(authorizedParty);
-                } 
-                
-                authorizedParties.AddRange(authorizedParty.SubUnits);
-            }
+            var authorizedParties = await altinnAccessManagementService.GetAuthorizedParties(userParty, cancellationToken);
             authorizedParties = authorizedParties.DistinctBy(party => party.PartyId).ToList();
             var authorizedPartiesDict = authorizedParties.ToDictionary(p => p.PartyId, p => p);
             foreach (int instanceOwnerPartyId in request.InstanceOwnerPartyIdList)

--- a/src/Altinn.Correspondence.Application/Helpers/UserClaimsHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/UserClaimsHelper.cs
@@ -22,6 +22,8 @@ namespace Altinn.Correspondence.Application.Helpers
             return null;
         }
 
+        public string? GetUserId() => _claims.FirstOrDefault(c => c.Type == UrnConstants.UserId)?.Value;
+
         public int GetMinimumAuthenticationLevel()
         {
             var authLevelClaim = _claims.FirstOrDefault(c => c.Type == UrnConstants.AuthenticationLevel);

--- a/src/Altinn.Correspondence.Common/Constants/UrnConstants.cs
+++ b/src/Altinn.Correspondence.Common/Constants/UrnConstants.cs
@@ -41,4 +41,8 @@ public static class UrnConstants
     /// xacml string that refers to systemuser authentication
     /// </summary>
     public const string SystemUser = "urn:altinn:systemuser";
+    /// <summary>
+    /// xacml string that refers to userid
+    /// </summary>
+    public const string UserId = "urn:altinn:userid";
 }

--- a/src/Altinn.Correspondence.Core/Repositories/IAltinnAccessManangementService.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IAltinnAccessManangementService.cs
@@ -4,5 +4,5 @@ namespace Altinn.Correspondence.Core.Repositories;
 
 public interface IAltinnAccessManagementService
 {
-    Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default);
+    Task<List<Party>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Correspondence.Core/Repositories/IAltinnAccessManangementService.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IAltinnAccessManangementService.cs
@@ -4,5 +4,5 @@ namespace Altinn.Correspondence.Core.Repositories;
 
 public interface IAltinnAccessManagementService
 {
-    Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, CancellationToken cancellationToken = default);
+    Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -27,7 +27,6 @@ namespace Altinn.Correspondence.Core.Repositories
             DateTimeOffset? to,
             CorrespondenceStatus? status,
             List<string> recipientIds,
-            List<string> resourceIds,
             bool includeActive,
             bool includeArchived,
             string searchString,

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementDevService.cs
@@ -8,7 +8,7 @@ namespace Altinn.Correspondence.Integrations.Altinn.AccessManagement;
 public class AltinnAccessManagementDevService : IAltinnAccessManagementService
 {
     private readonly int _digdirPartyId = 50952483;
-    public Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, CancellationToken cancellationToken = default)
+    public Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default)
     {
         PartyWithSubUnits party = new()
         {

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementDevService.cs
@@ -8,7 +8,7 @@ namespace Altinn.Correspondence.Integrations.Altinn.AccessManagement;
 public class AltinnAccessManagementDevService : IAltinnAccessManagementService
 {
     private readonly int _digdirPartyId = 50952483;
-    public Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default)
+    public Task<List<Party>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default)
     {
         PartyWithSubUnits party = new()
         {
@@ -20,6 +20,6 @@ public class AltinnAccessManagementDevService : IAltinnAccessManagementService
             UnitType = "Virksomhet",
             Name = "Digitaliseringsdirektoratet",
         };
-        return Task.FromResult(new List<PartyWithSubUnits> { party });
+        return Task.FromResult(new List<Party> { party });
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
@@ -38,11 +38,11 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
         };
     }
 
-    public async Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default)
+    public async Task<List<Party>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default)
     {
         string cacheKey = $"AuthorizedParties_{partyToRequestFor.PartyId}";
         try {
-            var cachedParties = await CacheHelpers.GetObjectFromCacheAsync<List<PartyWithSubUnits>>(cacheKey, _cache, cancellationToken);
+            var cachedParties = await CacheHelpers.GetObjectFromCacheAsync<List<Party>>(cacheKey, _cache, cancellationToken);
             if (cachedParties != null)
             {
                 return cachedParties;
@@ -73,12 +73,12 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
             _logger.LogError("Unexpected null or invalid json response from Authorization GetAuthorizedParties.");
             throw new Exception("Unexpected null or invalid json response from Authorization GetAuthorizedParties.");
         }
-        List<PartyWithSubUnits> parties = new();
+        List<Party> parties = new();
         foreach (var p in responseContent)
         {
             if (!p.onlyHierarchyElementWithNoAccess)
             {
-                parties.Add(new PartyWithSubUnits
+                parties.Add(new Party
                 {
                     PartyId = p.partyId,
                     PartyUuid = p.partyUuid,
@@ -115,9 +115,9 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
             _ => throw new NotImplementedException()
         };
     }
-    private List<PartyWithSubUnits> GetPartiesFromSubunits(List<AuthroizedPartiesResponse> subunits, int depth = 0)
+    private List<Party> GetPartiesFromSubunits(List<AuthroizedPartiesResponse> subunits, int depth = 0)
     {
-        List<PartyWithSubUnits> parties = new();
+        List<Party> parties = new();
         if (depth > _MAX_DEPTH_FOR_SUBUNITS)
         {
             _logger.LogWarning("Max depth for subunits reached. Ignoring further subunits.");
@@ -125,7 +125,7 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
         }
         foreach (var subunit in subunits)
         {
-            parties.Add(new PartyWithSubUnits
+            parties.Add(new Party
             {
 
                 PartyId = subunit.partyId,

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
@@ -38,7 +38,7 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
         };
     }
 
-    public async Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, CancellationToken cancellationToken = default)
+    public async Task<List<PartyWithSubUnits>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default)
     {
         string cacheKey = $"AuthorizedParties_{partyToRequestFor.PartyId}";
         try {
@@ -53,7 +53,7 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
             _logger.LogWarning(ex, "Error retrieving authorized parties from cache in Access Management Service.");
         }
 
-        AuthorizedPartiesRequest request = new(partyToRequestFor);
+        AuthorizedPartiesRequest request = new(partyToRequestFor, userId);
         _logger.LogInformation("PartyId {partyId} has partyType {partyType}", partyToRequestFor.PartyId, request.Type);
         JsonSerializerOptions serializerOptions = new()
         {
@@ -148,9 +148,14 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
         public string Type { get; init; }
         public string Value { get; init; }
 
-        public AuthorizedPartiesRequest(Party party)
+        public AuthorizedPartiesRequest(Party party, string? userId)
         {
-            if (party.PartyTypeName == PartyType.Person)
+            if (userId is not null)
+            {
+                Type = UrnConstants.UserId;
+                Value = userId;
+            }
+            else if (party.PartyTypeName == PartyType.Person)
             {
                 Type = UrnConstants.PersonIdAttribute;
                 Value = party.SSN;

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
@@ -40,7 +40,7 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
 
     public async Task<List<Party>> GetAuthorizedParties(Party partyToRequestFor, string? userId, CancellationToken cancellationToken = default)
     {
-        string cacheKey = $"AuthorizedParties_{partyToRequestFor.PartyId}";
+        string cacheKey = $"AuthorizedParties_{partyToRequestFor.PartyId}_{userId}";
         try {
             var cachedParties = await CacheHelpers.GetObjectFromCacheAsync<List<Party>>(cacheKey, _cache, cancellationToken);
             if (cachedParties != null)

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
@@ -76,15 +76,18 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
         List<PartyWithSubUnits> parties = new();
         foreach (var p in responseContent)
         {
-            parties.Add(new PartyWithSubUnits
+            if (!p.onlyHierarchyElementWithNoAccess)
             {
-                PartyId = p.partyId,
-                PartyUuid = p.partyUuid,
-                OrgNumber = p.organizationNumber,
-                SSN = p.personId,
-                Resources = p.authorizedResources,
-                PartyTypeName = GetType(p.type),
-            });
+                parties.Add(new PartyWithSubUnits
+                {
+                    PartyId = p.partyId,
+                    PartyUuid = p.partyUuid,
+                    OrgNumber = p.organizationNumber,
+                    SSN = p.personId,
+                    Resources = p.authorizedResources,
+                    PartyTypeName = GetType(p.type),
+                });
+            }
             if (p.subunits != null && p.subunits.Count > 0)
             {
                 parties.AddRange(GetPartiesFromSubunits(p.subunits));

--- a/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/AccessManagement/AltinnAccessManagementService.cs
@@ -54,7 +54,7 @@ public class AltinnAccessManagementService : IAltinnAccessManagementService
         }
 
         AuthorizedPartiesRequest request = new(partyToRequestFor, userId);
-        _logger.LogInformation("PartyId {partyId} has partyType {partyType}", partyToRequestFor.PartyId, request.Type);
+        _logger.LogInformation("PartyId {partyId} has partyType {partyType} with userId {userId}", partyToRequestFor.PartyId, request.Type, userId);
         JsonSerializerOptions serializerOptions = new()
         {
             PropertyNameCaseInsensitive = true,

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -87,7 +87,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
             }
 
             return query.Where(cs =>
-                statusesToFilter.Contains(cs.Statuses.OrderBy(s => s.Status).Last().Status));
+                statusesToFilter.Contains(cs.Statuses.Max(s => s.Status)));
         }
 
         public static IQueryable<CorrespondenceEntity> ExcludePurged(this IQueryable<CorrespondenceEntity> query)

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -157,7 +157,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
             }
         }
 
-        public async Task<List<CorrespondenceEntity>> GetCorrespondencesForParties(int limit, DateTimeOffset? from, DateTimeOffset? to, CorrespondenceStatus? status, List<string> recipientIds, List<string> resourceIds, bool includeActive, bool includeArchived, string searchString, CancellationToken cancellationToken, bool filterMigrated = true)
+        public async Task<List<CorrespondenceEntity>> GetCorrespondencesForParties(int limit, DateTimeOffset? from, DateTimeOffset? to, CorrespondenceStatus? status, List<string> recipientIds, bool includeActive, bool includeArchived, string searchString, CancellationToken cancellationToken, bool filterMigrated = true)
         {
             var correspondences = recipientIds.Count == 1
                 ? _context.Correspondences.Where(c => c.Recipient == recipientIds[0])     // Filter by single recipient
@@ -166,7 +166,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
             correspondences = correspondences
                 .Where(c => from == null || c.RequestedPublishTime > from)   // From date filter
                 .Where(c => to == null || c.RequestedPublishTime < to)       // To date filter                              
-                .Where(c => resourceIds.Count == 0 || resourceIds.Contains(c.ResourceId))       // Filter by resources
                 .IncludeByStatuses(includeActive, includeArchived, status) // Filter by statuses
                 .ExcludePurged() // Exclude purged correspondences
                 .Where(c => string.IsNullOrEmpty(searchString) || (c.Content != null && c.Content.MessageTitle.Contains(searchString))) // Filter by messageTitle containing searchstring


### PR DESCRIPTION
## Description
Use userid if existing to handle ec certificate users

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authorization now propagates a user ID from claims, logs invalid/missing party IDs as warnings, and continues processing instead of failing.
  * Search now filters only by recipient identifiers; resource-based filtering removed.
  * Recipient detection simplified: prefer organization number, then SSN; caller identifiers still included after authorization.

* **Bug Fixes**
  * Status evaluation uses the maximum status when multiple entries exist.
  * Returns empty results (with a warning) if no valid recipients are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->