### PR TITLE
Prevent Correspondences and certain sync events with Self-Identified Users to update Dialogporten

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -1,6 +1,5 @@
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
-using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Tests.Factories;
@@ -19,6 +18,8 @@ namespace Altinn.Correspondence.Tests.TestingController.Migration;
 [Collection(nameof(CustomWebApplicationTestsCollection))]
 public class MigrationControllerTests : MigrationTestBase
 {
+    internal const string _selfIdentifedPartyUuidUrn = "urn:altinn:party:uuid:B00D8E8B-3026-46B5-B144-A343AC799038";
+
     public MigrationControllerTests(CustomWebApplicationFactory factory) : base(factory)
     {
     }
@@ -250,7 +251,7 @@ public class MigrationControllerTests : MigrationTestBase
     {
         MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
             .CreateMigrateCorrespondence()
-            .WithRecipient("urn:altinn:party:uuid:B00D8E8B-3026-46B5-B144-A343AC799038")
+            .WithRecipient(_selfIdentifedPartyUuidUrn)
             .WithStatusEvent(MigrateCorrespondenceStatusExt.Read, new DateTime(2024, 1, 6, 11, 10, 21))
             .WithStatusEvent(MigrateCorrespondenceStatusExt.Read, new DateTime(2024, 1, 7, 15, 11, 56))
             .WithStatusEvent(MigrateCorrespondenceStatusExt.Read, new DateTime(2024, 1, 8, 14, 19, 22))
@@ -271,8 +272,10 @@ public class MigrationControllerTests : MigrationTestBase
         var makeAvailableResponse = await _migrationClient.PostAsJsonAsync(makeAvailableUrl, request);
         Assert.True(makeAvailableResponse.IsSuccessStatusCode);
         MakeCorrespondenceAvailableResponseExt respExt = await makeAvailableResponse.Content.ReadFromJsonAsync<MakeCorrespondenceAvailableResponseExt>();
+        Assert.NotNull(respExt);
         Assert.NotNull(respExt.Statuses);
         Assert.Equal(1, respExt.Statuses.Count);
+        Assert.Equal(resultObj.CorrespondenceId, respExt.Statuses.First().CorrespondenceId);
         Assert.False(respExt.Statuses.First().Ok);
 
         // Verify that correspondence still has IsMigrating set to true, which means we cannot retrieve it through GetOverview.
@@ -391,7 +394,7 @@ public class MigrationControllerTests : MigrationTestBase
             .WithStatusEvent(MigrateCorrespondenceStatusExt.Confirmed, new DateTime(2024, 1, 12, 14, 21, 05))
             .WithStatusEvent(MigrateCorrespondenceStatusExt.Archived, new DateTime(2024, 1, 22, 09, 55, 20))
             .WithCreatedAt(new DateTime(2024, 1, 1, 03, 09, 21))
-            .WithRecipient("urn:altinn:party:uuid:B00D8E8B-3026-46B5-B144-A343AC799038")
+            .WithRecipient(_selfIdentifedPartyUuidUrn)
             .WithResourceId("skd-migratedcorrespondence-5229-1")
             .Build();
         SetNotificationHistory(migrateCorrespondenceExt);

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -246,6 +246,41 @@ public class MigrationControllerTests : MigrationTestBase
     }
 
     [Fact]
+    public async Task MakeCorrespondenceAvailable_SelfIdentfied_Rejected()
+    {
+        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
+            .CreateMigrateCorrespondence()
+            .WithRecipient("urn:altinn:party:uuid:B00D8E8B-3026-46B5-B144-A343AC799038")
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Read, new DateTime(2024, 1, 6, 11, 10, 21))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Read, new DateTime(2024, 1, 7, 15, 11, 56))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Read, new DateTime(2024, 1, 8, 14, 19, 22))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Confirmed, new DateTime(2024, 1, 8, 14, 20, 5))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Archived, new DateTime(2024, 1, 9, 10, 50, 17))
+            .Build();
+        SetNotificationHistory(migrateCorrespondenceExt);
+
+        CorrespondenceMigrationStatusExt resultObj = await MigrateSingleCorrespondence(migrateCorrespondenceExt);
+        Assert.NotNull(resultObj);
+
+        MakeCorrespondenceAvailableRequestExt request = new MakeCorrespondenceAvailableRequestExt()
+        {
+            CreateEvents = false,
+            CorrespondenceIds = [resultObj.CorrespondenceId],
+            CorrespondenceId = resultObj.CorrespondenceId
+        };
+        var makeAvailableResponse = await _migrationClient.PostAsJsonAsync(makeAvailableUrl, request);
+        Assert.True(makeAvailableResponse.IsSuccessStatusCode);
+        MakeCorrespondenceAvailableResponseExt respExt = await makeAvailableResponse.Content.ReadFromJsonAsync<MakeCorrespondenceAvailableResponseExt>();
+        Assert.NotNull(respExt.Statuses);
+        Assert.Equal(1, respExt.Statuses.Count);
+        Assert.False(respExt.Statuses.First().Ok);
+
+        // Verify that correspondence still has IsMigrating set to true, which means we cannot retrieve it through GetOverview.
+        var getCorrespondenceOverviewResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{resultObj.CorrespondenceId}/content");
+        Assert.False(getCorrespondenceOverviewResponse.IsSuccessStatusCode);
+    }
+
+    [Fact]
     public async Task MakeCorrespondenceAvailable_Defined()
     {
         MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
@@ -345,6 +380,33 @@ public class MigrationControllerTests : MigrationTestBase
         // Verify that correspondence has IsMigrating set to false, which means we can retrieve it through GetOverview.
         var getCorrespondenceOverviewResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{resultObj.CorrespondenceId}/content");
         Assert.True(getCorrespondenceOverviewResponse.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task MakeCorrespondenceAvailable_OnCall_SelfIdentified_NotMadeAvailable()
+    {
+        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
+            .CreateMigrateCorrespondence()
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Read, new DateTime(2024, 1, 12, 14, 20, 11))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Confirmed, new DateTime(2024, 1, 12, 14, 21, 05))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Archived, new DateTime(2024, 1, 22, 09, 55, 20))
+            .WithCreatedAt(new DateTime(2024, 1, 1, 03, 09, 21))
+            .WithRecipient("urn:altinn:party:uuid:B00D8E8B-3026-46B5-B144-A343AC799038")
+            .WithResourceId("skd-migratedcorrespondence-5229-1")
+            .Build();
+        SetNotificationHistory(migrateCorrespondenceExt);
+
+        migrateCorrespondenceExt.MakeAvailable = true;
+
+        var initializeCorrespondenceResponse = await _migrationClient.PostAsJsonAsync(migrateCorrespondenceUrl, migrateCorrespondenceExt);
+        string result = await initializeCorrespondenceResponse.Content.ReadAsStringAsync();
+        Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, result);
+        CorrespondenceMigrationStatusExt resultObj = JsonConvert.DeserializeObject<CorrespondenceMigrationStatusExt>(result);
+        Assert.True(String.IsNullOrEmpty(resultObj.DialogId));
+
+        // Verify that correspondence has IsMigrating set to true, which means we cannot retrieve it through GetOverview.
+        var getCorrespondenceOverviewResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{resultObj.CorrespondenceId}/content");
+        Assert.False(getCorrespondenceOverviewResponse.IsSuccessStatusCode);
     }
 
     [Fact]

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/SyncCorrespondenceForwardingEventTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/SyncCorrespondenceForwardingEventTests.cs
@@ -1,11 +1,9 @@
 using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
