### PR TITLE
Remove AT21 environment from workflows as it is no longer in use

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -11,7 +11,6 @@ on:
           - staging
           - production
           - yt01
-          - at21
           - at22
           - at23
           - at24

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -15,7 +15,6 @@ on:
           - staging
           - production
           - yt01
-          - at21
           - at22
           - at23
           - at24


### PR DESCRIPTION
## Description
Remove AT21 environment from workflows as it is no longer in use. We have never really used it.

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)