### PR TITLE
Job to strip messageSummary for markdown and html

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CleanupMarkdownAndHTMLInSummaryHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CleanupMarkdownAndHTMLInSummaryHandlerTests.cs
@@ -1,0 +1,67 @@
+using Altinn.Correspondence.Application.CleanupMarkdownAndHTMLInSummary;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Altinn.Correspondence.Common.Helpers;
+using Xunit;
+using Altinn.Correspondence.Tests.Factories;
+
+namespace Altinn.Correspondence.Tests.TestingHandler;
+
+public class CleanupMarkdownAndHTMLInSummaryHandlerTests
+{
+    [Fact]
+    public async Task ExecuteCleanupInBackground_CleansMarkdownAndHtmlAndCountsAlreadyOk()
+    {
+        // Arrange
+        var now = DateTimeOffset.UtcNow;
+        var c1 = new CorrespondenceEntityBuilder()
+            .WithCreated(now.UtcDateTime.AddMinutes(-2))
+            .WithMessageSummary("Some **markdown**")
+            .WithExternalReference(ReferenceType.DialogportenDialogId, "d1")
+            .Build();
+        var c2 = new CorrespondenceEntityBuilder()
+            .WithCreated(now.UtcDateTime.AddMinutes(-1))
+            .WithMessageSummary("Already clean")
+            .WithExternalReference(ReferenceType.DialogportenDialogId, "d2")
+            .Build();
+
+        var repo = new Mock<ICorrespondenceRepository>();
+        repo.SetupSequence(r => r.GetCorrespondencesWindowAfter(
+            It.IsAny<int>(),
+            It.IsAny<DateTimeOffset?>(),
+            It.IsAny<Guid?>(),
+            true,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CorrespondenceEntity> { c1, c2 })
+            .ReturnsAsync(new List<CorrespondenceEntity>());
+        repo.Setup(r => r.GetCorrespondencesByNoAltinn2IdAndExistingDialog(
+                It.IsAny<List<Guid>>(),
+                It.IsAny<ReferenceType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<Guid> ids, ReferenceType _, CancellationToken __) =>
+                new List<CorrespondenceEntity> { c1, c2 }.Where(x => ids.Contains(x.Id)).ToList());
+
+        var dialog = new Mock<IDialogportenService>();
+        var cleanedC1Summary = TextValidation.StripSummaryForHtmlAndMarkdown(c1.Content.MessageSummary);
+
+        dialog.Setup(s => s.TryRemoveMarkdownAndHtmlFromSummary("d1", cleanedC1Summary, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        dialog.Setup(s => s.TryRemoveMarkdownAndHtmlFromSummary("d2", "Already clean", It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var bg = new Mock<IBackgroundJobClient>();
+        var logger = new Mock<ILogger<CleanupMarkdownAndHTMLInSummaryHandler>>();
+
+        var handler = new CleanupMarkdownAndHTMLInSummaryHandler(repo.Object, dialog.Object, bg.Object, logger.Object);
+
+        // Act
+        await handler.ExecuteCleanupInBackground(100, CancellationToken.None);
+
+        // Assert
+        dialog.Verify(s => s.TryRemoveMarkdownAndHtmlFromSummary("d1", "Some markdown", It.IsAny<CancellationToken>()), Times.Once);
+        dialog.Verify(s => s.TryRemoveMarkdownAndHtmlFromSummary("d2", "Already clean", It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
@@ -1,6 +1,7 @@
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.CleanupOrphanedDialogs;
 using Altinn.Correspondence.Application.CleanupPerishingDialogs;
+using Altinn.Correspondence.Application.CleanupMarkdownAndHTMLInSummary;
 using Altinn.Correspondence.Common.Constants;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -23,7 +24,7 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
     /// <response code="401">Unauthorized</response>
     /// <response code="403">Forbidden</response>
     [HttpPost]
-    [Route("cleanup-orphaned-dialogs")] 
+    [Route("cleanup-orphaned-dialogs")]
     [Authorize(Policy = AuthorizationConstants.Maintenance)]
     [Produces("application/json")]
     [ProducesResponseType(typeof(CleanupOrphanedDialogsResponse), StatusCodes.Status200OK)]
@@ -49,7 +50,7 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
     /// <response code="401">Unauthorized</response>
     /// <response code="403">Forbidden</response>
     [HttpPost]
-    [Route("cleanup-perishing-dialogs")] 
+    [Route("cleanup-perishing-dialogs")]
     [Authorize(Policy = AuthorizationConstants.Maintenance)]
     [Produces("application/json")]
     [ProducesResponseType(typeof(CleanupPerishingDialogsResponse), StatusCodes.Status200OK)]
@@ -75,7 +76,7 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
     /// <response code="401">Unauthorized</response>
     /// <response code="403">Forbidden</response>
     [HttpPost]
-    [Route("restore-soft-deleted-dialogs")] 
+    [Route("restore-soft-deleted-dialogs")]
     [Authorize(Policy = AuthorizationConstants.Maintenance)]
     [Produces("application/json")]
     [ProducesResponseType(typeof(RestoreSoftDeletedDialogsResponse), StatusCodes.Status200OK)]
@@ -94,10 +95,30 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
         );
     }
 
+
+    [HttpPost]
+    [Route("cleanup-markdown-and-html-in-summary")]
+    [Authorize(Policy = AuthorizationConstants.Maintenance)]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(CleanupMarkdownAndHTMLInSummaryResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult> CleanupMarkdownAndHtmlInSummary(
+        [FromServices] CleanupMarkdownAndHTMLInSummaryHandler handler,
+        [FromBody] CleanupMarkdownAndHTMLInSummaryRequest request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Request to cleanup markdown and html in summary received");
+        var result = await handler.Process(request, HttpContext.User, cancellationToken);
+        return result.Match(
+            Ok,
+            Problem
+        );
+    }
+
+
     private ActionResult Problem(Error error) => Problem(
         detail: error.Message,
         statusCode: (int)error.StatusCode,
         extensions: new Dictionary<string, object?> { { "errorCode", error.ErrorCode } });
 }
-
-

--- a/src/Altinn.Correspondence.Application/CleanupMarkdownAndHTMLInSummary/CleanupMarkdownAndHTMLInSummaryHandler.cs
+++ b/src/Altinn.Correspondence.Application/CleanupMarkdownAndHTMLInSummary/CleanupMarkdownAndHTMLInSummaryHandler.cs
@@ -1,0 +1,160 @@
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using Microsoft.Extensions.Logging;
+using OneOf;
+using System.Security.Claims;
+using Hangfire;
+using Altinn.Correspondence.Common.Helpers;
+
+namespace Altinn.Correspondence.Application.CleanupMarkdownAndHTMLInSummary;
+
+public class CleanupMarkdownAndHTMLInSummaryHandler(
+    ICorrespondenceRepository correspondenceRepository,
+    IDialogportenService dialogportenService,
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<CleanupMarkdownAndHTMLInSummaryHandler> logger) : IHandler<CleanupMarkdownAndHTMLInSummaryRequest, CleanupMarkdownAndHTMLInSummaryResponse>
+{
+    public Task<OneOf<CleanupMarkdownAndHTMLInSummaryResponse, Error>> Process(CleanupMarkdownAndHTMLInSummaryRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Starting cleanup of perishing dialogs (removing expiresAt) with window size {windowSize}", request.WindowSize);
+
+        var jobId = backgroundJobClient.Enqueue(() => ExecuteCleanupInBackground(request.WindowSize, CancellationToken.None));
+
+        logger.LogInformation("Cleanup job {jobId} has been enqueued", jobId);
+
+        return Task.FromResult<OneOf<CleanupMarkdownAndHTMLInSummaryResponse, Error>>(new CleanupMarkdownAndHTMLInSummaryResponse
+        {
+            JobId = jobId,
+            Message = "Cleanup job has been Enqueued"
+        });
+    }
+
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(timeoutInSeconds: 43200)]
+    public async Task ExecuteCleanupInBackground(int windowSize, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Executing cleanup of dialogs with markdown or html in summary in background job");
+
+        var totalProcessed = 0;
+        var totalPatched = 0;
+        var totalAlreadyOk = 0;
+        var totalErrors = 0;
+        var allErrors = new List<string>();
+        try
+        {
+            DateTimeOffset? lastCreated = null;
+            Guid? lastId = null;
+            bool isMoreCorrespondences = true;
+
+            while (isMoreCorrespondences)
+            {
+                logger.LogInformation("Processing batch starting after cursor {correspondenceId}", lastId);
+                var correspondencesWindow = await correspondenceRepository.GetCorrespondencesWindowAfter
+                (windowSize + 1,
+                lastCreated,
+                lastId,
+                true,
+                cancellationToken);
+
+                isMoreCorrespondences = correspondencesWindow.Count > windowSize;
+                if (isMoreCorrespondences)
+                {
+                    correspondencesWindow = correspondencesWindow.Take(windowSize).ToList();
+                }
+                if (correspondencesWindow.Count > 0)
+                {
+                    var last = correspondencesWindow[^1];
+                    lastCreated = last.Created;
+                    lastId = last.Id;
+                }
+                var windowIds = correspondencesWindow.Select(c => c.Id).ToList();
+                var candidates = await correspondenceRepository.GetCorrespondencesByNoAltinn2IdAndExistingDialog(
+                    windowIds,
+                    ReferenceType.DialogportenDialogId,
+                    cancellationToken);
+                logger.LogInformation("Found {candidateCount} candidates for cleanup in current window", candidates.Count);
+
+                foreach (var correspondence in candidates)
+                {
+                    try
+                    {
+                        totalProcessed++;
+                        var (patched, alreadyOk) = await ProcessSingleCorrespondence(correspondence);
+                        if (patched)
+                        {
+                            totalPatched++;
+                        }
+                        else if (alreadyOk)
+                        {
+                            totalAlreadyOk++;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        totalErrors++;
+                        var errorMessage = $"Error processing correspondence {correspondence.Id}: {ex.Message}";
+                        allErrors.Add(errorMessage);
+                        logger.LogError(ex, "Failed to process correspondence {correspondenceId}", correspondence.Id);
+                    }
+                }
+
+                totalProcessed += candidates.Count;
+
+                if (correspondencesWindow.Count == 0)
+                {
+                    isMoreCorrespondences = false;
+                }
+
+            }
+
+            logger.LogInformation("Background cleanup completed. Total processed: {processedCount}, Total patched: {patchedCount}, Already ok: {alreadyOkCount}, Total errors: {errorCount}", 
+                totalProcessed, totalPatched, totalAlreadyOk, totalErrors);
+                
+            if (allErrors.Count > 0)
+            {
+                logger.LogWarning("Cleanup completed with {errorCount} errors: {errors}", totalErrors, string.Join("; ", allErrors));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to execute background cleanup of dialogs with markdown or html in summary");
+            throw;
+        }
+    }
+
+    private async Task<(bool patched, bool alreadyOk)> ProcessSingleCorrespondence(CorrespondenceEntity correspondence)
+    {
+        var dialogId = correspondence.ExternalReferences
+            .FirstOrDefault(er => er.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
+            var originalSummary = correspondence.Content?.MessageSummary;
+
+            if (originalSummary == null)
+            {
+                logger.LogWarning("Skipping correspondence {correspondenceId} as it has no summary", correspondence.Id);
+                return (false, false);
+            }
+            else
+            {
+                var newSummary = TextValidation.StripSummaryForHtmlAndMarkdown(originalSummary);
+                if (newSummary.ToString().Length < originalSummary.ToString().Length)
+                {
+                    logger.LogInformation("Attempting to update summary on correspondence {correspondenceId}", correspondence.Id);
+                    var updated = await dialogportenService.TryRemoveMarkdownAndHtmlFromSummary(dialogId, newSummary);
+                    if (updated)
+                    {
+                        logger.LogInformation("Successfully updated summary on correspondence {correspondenceId}", correspondence.Id);
+                        return (true, false);
+                    }
+                    else
+                    {
+                        logger.LogWarning("Failed to update summary on correspondence {correspondenceId}", correspondence.Id);
+                        return (false, false);
+                    }
+                }
+                logger.LogInformation("No markdown or html found in summary for correspondence {correspondenceId}, no update needed", correspondence.Id);
+                return (false, true);
+            }
+    }
+} 

--- a/src/Altinn.Correspondence.Application/CleanupMarkdownAndHTMLInSummary/CleanupMarkdownAndHTMLInSummaryHandler.cs
+++ b/src/Altinn.Correspondence.Application/CleanupMarkdownAndHTMLInSummary/CleanupMarkdownAndHTMLInSummaryHandler.cs
@@ -18,7 +18,7 @@ public class CleanupMarkdownAndHTMLInSummaryHandler(
 {
     public Task<OneOf<CleanupMarkdownAndHTMLInSummaryResponse, Error>> Process(CleanupMarkdownAndHTMLInSummaryRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Starting cleanup of perishing dialogs (removing expiresAt) with window size {windowSize}", request.WindowSize);
+        logger.LogInformation("Starting cleanup of dialogs with markdown or html in summary with window size {windowSize}", request.WindowSize);
 
         var jobId = backgroundJobClient.Enqueue(() => ExecuteCleanupInBackground(request.WindowSize, CancellationToken.None));
 
@@ -106,7 +106,6 @@ public class CleanupMarkdownAndHTMLInSummaryHandler(
                 {
                     isMoreCorrespondences = false;
                 }
-
             }
 
             logger.LogInformation("Background cleanup completed. Total processed: {processedCount}, Total patched: {patchedCount}, Already ok: {alreadyOkCount}, Total errors: {errorCount}", 

--- a/src/Altinn.Correspondence.Application/CleanupMarkdownAndHTMLInSummary/CleanupMarkdownAndHTMLInSummaryRequest.cs
+++ b/src/Altinn.Correspondence.Application/CleanupMarkdownAndHTMLInSummary/CleanupMarkdownAndHTMLInSummaryRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Correspondence.Application.CleanupMarkdownAndHTMLInSummary;
+
+public class CleanupMarkdownAndHTMLInSummaryRequest
+{
+    [Range(100, int.MaxValue)]
+    public int WindowSize { get; set; } = 10000;
+} 

--- a/src/Altinn.Correspondence.Application/CleanupMarkdownAndHTMLInSummary/CleanupMarkdownAndHTMLInSummaryResponse.cs
+++ b/src/Altinn.Correspondence.Application/CleanupMarkdownAndHTMLInSummary/CleanupMarkdownAndHTMLInSummaryResponse.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Correspondence.Application.CleanupMarkdownAndHTMLInSummary;
+
+public class CleanupMarkdownAndHTMLInSummaryResponse
+{
+    public string? JobId { get; set; }
+    public string? Message { get; set; }
+} 

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -67,6 +67,7 @@ public static class DependencyInjection
         // Maintenance
         services.AddScoped<CleanupOrphanedDialogsHandler>();
         services.AddScoped<CleanupPerishingDialogs.CleanupPerishingDialogsHandler>();
+        services.AddScoped<CleanupMarkdownAndHTMLInSummary.CleanupMarkdownAndHTMLInSummaryHandler>();
         services.AddScoped<RestoreSoftDeletedDialogsHandler>();
 
         // Statistics & Reporting

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -66,7 +66,7 @@ namespace Altinn.Correspondence.Core.Repositories
             ReferenceType referenceType,
             List<CorrespondenceStatus> currentStatuses,
             CancellationToken cancellationToken);
-        
+
         Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndNotCurrentStatuses(
             List<Guid> correspondenceIds,
             ReferenceType referenceType,
@@ -77,9 +77,11 @@ namespace Altinn.Correspondence.Core.Repositories
             List<Guid> correspondenceIds,
             ReferenceType referenceType,
             CancellationToken cancellationToken);
-        
+
         Task<List<CorrespondenceEntity>> GetCorrespondencesForReport(bool includeAltinn2, CancellationToken cancellationToken);
-        
+
         Task<CorrespondenceEntity?> GetCorrespondenceByIdempotentKey(Guid idempotentKey, CancellationToken cancellationToken);
+
+        Task<List<CorrespondenceEntity?>> GetCorrespondencesByNoAltinn2IdAndExistingDialog(List<Guid> windowIds, ReferenceType referenceType, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
@@ -20,4 +20,5 @@ public interface IDialogportenService
     Task<bool> TryRestoreSoftDeletedDialog(string dialogId, CancellationToken cancellationToken = default);
     Task CreateCorrespondencePurgedActivity(Guid correspondenceId, DialogportenActorType actorType, string actorName, DateTimeOffset activityTimestamp);
     Task UpdateSystemLabelsOnDialog(Guid correspondenceId, string enduserId, List<DialogPortenSystemLabel>? systemLabelsToAdd, List<DialogPortenSystemLabel>? systemLabelsToRemove);
+    Task <bool> TryRemoveMarkdownAndHtmlFromSummary(string dialogId, string newSummary, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
@@ -78,5 +78,10 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
         {
             return Task.FromResult(Guid.NewGuid().ToString());
         }
+
+        public Task<bool> TryRemoveMarkdownAndHtmlFromSummary(string dialogId, string newSummary, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(true);
+        }
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -530,6 +530,27 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
         return (openActivityId, confirmActivityId);
     }
 
+    public async Task<bool> TryRemoveMarkdownAndHtmlFromSummary(string dialogId, string newSummary, CancellationToken cancellationToken = default)
+    {
+        var dialog = await GetDialog(dialogId);
+        if (dialog is null)
+        {
+            throw new Exception($"Dialog {dialogId} not found when attempting to remove markdown and html from summary");
+        }
+
+        var strippedSummary = newSummary;
+        var patchRequestBuilder = new DialogPatchRequestBuilder()
+            .WithReplaceSummaryOperation(strippedSummary);
+        var patchRequest = patchRequestBuilder.Build();
+        var response = await _httpClient.PatchAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}", patchRequest, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogError(($"Response from Dialogporten when removing markdown and html from summary for {dialogId} was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}"));
+            return false;
+        }
+        return true;
+    }
+
 
     #region MigrationRelated    
     /// <summary>

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Factories/PatchDialogRequestBuilder.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Factories/PatchDialogRequestBuilder.cs
@@ -12,7 +12,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
         internal DialogPatchRequestBuilder WithRemoveGuiActionOperation(int guiActionToRemoveIndex)
         {
             _PatchDialogRequest.Add(
-                new 
+                new
                 {
                     op = "remove",
                     path = $"/guiActions/{guiActionToRemoveIndex}"
@@ -24,7 +24,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
         internal DialogPatchRequestBuilder WithRemoveApiActionOperation(int apiActionToRemoveIndex)
         {
             _PatchDialogRequest.Add(
-                new 
+                new
                 {
                     op = "remove",
                     path = $"/apiActions/{apiActionToRemoveIndex}"
@@ -36,7 +36,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
         internal DialogPatchRequestBuilder WithReplaceStatusOperation(string newStatus)
         {
             _PatchDialogRequest.Add(
-                new 
+                new
                 {
                     op = "replace",
                     path = "/status",
@@ -53,6 +53,19 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
                 {
                     op = "remove",
                     path = "/expiresAt"
+                }
+            );
+            return this;
+        }
+        
+        internal DialogPatchRequestBuilder WithReplaceSummaryOperation(string newSummary)
+        {
+            _PatchDialogRequest.Add(
+                new
+                {
+                    op = "replace",
+                    path = "/content/summary",
+                    value = newSummary
                 }
             );
             return this;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Factories/PatchDialogRequestBuilder.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Factories/PatchDialogRequestBuilder.cs
@@ -64,7 +64,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
                 new
                 {
                     op = "replace",
-                    path = "/content/summary",
+                    path = "/content/summary/value/0/value",
                     value = newSummary
                 }
             );

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -367,6 +367,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .Where(c => c.Altinn2CorrespondenceId == null)
                 .Where(c => c.ExternalReferences.Any(er => er.ReferenceType == referenceType))
                 .Include(c => c.Content)
+                .Include(c => c.ExternalReferences)
                 .ToListAsync(cancellationToken);
         }
     }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -278,7 +278,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .Include(c => c.ExternalReferences)
                 .ToListAsync(cancellationToken);
         }
-        
+
         public async Task<List<CorrespondenceEntity>> GetCorrespondencesByIdsWithExternalReferenceAndNotCurrentStatuses(
             List<Guid> correspondenceIds,
             ReferenceType referenceType,
@@ -349,6 +349,25 @@ namespace Altinn.Correspondence.Persistence.Repositories
             .SingleOrDefaultAsync(cancellationToken);
 
             return correspondence;
+        }
+
+        public async Task<List<CorrespondenceEntity>> GetCorrespondencesByNoAltinn2IdAndExistingDialog(
+            List<Guid> correspondenceIds,
+            ReferenceType referenceType,
+            CancellationToken cancellationToken)
+        {
+            if (correspondenceIds == null || correspondenceIds.Count == 0)
+            {
+                return new List<CorrespondenceEntity>();
+            }
+            return await _context.Correspondences
+                .AsNoTracking()
+                .AsSplitQuery()
+                .Where(c => correspondenceIds.Contains(c.Id))
+                .Where(c => c.Altinn2CorrespondenceId == null)
+                .Where(c => c.ExternalReferences.Any(er => er.ReferenceType == referenceType))
+                .Include(c => c.Content)
+                .ToListAsync(cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Description
A job can now be run in order to remove markdown and html from message summaries. The PR includes a method which utilizes a helper method to convert markdown to html, and then remove the html tags from the string. The job retrieves relevant correspondences, and thus sorts messages who needs patching and which messages are already plain text.
The job calls upon Dialogportens patch endpoint for the relevant correspondences.

## Related Issue(s)
- #1378

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)