-using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Tests.Factories;
 using Altinn.Correspondence.Tests.Fixtures;
 using Altinn.Correspondence.Tests.Helpers;
 using Altinn.Correspondence.Tests.TestingController.Migration.Base;
-using Npgsql.Internal;
 using System.Net;
 using System.Net.Http.Json;
 

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
@@ -566,7 +566,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         }
 
         [Fact]
-        public async Task Available_ArchivedBySelfIdentfiedUser_NoDPUpdate()
+        public async Task Available_ArchivedBySelfIdentifiedUser_NoDPUpdate()
         {
             // Arrange
             var correspondence = new CorrespondenceEntityBuilder()

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
@@ -32,9 +32,11 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         private readonly SyncCorrespondenceStatusEventHandler _handler;
         private readonly PurgeCorrespondenceHelper _purgeHelper;
 
-        private Guid _defaultPartyUuid = Guid.NewGuid();
-        private string _defaultPartyOrgnumber = "123456789";
-        private string _defaultPartyIdentifier = $"{UrnConstants.OrganizationNumberAttribute}:{123456789}";
+        private Guid _defaultUserPartyUuid = Guid.NewGuid();
+        private string _defaultUserPartySSN = "12018012345";
+        private string _defaultUserPartyIdentifier = $"{UrnConstants.PersonIdAttribute}:{12018012345}";
+
+        private Guid _selfIdentifiedUserPartyUuid = Guid.NewGuid();
 
         public SyncCorrespondenceStatusEventHandlerTests()
         {
@@ -87,13 +89,13 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         Status = CorrespondenceStatus.Read,
                         StatusChanged = DateTimeOffset.UtcNow,
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceStatusEntity
                     {
                         Status = CorrespondenceStatus.Confirmed,
                         StatusChanged = DateTimeOffset.UtcNow,
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -121,8 +123,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceStatusRepositoryMock.Verify(
                 x => x.AddCorrespondenceStatuses(It.Is<List<CorrespondenceStatusEntity>>(list =>
                     list.Count == 2 &&
-                    list.Any(e => e.Status == CorrespondenceStatus.Read && e.PartyUuid == _defaultPartyUuid && e.SyncedFromAltinn2 != null) &&
-                    list.Any(e => e.Status == CorrespondenceStatus.Confirmed && e.PartyUuid == _defaultPartyUuid && e.SyncedFromAltinn2 != null)
+                    list.Any(e => e.Status == CorrespondenceStatus.Read && e.PartyUuid == _defaultUserPartyUuid && e.SyncedFromAltinn2 != null) &&
+                    list.Any(e => e.Status == CorrespondenceStatus.Confirmed && e.PartyUuid == _defaultUserPartyUuid && e.SyncedFromAltinn2 != null)
                 ), It.IsAny<CancellationToken>()),
                 Times.Once);
             _correspondenceStatusRepositoryMock.VerifyNoOtherCalls();
@@ -153,19 +155,19 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         Status = CorrespondenceStatus.Published,
                         StatusChanged = DateTimeOffset.UtcNow,
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceStatusEntity
                     {
                         Status = CorrespondenceStatus.Fetched,
                         StatusChanged = DateTimeOffset.UtcNow,
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceStatusEntity
                     {
                         Status = CorrespondenceStatus.Replied,
                         StatusChanged = DateTimeOffset.UtcNow,
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -199,7 +201,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             // Arrange
             var correspondence = new CorrespondenceEntityBuilder()
                 .WithStatus(CorrespondenceStatus.Published)
-                .WithStatus(CorrespondenceStatus.Read, new DateTime(2023, 10, 1, 12, 0, 0), _defaultPartyUuid)
+                .WithStatus(CorrespondenceStatus.Read, new DateTime(2023, 10, 1, 12, 0, 0), _defaultUserPartyUuid)
                 .WithAltinn2CorrespondenceId(12345)
                 .WithIsMigrating(true) // Not available in Altinn 3 APIs
                 .Build();
@@ -214,7 +216,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         Status = CorrespondenceStatus.Read,
                         StatusChanged =  new DateTime(2023, 10, 1, 12, 0, 0),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -247,7 +249,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             // Arrange
             var correspondence = new CorrespondenceEntityBuilder()
                 .WithStatus(CorrespondenceStatus.Published)
-                .WithStatus(CorrespondenceStatus.Read, new DateTime(2023, 10, 1, 11, 0, 0, 0), _defaultPartyUuid)                
+                .WithStatus(CorrespondenceStatus.Read, new DateTime(2023, 10, 1, 11, 0, 0, 0), _defaultUserPartyUuid)                
                 .WithAltinn2CorrespondenceId(12345)
                 .WithIsMigrating(true) // Not available in Altinn 3 APIs
                 .Build();
@@ -262,37 +264,37 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         Status = CorrespondenceStatus.Read,
                         StatusChanged =  new DateTime(2023, 10, 1, 12, 0, 0, 0),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceStatusEntity
                     {
                         Status = CorrespondenceStatus.Read,
                         StatusChanged =  new DateTime(2023, 10, 1, 12, 0, 0, 150),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceStatusEntity
                     {
                         Status = CorrespondenceStatus.Confirmed,
                         StatusChanged =  new DateTime(2023, 10, 1, 12, 5, 0, 0),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceStatusEntity
                     {
                         Status = CorrespondenceStatus.Confirmed,
                         StatusChanged =  new DateTime(2023, 10, 1, 12, 5, 0, 150),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceStatusEntity
                     {
                         Status = CorrespondenceStatus.Archived,
                         StatusChanged =  new DateTime(2023, 10, 1, 12, 6, 0, 150),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceStatusEntity
                     {
                         Status = CorrespondenceStatus.Archived,
                         StatusChanged =  new DateTime(2023, 10, 1, 12, 6, 0, 150),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 },
                 SyncedDeleteEvents = new List<CorrespondenceDeleteEventEntity>
@@ -301,13 +303,13 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.HardDeletedByRecipient,
                         EventOccurred = new DateTime(2023, 10, 1, 12, 7, 0),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceDeleteEventEntity
                     {
                         EventType = CorrespondenceDeleteEventType.HardDeletedByRecipient,
                         EventOccurred = new DateTime(2023, 10, 1, 12, 7, 0, 500),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -322,9 +324,6 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock
                 .Setup(x => x.GetDeleteEventsForCorrespondenceId(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<CorrespondenceDeleteEventEntity>());
-            _altinnRegisterServiceMock
-                .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Core.Models.Entities.Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
 
             // Act
             var result = await _handler.Process(request, null, CancellationToken.None);
@@ -340,9 +339,9 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceStatusRepositoryMock.Verify(
                x => x.AddCorrespondenceStatuses(It.Is<List<CorrespondenceStatusEntity>>(list =>
                    list.Count == 3 &&
-                   list.Any(e => e.Status == CorrespondenceStatus.Read && e.PartyUuid == _defaultPartyUuid && e.SyncedFromAltinn2 != null) &&
-                   list.Any(e => e.Status == CorrespondenceStatus.Confirmed && e.PartyUuid == _defaultPartyUuid && e.SyncedFromAltinn2 != null) &&
-                   list.Any(e => e.Status == CorrespondenceStatus.Archived && e.PartyUuid == _defaultPartyUuid && e.SyncedFromAltinn2 != null)
+                   list.Any(e => e.Status == CorrespondenceStatus.Read && e.PartyUuid == _defaultUserPartyUuid && e.SyncedFromAltinn2 != null) &&
+                   list.Any(e => e.Status == CorrespondenceStatus.Confirmed && e.PartyUuid == _defaultUserPartyUuid && e.SyncedFromAltinn2 != null) &&
+                   list.Any(e => e.Status == CorrespondenceStatus.Archived && e.PartyUuid == _defaultUserPartyUuid && e.SyncedFromAltinn2 != null)
                ), It.IsAny<CancellationToken>()),
                Times.Once);
             _correspondenceStatusRepositoryMock.Verify(x => x.AddCorrespondenceStatus(
@@ -350,7 +349,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     e.CorrespondenceId == correspondenceId &&
                     e.Status == CorrespondenceStatus.PurgedByRecipient &&
                     e.StatusChanged.Equals(new DateTimeOffset(new DateTime(2023, 10, 1, 12, 7, 0))) &&
-                    e.PartyUuid == _defaultPartyUuid &&
+                    e.PartyUuid == _defaultUserPartyUuid &&
                     e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -367,7 +366,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             // Arrange
             var correspondence = new CorrespondenceEntityBuilder()
                 .WithStatus(CorrespondenceStatus.Published)
-                .WithStatus(CorrespondenceStatus.Read, new DateTime(2023, 10, 1, 12, 0, 0), _defaultPartyUuid)
+                .WithStatus(CorrespondenceStatus.Read, new DateTime(2023, 10, 1, 12, 0, 0), _defaultUserPartyUuid)
                 .WithAltinn2CorrespondenceId(12345)
                 .WithIsMigrating(true) // Not available in Altinn 3 APIs
                 .Build();
@@ -382,7 +381,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         Status = CorrespondenceStatus.Read,
                         StatusChanged =  new DateTime(2023, 10, 1, 12, 0, 2),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -411,7 +410,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceStatusRepositoryMock.Verify(
                 x => x.AddCorrespondenceStatuses(It.Is<List<CorrespondenceStatusEntity>>(list =>
                     list.Count == 1 &&
-                    list.Any(e => e.Status == CorrespondenceStatus.Read && e.PartyUuid == _defaultPartyUuid && e.SyncedFromAltinn2 != null)
+                    list.Any(e => e.Status == CorrespondenceStatus.Read && e.PartyUuid == _defaultUserPartyUuid && e.SyncedFromAltinn2 != null)
                 ), It.IsAny<CancellationToken>()),
                 Times.Once);
             _correspondenceStatusRepositoryMock.VerifyNoOtherCalls();
@@ -442,13 +441,13 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         Status = CorrespondenceStatus.Read,
                         StatusChanged = DateTimeOffset.UtcNow,
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceStatusEntity
                     {
                         Status = CorrespondenceStatus.Confirmed,
                         StatusChanged = DateTimeOffset.UtcNow,
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -477,8 +476,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceStatusRepositoryMock.Verify(
                 x => x.AddCorrespondenceStatuses(It.Is<List<CorrespondenceStatusEntity>>(list =>
                     list.Count == 2 &&
-                    list.Any(e => e.Status == CorrespondenceStatus.Read && e.PartyUuid == _defaultPartyUuid && e.SyncedFromAltinn2 != null) &&
-                    list.Any(e => e.Status == CorrespondenceStatus.Confirmed && e.PartyUuid == _defaultPartyUuid && e.SyncedFromAltinn2 != null)
+                    list.Any(e => e.Status == CorrespondenceStatus.Read && e.PartyUuid == _defaultUserPartyUuid && e.SyncedFromAltinn2 != null) &&
+                    list.Any(e => e.Status == CorrespondenceStatus.Confirmed && e.PartyUuid == _defaultUserPartyUuid && e.SyncedFromAltinn2 != null)
                 ), It.IsAny<CancellationToken>()),
                 Times.Once);
             _correspondenceStatusRepositoryMock.VerifyNoOtherCalls();
@@ -517,7 +516,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         Status = CorrespondenceStatus.Archived,
                         StatusChanged = DateTimeOffset.UtcNow,
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -530,8 +529,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.AddCorrespondenceStatuses(It.IsAny<List<CorrespondenceStatusEntity>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((List<CorrespondenceStatusEntity> r, CancellationToken _) => r);           
             _altinnRegisterServiceMock
-                .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Core.Models.Entities.Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
+                .Setup(x => x.LookUpPartyByPartyUuid(_defaultUserPartyUuid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = _defaultUserPartyUuid, SSN = _defaultUserPartySSN, PartyTypeName = PartyType.Person });
 
             // Act
             var result = await _handler.Process(request, null, CancellationToken.None);
@@ -548,22 +547,89 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceStatusRepositoryMock.Verify(
                 x => x.AddCorrespondenceStatuses(It.Is<List<CorrespondenceStatusEntity>>(list =>
                     list.Count == 1 &&
-                    list.Any(e => e.Status == CorrespondenceStatus.Archived && e.PartyUuid == _defaultPartyUuid && e.SyncedFromAltinn2 != null)
+                    list.Any(e => e.Status == CorrespondenceStatus.Archived && e.PartyUuid == _defaultUserPartyUuid && e.SyncedFromAltinn2 != null)
                 ), It.IsAny<CancellationToken>()),
                 Times.Once);
             _correspondenceStatusRepositoryMock.VerifyNoOtherCalls();
             
             // Verify background jobs Dialogporten activities            
-            VerifyDialogportenServiceSetArchivedSystemLabelOnDialogEnqueued(correspondenceId, _defaultPartyIdentifier);
+            VerifyDialogportenServiceSetArchivedSystemLabelOnDialogEnqueued(correspondenceId, _defaultUserPartyIdentifier);
 
             // Verify register lookup performed
-            _altinnRegisterServiceMock.Verify(_altinnRegisterServiceMock => _altinnRegisterServiceMock.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()), Times.Once);
+            _altinnRegisterServiceMock.Verify(_altinnRegisterServiceMock => _altinnRegisterServiceMock.LookUpPartyByPartyUuid(_defaultUserPartyUuid, It.IsAny<CancellationToken>()), Times.Once);
             _altinnRegisterServiceMock.VerifyNoOtherCalls();
 
             // Should not trigger any additional Dialogporten changes or background jobs
             _backgroundJobClientMock.VerifyNoOtherCalls();
             _dialogPortenServiceMock.VerifyNoOtherCalls();
             _correspondenceDeleteEventRepositoryMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task Available_ArchivedBySelfIdentfiedUser_NoDPUpdate()
+        {
+            // Arrange
+            var correspondence = new CorrespondenceEntityBuilder()
+                .WithStatus(CorrespondenceStatus.Published)
+                .WithAltinn2CorrespondenceId(12345)
+                .WithDialogId("dialog-id-123")
+                .Build();
+            var correspondenceId = correspondence.Id;
+            var recipient = correspondence.Recipient;
+            var request = new SyncCorrespondenceStatusEventRequest
+            {
+                CorrespondenceId = correspondenceId,
+                SyncedEvents = new List<CorrespondenceStatusEntity>
+                {
+                    new CorrespondenceStatusEntity
+                    {
+                        Status = CorrespondenceStatus.Archived,
+                        StatusChanged = DateTimeOffset.UtcNow,
+                        PartyUuid = _selfIdentifiedUserPartyUuid
+                    }
+                }
+            };
+
+            // Mock correspondence repository
+            _correspondenceRepositoryMock
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, false, false, It.IsAny<CancellationToken>(), true))
+                .ReturnsAsync(correspondence);
+            _correspondenceStatusRepositoryMock
+                .Setup(x => x.AddCorrespondenceStatuses(It.IsAny<List<CorrespondenceStatusEntity>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<CorrespondenceStatusEntity> r, CancellationToken _) => r);
+            _altinnRegisterServiceMock
+                .Setup(x => x.LookUpPartyByPartyUuid(_selfIdentifiedUserPartyUuid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = _selfIdentifiedUserPartyUuid, PartyTypeName = PartyType.SelfIdentified });
+
+            // Act
+            var result = await _handler.Process(request, null, CancellationToken.None);
+
+            // Assert OK Return
+            Assert.True(result.IsT0);
+            Assert.Equal(correspondenceId, result.AsT0);
+
+            // Verify correct calls to Correspondence repository
+            _correspondenceRepositoryMock.Verify(x => x.GetCorrespondenceById(correspondenceId, true, false, false, It.IsAny<CancellationToken>(), true), Times.Once);
+            _correspondenceRepositoryMock.VerifyNoOtherCalls();
+
+            // Verify that the statuses were added to Repository with SyncedFromAltinn2 set
+            _correspondenceStatusRepositoryMock.Verify(
+                x => x.AddCorrespondenceStatuses(It.Is<List<CorrespondenceStatusEntity>>(list =>
+                    list.Count == 1 &&
+                    list.Any(e => e.Status == CorrespondenceStatus.Archived && e.PartyUuid == _selfIdentifiedUserPartyUuid && e.SyncedFromAltinn2 != null)
+                ), It.IsAny<CancellationToken>()),
+                Times.Once);
+            _correspondenceStatusRepositoryMock.VerifyNoOtherCalls();
+
+            // No DP update should be triggered for SelfIdentified users
+
+            // Verify register lookup performed
+            _altinnRegisterServiceMock.Verify(_altinnRegisterServiceMock => _altinnRegisterServiceMock.LookUpPartyByPartyUuid(_selfIdentifiedUserPartyUuid, It.IsAny<CancellationToken>()), Times.Once);
+            _altinnRegisterServiceMock.VerifyNoOtherCalls();
+
+            // Should not trigger any additional Dialogporten changes or background jobs
+            _backgroundJobClientMock.VerifyNoOtherCalls();
+            _dialogPortenServiceMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -588,7 +654,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.HardDeletedByRecipient,
                         EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -629,7 +695,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     e.CorrespondenceId == correspondenceId &&
                     e.Status == CorrespondenceStatus.PurgedByRecipient &&
                     e.StatusChanged.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0))) &&
-                    e.PartyUuid == _defaultPartyUuid &&
+                    e.PartyUuid == _defaultUserPartyUuid &&
                     e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -638,7 +704,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                It.Is<CorrespondenceDeleteEventEntity>(e =>
                    e.EventType == CorrespondenceDeleteEventType.HardDeletedByRecipient
-                   && e.PartyUuid == _defaultPartyUuid
+                   && e.PartyUuid == _defaultUserPartyUuid
                    && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                    && e.SyncedFromAltinn2 != null),
                It.IsAny<CancellationToken>()), Times.Once);
@@ -677,7 +743,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.SoftDeletedByRecipient,
                         EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -699,8 +765,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<AttachmentEntity>());
             _altinnRegisterServiceMock
-                .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
+                .Setup(x => x.LookUpPartyByPartyUuid(_defaultUserPartyUuid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = _defaultUserPartyUuid, SSN = _defaultUserPartySSN, PartyTypeName = PartyType.Person });
 
             // Act
             var result = await _handler.Process(request, null, CancellationToken.None);
@@ -719,7 +785,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                It.Is<CorrespondenceDeleteEventEntity>(e =>
                    e.EventType == CorrespondenceDeleteEventType.SoftDeletedByRecipient
-                   && e.PartyUuid == _defaultPartyUuid
+                   && e.PartyUuid == _defaultUserPartyUuid
                    && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                    && e.SyncedFromAltinn2 != null),
                It.IsAny<CancellationToken>()), Times.Once);
@@ -727,7 +793,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.VerifyNoOtherCalls();
 
             // Verify background jobs Dialogporten activities
-            VerifySoftDeleteUpdateForDialogportenEnqueued(correspondence.Id, _defaultPartyIdentifier, CorrespondenceDeleteEventType.SoftDeletedByRecipient);
+            VerifySoftDeleteUpdateForDialogportenEnqueued(correspondence.Id, _defaultUserPartyIdentifier, CorrespondenceDeleteEventType.SoftDeletedByRecipient);
 
             // Should not trigger any additional Dialogporten changes or background jobs
             _backgroundJobClientMock.VerifyNoOtherCalls();
@@ -735,12 +801,11 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         }
 
         [Fact]
-        public async Task Available_SoftDeleteByRecipient_ArchivedBeforeSoftDelete_OK()
+        public async Task Available_SoftDeleteBySelfIdentifiedRecipient_NoDPUpdate()
         {
             // Arrange
             var correspondence = new CorrespondenceEntityBuilder()
                 .WithStatus(CorrespondenceStatus.Published)
-                .WithStatus(CorrespondenceStatus.Archived, new DateTime(2025, 7, 1, 12, 0, 0), _defaultPartyUuid)
                 .WithAltinn2CorrespondenceId(12345)
                 .WithDialogId("dialog-id-123")
                 .Build();
@@ -757,7 +822,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.SoftDeletedByRecipient,
                         EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _selfIdentifiedUserPartyUuid
                     }
                 }
             };
@@ -779,8 +844,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<AttachmentEntity>());
             _altinnRegisterServiceMock
-                .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
+                .Setup(x => x.LookUpPartyByPartyUuid(_selfIdentifiedUserPartyUuid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = _selfIdentifiedUserPartyUuid, PartyTypeName = PartyType.SelfIdentified });
 
             // Act
             var result = await _handler.Process(request, null, CancellationToken.None);
@@ -799,7 +864,86 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                It.Is<CorrespondenceDeleteEventEntity>(e =>
                    e.EventType == CorrespondenceDeleteEventType.SoftDeletedByRecipient
-                   && e.PartyUuid == _defaultPartyUuid
+                   && e.PartyUuid == _selfIdentifiedUserPartyUuid
+                   && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
+                   && e.SyncedFromAltinn2 != null),
+               It.IsAny<CancellationToken>()), Times.Once);
+            _correspondenceDeleteEventRepositoryMock.Verify(x => x.GetDeleteEventsForCorrespondenceId(correspondenceId, It.IsAny<CancellationToken>()), Times.Once);
+            _correspondenceDeleteEventRepositoryMock.VerifyNoOtherCalls();
+
+            // No soft delete enqueued in Dialogporten for self-identified users
+
+            // Should not trigger any additional Dialogporten changes or background jobs
+            _backgroundJobClientMock.VerifyNoOtherCalls();
+            _dialogPortenServiceMock.VerifyNoOtherCalls(); 
+        }
+
+        [Fact]
+        public async Task Available_SoftDeleteByRecipient_ArchivedBeforeSoftDelete_OK()
+        {
+            // Arrange
+            var correspondence = new CorrespondenceEntityBuilder()
+                .WithStatus(CorrespondenceStatus.Published)
+                .WithStatus(CorrespondenceStatus.Archived, new DateTime(2025, 7, 1, 12, 0, 0), _defaultUserPartyUuid)
+                .WithAltinn2CorrespondenceId(12345)
+                .WithDialogId("dialog-id-123")
+                .Build();
+            var correspondenceId = correspondence.Id;
+            var recipient = correspondence.Recipient;
+            var sender = correspondence.Sender;
+            var request = new SyncCorrespondenceStatusEventRequest
+            {
+                CorrespondenceId = correspondenceId,
+                SyncedEvents = null,
+                SyncedDeleteEvents = new List<CorrespondenceDeleteEventEntity>
+                {
+                    new CorrespondenceDeleteEventEntity
+                    {
+                        EventType = CorrespondenceDeleteEventType.SoftDeletedByRecipient,
+                        EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
+                        PartyUuid = _defaultUserPartyUuid
+                    }
+                }
+            };
+
+            // Mock correspondence repository
+            _correspondenceRepositoryMock
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, false, false, It.IsAny<CancellationToken>(), true))
+                .ReturnsAsync(correspondence);
+            _correspondenceStatusRepositoryMock
+                .Setup(x => x.AddCorrespondenceStatuses(It.IsAny<List<CorrespondenceStatusEntity>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<CorrespondenceStatusEntity> r, CancellationToken _) => r);
+            _correspondenceDeleteEventRepositoryMock
+                .Setup(x => x.GetDeleteEventsForCorrespondenceId(correspondenceId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<CorrespondenceDeleteEventEntity>());
+            _correspondenceDeleteEventRepositoryMock
+               .Setup(x => x.AddDeleteEvent(It.IsAny<CorrespondenceDeleteEventEntity>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync((CorrespondenceDeleteEventEntity r, CancellationToken _) => r);
+            _attachmentRepositoryMock
+                .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<AttachmentEntity>());
+            _altinnRegisterServiceMock
+                 .Setup(x => x.LookUpPartyByPartyUuid(_defaultUserPartyUuid, It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(new Party { PartyUuid = _defaultUserPartyUuid, SSN = _defaultUserPartySSN, PartyTypeName = PartyType.Person });
+
+            // Act
+            var result = await _handler.Process(request, null, CancellationToken.None);
+
+            // Assert OK Return
+            Assert.True(result.IsT0);
+            Assert.Equal(correspondenceId, result.AsT0);
+
+            // Verify correct calls to Correspondence repository
+            _correspondenceRepositoryMock.Verify(x => x.GetCorrespondenceById(correspondenceId, true, false, false, It.IsAny<CancellationToken>(), true), Times.Once);
+            _correspondenceRepositoryMock.VerifyNoOtherCalls();
+
+            // Verify that no statuses were added to Repository with SyncedFromAltinn2 set
+            _correspondenceStatusRepositoryMock.VerifyNoOtherCalls();
+
+            _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
+               It.Is<CorrespondenceDeleteEventEntity>(e =>
+                   e.EventType == CorrespondenceDeleteEventType.SoftDeletedByRecipient
+                   && e.PartyUuid == _defaultUserPartyUuid
                    && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                    && e.SyncedFromAltinn2 != null),
                It.IsAny<CancellationToken>()), Times.Once);
@@ -807,7 +951,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.VerifyNoOtherCalls();
 
             // Verify background jobs Dialogporten activities
-            VerifySoftDeleteUpdateForDialogportenEnqueued(correspondence.Id, _defaultPartyIdentifier, CorrespondenceDeleteEventType.SoftDeletedByRecipient);
+            VerifySoftDeleteUpdateForDialogportenEnqueued(correspondence.Id, _defaultUserPartyIdentifier, CorrespondenceDeleteEventType.SoftDeletedByRecipient);
 
             // Should not trigger any additional Dialogporten changes or background jobs
             _backgroundJobClientMock.VerifyNoOtherCalls();
@@ -820,7 +964,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             // Arrange
             var correspondence = new CorrespondenceEntityBuilder()
                 .WithStatus(CorrespondenceStatus.Published)
-                .WithStatus(CorrespondenceStatus.Archived, new DateTime(2025, 7, 1, 12, 0, 0), _defaultPartyUuid)
+                .WithStatus(CorrespondenceStatus.Archived, new DateTime(2025, 7, 1, 12, 0, 0), _defaultUserPartyUuid)
                 .WithAltinn2CorrespondenceId(12345)
                 .WithDialogId("dialog-id-123")
                 .Build();
@@ -837,7 +981,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.RestoredByRecipient,
                         EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -857,7 +1001,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.SoftDeletedByRecipient,
                         EventOccurred = new  DateTimeOffset(new DateTime(2025, 7, 15, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 });
             _correspondenceDeleteEventRepositoryMock
@@ -867,8 +1011,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<AttachmentEntity>());
             _altinnRegisterServiceMock
-                .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
+                 .Setup(x => x.LookUpPartyByPartyUuid(_defaultUserPartyUuid, It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(new Party { PartyUuid = _defaultUserPartyUuid, SSN = _defaultUserPartySSN, PartyTypeName = PartyType.Person });
 
             // Act
             var result = await _handler.Process(request, null, CancellationToken.None);
@@ -887,7 +1031,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
               It.Is<CorrespondenceDeleteEventEntity>(e =>
                   e.EventType == CorrespondenceDeleteEventType.RestoredByRecipient
-                  && e.PartyUuid == _defaultPartyUuid
+                  && e.PartyUuid == _defaultUserPartyUuid
                   && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                   && e.SyncedFromAltinn2 != null),
               It.IsAny<CancellationToken>()), Times.Once);
@@ -895,7 +1039,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.VerifyNoOtherCalls();
 
             // Verify background jobs Dialogporten activities            
-            VerifyDialogportenServiceSetArchivedSystemLabelOnDialogEnqueued(correspondenceId, _defaultPartyIdentifier);
+            VerifyDialogportenServiceSetArchivedSystemLabelOnDialogEnqueued(correspondenceId, _defaultUserPartyIdentifier);
 
             // Should not trigger any additional Dialogporten changes or background jobs
             _backgroundJobClientMock.VerifyNoOtherCalls();
@@ -924,13 +1068,13 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.SoftDeletedByRecipient,
                         EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceDeleteEventEntity
                     {
                         EventType = CorrespondenceDeleteEventType.HardDeletedByRecipient,
                         EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 15, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -952,8 +1096,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<AttachmentEntity>());
             _altinnRegisterServiceMock
-                .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
+                .Setup(x => x.LookUpPartyByPartyUuid(_defaultUserPartyUuid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = _defaultUserPartyUuid, SSN = _defaultUserPartySSN, PartyTypeName = PartyType.Person });
             _backgroundJobClientMock
                 .Setup(x => x.Create(It.Is<Job>(j => j.Method.Name == nameof(IDialogportenService.CreateCorrespondencePurgedActivity)), It.IsAny<EnqueuedState>())).Returns("1");
 
@@ -974,7 +1118,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     e.CorrespondenceId == correspondenceId &&
                     e.Status == CorrespondenceStatus.PurgedByRecipient &&
                     e.StatusChanged.Equals(new DateTimeOffset(new DateTime(2025, 8, 15, 12, 0, 0))) &&
-                    e.PartyUuid == _defaultPartyUuid &&
+                    e.PartyUuid == _defaultUserPartyUuid &&
                     e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -983,14 +1127,14 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                It.Is<CorrespondenceDeleteEventEntity>(e =>
                    e.EventType == CorrespondenceDeleteEventType.SoftDeletedByRecipient
-                   && e.PartyUuid == _defaultPartyUuid
+                   && e.PartyUuid == _defaultUserPartyUuid
                    && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                    && e.SyncedFromAltinn2 != null),
                It.IsAny<CancellationToken>()), Times.Once);
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                It.Is<CorrespondenceDeleteEventEntity>(e =>
                    e.EventType == CorrespondenceDeleteEventType.HardDeletedByRecipient
-                   && e.PartyUuid == _defaultPartyUuid
+                   && e.PartyUuid == _defaultUserPartyUuid
                    && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 15, 12, 0, 0)))
                    && e.SyncedFromAltinn2 != null),
                It.IsAny<CancellationToken>()), Times.Once);
