### PR TITLE
fix incorrect contentReference for messageBody

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogTransmissionMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogTransmissionMapper.cs
@@ -66,8 +66,8 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 {
                     new TransmissionValue
                     {
-                        Value = $"{baseUrl}/correspondence/{correspondence.Id}",
-                        LanguageCode = "nb"
+                        Value = $"{baseUrl.TrimEnd('/')}/correspondence/api/v1/correspondence/{correspondence.Id}/content",
+                        LanguageCode = correspondence.Content.Language
                     }
             }
             }


### PR DESCRIPTION
## Description
Fixed the contentReference for messageBody in a transmission.

## Related Issue(s)
- #1381 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected content links in dialog transmissions to point to the proper content endpoint.
  * Ensured the language in content references matches the correspondence’s language instead of defaulting to Norwegian Bokmål.
  * Improved URL handling to normalize trailing slashes, preventing broken or duplicate-slash links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->