@@ -1000,7 +1144,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             VerifyAltinnEventEnqueued(correspondenceId, AltinnEventType.CorrespondencePurged, sender);
 
             // Verify background jobs Dialogporten activities            
-            VerifySoftDeleteUpdateForDialogportenEnqueued(correspondence.Id, _defaultPartyIdentifier, CorrespondenceDeleteEventType.SoftDeletedByRecipient);
+            VerifySoftDeleteUpdateForDialogportenEnqueued(correspondence.Id, _defaultUserPartyIdentifier, CorrespondenceDeleteEventType.SoftDeletedByRecipient);
             VerifyDialogportenServiceCreatePurgedActivityEnqueued(correspondenceId, DialogportenActorType.Recipient, "mottaker", new DateTimeOffset(new DateTime(2025, 8, 15, 12, 0, 0)));
             VerifyDialogportenServiceSoftDeleteDialogEnqueued("dialog-id-123");
 
@@ -1032,7 +1176,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.RestoredByRecipient,
                         EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -1054,8 +1198,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<AttachmentEntity>());
             _altinnRegisterServiceMock
-                .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
+                .Setup(x => x.LookUpPartyByPartyUuid(_defaultUserPartyUuid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = _defaultUserPartyUuid, SSN = _defaultUserPartySSN, PartyTypeName = PartyType.Person });
 
             // Act
             var result = await _handler.Process(request, null, CancellationToken.None);
@@ -1074,7 +1218,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                It.Is<CorrespondenceDeleteEventEntity>(e =>
                    e.EventType == CorrespondenceDeleteEventType.RestoredByRecipient
-                   && e.PartyUuid == _defaultPartyUuid
+                   && e.PartyUuid == _defaultUserPartyUuid
                    && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                    && e.SyncedFromAltinn2 != null),
                It.IsAny<CancellationToken>()), Times.Once);
@@ -1082,7 +1226,85 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.VerifyNoOtherCalls();
 
             // Verify background jobs Dialogporten activities
-            VerifySoftDeleteUpdateForDialogportenEnqueued(correspondence.Id, _defaultPartyIdentifier, CorrespondenceDeleteEventType.RestoredByRecipient);
+            VerifySoftDeleteUpdateForDialogportenEnqueued(correspondence.Id, _defaultUserPartyIdentifier, CorrespondenceDeleteEventType.RestoredByRecipient);
+
+            // Should not trigger any additional Dialogporten changes or background jobs
+            _backgroundJobClientMock.VerifyNoOtherCalls();
+            _dialogPortenServiceMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task Available_RestoreBySelfIdentifiedRecipient_NoDPUpdate()
+        {
+            // Arrange
+            var correspondence = new CorrespondenceEntityBuilder()
+                .WithStatus(CorrespondenceStatus.Published)
+                .WithAltinn2CorrespondenceId(12345)
+                .WithDialogId("dialog-id-123")
+                .Build();
+            var correspondenceId = correspondence.Id;
+            var recipient = correspondence.Recipient;
+            var sender = correspondence.Sender;
+            var request = new SyncCorrespondenceStatusEventRequest
+            {
+                CorrespondenceId = correspondenceId,
+                SyncedEvents = null,
+                SyncedDeleteEvents = new List<CorrespondenceDeleteEventEntity>
+                {
+                    new CorrespondenceDeleteEventEntity
+                    {
+                        EventType = CorrespondenceDeleteEventType.RestoredByRecipient,
+                        EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
+                        PartyUuid = _selfIdentifiedUserPartyUuid
+                    }
+                }
+            };
+
+            // Mock correspondence repository
+            _correspondenceRepositoryMock
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, false, false, It.IsAny<CancellationToken>(), true))
+                .ReturnsAsync(correspondence);
+            _correspondenceStatusRepositoryMock
+                .Setup(x => x.AddCorrespondenceStatuses(It.IsAny<List<CorrespondenceStatusEntity>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<CorrespondenceStatusEntity> r, CancellationToken _) => r);
+            _correspondenceDeleteEventRepositoryMock
+                .Setup(x => x.GetDeleteEventsForCorrespondenceId(correspondenceId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<CorrespondenceDeleteEventEntity>());
+            _correspondenceDeleteEventRepositoryMock
+               .Setup(x => x.AddDeleteEvent(It.IsAny<CorrespondenceDeleteEventEntity>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync((CorrespondenceDeleteEventEntity r, CancellationToken _) => r);
+            _attachmentRepositoryMock
+                .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<AttachmentEntity>());
+            _altinnRegisterServiceMock
+                .Setup(x => x.LookUpPartyByPartyUuid(_selfIdentifiedUserPartyUuid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = _selfIdentifiedUserPartyUuid,PartyTypeName = PartyType.SelfIdentified });
+
+            // Act
+            var result = await _handler.Process(request, null, CancellationToken.None);
+
+            // Assert OK Return
+            Assert.True(result.IsT0);
+            Assert.Equal(correspondenceId, result.AsT0);
+
+            // Verify correct calls to Correspondence repository
+            _correspondenceRepositoryMock.Verify(x => x.GetCorrespondenceById(correspondenceId, true, false, false, It.IsAny<CancellationToken>(), true), Times.Once);
+            _correspondenceRepositoryMock.VerifyNoOtherCalls();
+
+            // Verify that no statuses were added to Repository with SyncedFromAltinn2 set
+            _correspondenceStatusRepositoryMock.VerifyNoOtherCalls();
+
+            _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
+               It.Is<CorrespondenceDeleteEventEntity>(e =>
+                   e.EventType == CorrespondenceDeleteEventType.RestoredByRecipient
+                   && e.PartyUuid == _selfIdentifiedUserPartyUuid
+                   && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
+                   && e.SyncedFromAltinn2 != null),
+               It.IsAny<CancellationToken>()), Times.Once);
+            _correspondenceDeleteEventRepositoryMock.Verify(x => x.GetDeleteEventsForCorrespondenceId(correspondenceId, It.IsAny<CancellationToken>()), Times.Once);
+            _correspondenceDeleteEventRepositoryMock.VerifyNoOtherCalls();
+
+            // No restore in Dialogporten enqueued for self-identified users
 
             // Should not trigger any additional Dialogporten changes or background jobs
             _backgroundJobClientMock.VerifyNoOtherCalls();
@@ -1095,7 +1317,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             // Arrange
             var correspondence = new CorrespondenceEntityBuilder()
                 .WithCreated(new DateTime(2025, 8, 1, 12, 0, 0))
-                .WithStatus(CorrespondenceStatus.Published, new DateTime(2025, 8, 1, 12, 0, 0), _defaultPartyUuid)
+                .WithStatus(CorrespondenceStatus.Published, new DateTime(2025, 8, 1, 12, 0, 0), _defaultUserPartyUuid)
                 .WithDialogId("dialog-id-123")
                 .WithAltinn2CorrespondenceId(12345)
                 .WithAttachment("fjas.txt")
@@ -1113,7 +1335,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.HardDeletedByServiceOwner,
                         EventOccurred = new  DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -1178,7 +1400,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     e.CorrespondenceId == correspondenceId &&
                     e.Status == CorrespondenceStatus.PurgedByAltinn &&
                     e.StatusChanged.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0))) &&
-                    e.PartyUuid == _defaultPartyUuid &&
+                    e.PartyUuid == _defaultUserPartyUuid &&
                     e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -1187,7 +1409,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                 It.Is<CorrespondenceDeleteEventEntity>(e =>
                     e.EventType == CorrespondenceDeleteEventType.HardDeletedByServiceOwner 
-                    && e.PartyUuid == _defaultPartyUuid 
+                    && e.PartyUuid == _defaultUserPartyUuid
                     && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                     && e.SyncedFromAltinn2 != null),                
                 It.IsAny<CancellationToken>()), Times.Once);
@@ -1228,7 +1450,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.HardDeletedByRecipient,
                         EventOccurred = new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -1267,7 +1489,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     e.CorrespondenceId == correspondenceId &&
                     e.Status == CorrespondenceStatus.PurgedByRecipient &&
                     e.StatusChanged.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0))) &&
-                    e.PartyUuid == _defaultPartyUuid &&
+                    e.PartyUuid == _defaultUserPartyUuid &&
                     e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -1276,7 +1498,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                It.Is<CorrespondenceDeleteEventEntity>(e =>
                    e.EventType == CorrespondenceDeleteEventType.HardDeletedByRecipient
-                   && e.PartyUuid == _defaultPartyUuid
+                   && e.PartyUuid == _defaultUserPartyUuid
                    && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                    && e.SyncedFromAltinn2 != null),
                It.IsAny<CancellationToken>()), Times.Once);
@@ -1294,7 +1516,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             // Arrange
             var correspondence = new CorrespondenceEntityBuilder()
                 .WithStatus(CorrespondenceStatus.Published)
-                .WithStatus(CorrespondenceStatus.PurgedByRecipient, new DateTime(2025, 8, 1, 12, 0, 0), _defaultPartyUuid)
+                .WithStatus(CorrespondenceStatus.PurgedByRecipient, new DateTime(2025, 8, 1, 12, 0, 0), _defaultUserPartyUuid)
                 .WithAltinn2CorrespondenceId(12345)
                 .WithIsMigrating(true) // Not Available in Altinn 3                
                 .Build();
@@ -1310,7 +1532,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         Status = CorrespondenceStatus.PurgedByRecipient,
                         StatusChanged = new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -1364,7 +1586,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.SoftDeletedByRecipient,
                         EventOccurred = new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -1385,9 +1607,6 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _attachmentRepositoryMock
                 .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<AttachmentEntity>());
-            _altinnRegisterServiceMock
-               .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-               .ReturnsAsync(new Core.Models.Entities.Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
 
             // Act
             var result = await _handler.Process(request, null, CancellationToken.None);
@@ -1406,7 +1625,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                 It.Is<CorrespondenceDeleteEventEntity>(e =>
                     e.EventType == CorrespondenceDeleteEventType.SoftDeletedByRecipient
-                    && e.PartyUuid == _defaultPartyUuid
+                    && e.PartyUuid == _defaultUserPartyUuid
                     && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                     && e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()), Times.Once);
@@ -1440,13 +1659,13 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.HardDeletedByRecipient,
                         EventOccurred = new DateTimeOffset(new DateTime(2025, 8, 15, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     },
                     new CorrespondenceDeleteEventEntity
                     {
                         EventType = CorrespondenceDeleteEventType.SoftDeletedByRecipient,
                         EventOccurred = new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -1467,9 +1686,6 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _attachmentRepositoryMock
                 .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<AttachmentEntity>());
-            _altinnRegisterServiceMock
-               .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-               .ReturnsAsync(new Core.Models.Entities.Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
 
             // Act
             var result = await _handler.Process(request, null, CancellationToken.None);
@@ -1488,7 +1704,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     e.CorrespondenceId == correspondenceId &&
                     e.Status == CorrespondenceStatus.PurgedByRecipient &&
                     e.StatusChanged.Equals(new DateTimeOffset(new DateTime(2025, 8, 15, 12, 0, 0))) &&
-                    e.PartyUuid == _defaultPartyUuid &&
+                    e.PartyUuid == _defaultUserPartyUuid &&
                     e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -1497,14 +1713,14 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                 It.Is<CorrespondenceDeleteEventEntity>(e =>
                     e.EventType == CorrespondenceDeleteEventType.SoftDeletedByRecipient
-                    && e.PartyUuid == _defaultPartyUuid
+                    && e.PartyUuid == _defaultUserPartyUuid
                     && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                     && e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()), Times.Once);
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                 It.Is<CorrespondenceDeleteEventEntity>(e =>
                     e.EventType == CorrespondenceDeleteEventType.HardDeletedByRecipient
-                    && e.PartyUuid == _defaultPartyUuid
+                    && e.PartyUuid == _defaultUserPartyUuid
                     && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 15, 12, 0, 0)))
                     && e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()), Times.Once);
@@ -1538,7 +1754,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     {
                         EventType = CorrespondenceDeleteEventType.RestoredByRecipient,
                         EventOccurred = new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)),
-                        PartyUuid = _defaultPartyUuid
+                        PartyUuid = _defaultUserPartyUuid
                     }
                 }
             };
@@ -1560,8 +1776,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.GetAttachmentsByCorrespondence(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<AttachmentEntity>());
             _altinnRegisterServiceMock
-               .Setup(x => x.LookUpPartyByPartyUuid(_defaultPartyUuid, It.IsAny<CancellationToken>()))
-               .ReturnsAsync(new Core.Models.Entities.Party { PartyUuid = _defaultPartyUuid, OrgNumber = _defaultPartyOrgnumber, PartyTypeName = PartyType.Organization });
+                .Setup(x => x.LookUpPartyByPartyUuid(_defaultUserPartyUuid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = _defaultUserPartyUuid, SSN = _defaultUserPartySSN, PartyTypeName = PartyType.Person });
 
             // Act
             var result = await _handler.Process(request, null, CancellationToken.None);
@@ -1580,7 +1796,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceDeleteEventRepositoryMock.Verify(x => x.AddDeleteEvent(
                 It.Is<CorrespondenceDeleteEventEntity>(e =>
                     e.EventType == CorrespondenceDeleteEventType.RestoredByRecipient
-                    && e.PartyUuid == _defaultPartyUuid
+                    && e.PartyUuid == _defaultUserPartyUuid
                     && e.EventOccurred.Equals(new DateTimeOffset(new DateTime(2025, 8, 1, 12, 0, 0)))
                     && e.SyncedFromAltinn2 != null),
                 It.IsAny<CancellationToken>()), Times.Once);            

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
@@ -183,6 +184,11 @@ public class MigrateCorrespondenceHandler(
         if(correspondence.HasBeenPurged())
         {
             throw new InvalidOperationException($"Correspondence with id {correspondenceId} is purged and cannot be made available in Dialogporten or API");
+        }
+        
+        if(correspondence.Recipient.IsWithPartyUuidPrefix())
+        {
+            throw new InvalidOperationException($"Correspondence with id {correspondenceId} has an Self-Identifed User as recipient and cannot be made available in Dialogporten");
         }
 
         // If the correspondence was soft deleted in Altinn 2, we need to pass this forward in order to set the system label correctly on the Dialog

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -186,9 +186,9 @@ public class MigrateCorrespondenceHandler(
             throw new InvalidOperationException($"Correspondence with id {correspondenceId} is purged and cannot be made available in Dialogporten or API");
         }
         
-        if(correspondence.Recipient.IsWithPartyUuidPrefix())
+        if(!string.IsNullOrEmpty(correspondence.Recipient) && correspondence.Recipient.IsWithPartyUuidPrefix())
         {
-            throw new InvalidOperationException($"Correspondence with id {correspondenceId} has an Self-Identifed User as recipient and cannot be made available in Dialogporten");
+            throw new InvalidOperationException($"Correspondence with id {correspondenceId} has a Self-Identifed user as recipient and cannot be made available in Dialogporten");
         }
 
         // If the correspondence was soft deleted in Altinn 2, we need to pass this forward in order to set the system label correctly on the Dialog

--- a/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceStatusEventHandler.cs
+++ b/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceStatusEventHandler.cs
@@ -395,10 +395,9 @@ public class SyncCorrespondenceStatusEventHandler(
             }
             else
             {
-                bool isArchived = correspondence.StatusHasBeen(CorrespondenceStatus.Archived);
-
                 // Perform SoftDelete or Restore in Dialogporten
-                await SetSoftDeleteOrRestoreOnDialog(correspondence.Id, enduserIdByPartyUuid[deleteEventToSync.PartyUuid], deleteEventToSync.EventType, correspondence.StatusHasBeen(CorrespondenceStatus.Archived), cancellationToken);
+                bool isArchived = correspondence.StatusHasBeen(CorrespondenceStatus.Archived);
+                await SetSoftDeleteOrRestoreOnDialog(correspondence.Id, enduserIdByPartyUuid[deleteEventToSync.PartyUuid], deleteEventToSync.EventType, isArchived, cancellationToken);
             }
         }
     }

--- a/src/Altinn.Correspondence.Common/Constants/UrnConstants.cs
+++ b/src/Altinn.Correspondence.Common/Constants/UrnConstants.cs
@@ -14,9 +14,13 @@ public static class UrnConstants
     /// </summary>
     public const string OrganizationNumberAttribute = "urn:altinn:organization:identifier-no";
     /// <summary>
-    /// xacml string that represents party
+    /// xacml string that represents partyId
     /// </summary>
     public const string Party = "urn:altinn:partyid";
+    /// <summary>
+    /// xacml string that represents partyUuid
+    /// </summary>
+    public const string PartyUuid = "urn:altinn:party:uuid";
     /// <summary>
     /// xacml string that represents person identifier
     /// </summary>

--- a/src/Altinn.Correspondence.Common/Helpers/StringExtensions.cs
+++ b/src/Altinn.Correspondence.Common/Helpers/StringExtensions.cs
@@ -115,6 +115,11 @@ public static class StringExtensions
         return identifier.StartsWith("0192:");
     }
 
+    public static bool IsWithPartyUuidPrefix(this string identifier)
+    {
+        return identifier.StartsWith(UrnConstants.PartyUuid);
+    }
+
     /// <summary>
     /// Adds a prefix to the identifier if it is a organization number (9 digits) or social security number (11 digits).
     /// </summary>

--- a/src/Altinn.Correspondence.Common/Helpers/StringExtensions.cs
+++ b/src/Altinn.Correspondence.Common/Helpers/StringExtensions.cs
@@ -117,7 +117,7 @@ public static class StringExtensions
 
     public static bool IsWithPartyUuidPrefix(this string identifier)
     {
-        return identifier.StartsWith(UrnConstants.PartyUuid);
+        return identifier.StartsWith($"{UrnConstants.PartyUuid}:", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -1,3 +1,4 @@
+using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 
@@ -96,6 +97,12 @@ namespace Altinn.Correspondence.Persistence.Helpers
                     !cs.Statuses.Any(s =>
                         s.Status == CorrespondenceStatus.PurgedByAltinn ||
                         s.Status == CorrespondenceStatus.PurgedByRecipient));
+        }
+
+        public static IQueryable<CorrespondenceEntity> ExcludeSelfIdentifiedRecipients(this IQueryable<CorrespondenceEntity> query)
+        {
+            return query.Where(cs =>
+                    !cs.Recipient.IsWithPartyUuidPrefix());
         }
 
         public static IQueryable<CorrespondenceEntity> WhereCurrentStatusIn(

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -1,4 +1,4 @@
-using Altinn.Correspondence.Common.Helpers;
+using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 
@@ -101,8 +101,8 @@ namespace Altinn.Correspondence.Persistence.Helpers
 
         public static IQueryable<CorrespondenceEntity> ExcludeSelfIdentifiedRecipients(this IQueryable<CorrespondenceEntity> query)
         {
-            return query.Where(cs =>
-                    !cs.Recipient.IsWithPartyUuidPrefix());
+            var prefix = UrnConstants.PartyUuid + ":";
+            return query.Where(cs => cs.Recipient == null || !cs.Recipient.StartsWith(prefix));
         }
 
         public static IQueryable<CorrespondenceEntity> WhereCurrentStatusIn(

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -191,6 +191,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
             return _context.Correspondences
                 .Where(c => c.Altinn2CorrespondenceId != null && c.IsMigrating) // Only include correspondences that are not already migrated 
                 .ExcludePurged() // Exclude purged correspondences
+                .ExcludeSelfIdentifiedRecipients() // Exclude correspondences belonging to self identified users
                 .OrderByDescending(c => c.Created)
                 .ThenBy(c => c.Id)
                 .Skip(offset)


### PR DESCRIPTION
Since Dialogporten so far does not support Self-Identified users, I have added logic that prevents Migrated Correspondences and sync events that belong to Self-Identified users from being updated in Dialogporten.

## Description
MakeAvailable will now reject any Migrated Correspondences that have a Recipient on format of `urn:altinn:party:uuid:<partyuuid>` - which is only used (for now) for Self Identified users.

Added handling of cases where Self Identified users have performed staus changes that cannot be synced to Dialogporten since it requires explicitly "EndUserId" on the "urn:altinn:person:identifier-no"
- Archive
- Soft Delete
- Restore.

## Related Issue(s)
- #1369 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented making correspondences available when the recipient is a self-identified user, avoiding unintended exposure.
  * Excluded self-identified recipients from migration candidates to ensure only eligible correspondences are migrated.
  * Improved status sync to avoid external updates for self-identified users and handle missing identifiers gracefully.
* **Tests**
  * Added extensive tests covering self-identified recipient flows for availability, migration, and status synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->