### PR TITLE
MakeCorrespondenceAvailableInDialogportenAndApi after RequestedPublishTime

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
@@ -88,6 +88,12 @@ namespace Altinn.Correspondence.Tests.Factories
             return this;
         }
 
+        public MigrateCorrespondenceBuilder WithRequestedPublishTime(DateTime requestedPublishTime)
+        {
+            _migratedCorrespondence.CorrespondenceData.Correspondence.RequestedPublishTime = new DateTimeOffset(requestedPublishTime);
+            return this;
+        }
+
         public MigrateCorrespondenceBuilder WithRecipient(string recipient)
         {
             _migratedCorrespondence.CorrespondenceData.Recipients.Clear();

--- a/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
@@ -88,9 +88,9 @@ namespace Altinn.Correspondence.Tests.Factories
             return this;
         }
 
-        public MigrateCorrespondenceBuilder WithRequestedPublishTime(DateTime requestedPublishTime)
+        public MigrateCorrespondenceBuilder WithRequestedPublishTime(DateTimeOffset requestedPublishTime)
         {
-            _migratedCorrespondence.CorrespondenceData.Correspondence.RequestedPublishTime = new DateTimeOffset(requestedPublishTime);
+            _migratedCorrespondence.CorrespondenceData.Correspondence.RequestedPublishTime = requestedPublishTime;
             return this;
         }
 

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -6,7 +6,6 @@ using Altinn.Correspondence.Tests.Factories;
 using Altinn.Correspondence.Tests.Fixtures;
 using Altinn.Correspondence.Tests.Helpers;
 using Altinn.Correspondence.Tests.TestingController.Migration.Base;
-using DotNet.Testcontainers.Builders;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using System.Net;
@@ -392,8 +391,8 @@ public class MigrationControllerTests : MigrationTestBase
     {
         MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
             .CreateMigrateCorrespondence()
-            .WithCreatedAt(DateTime.Now.AddMinutes(-5))
-            .WithRequestedPublishTime(DateTime.Now.AddSeconds(2))
+            .WithCreatedAt(DateTimeOffset.Now.AddMinutes(-5))
+            .WithRequestedPublishTime(DateTimeOffset.Now.AddSeconds(5))
             .WithRecipient("urn:altinn:person:identifier-no:29909898925")
             .WithResourceId("skd-migratedcorrespondence-5229-1")
             .Build();
@@ -411,9 +410,9 @@ public class MigrationControllerTests : MigrationTestBase
         var getCorrespondenceOverviewResponse1 = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{resultObj.CorrespondenceId}/content");
         Assert.False(getCorrespondenceOverviewResponse1.IsSuccessStatusCode);
 
-        await Task.Delay(3000); // Wait until after requested publish time
+        await Task.Delay(6000); // Wait until after requested publish time
 
-        // Verify that correspondence has IsMigrating set to true, which means we can retrieve it through GetOverview.
+        // Verify that correspondence has IsMigrating set to false, which means we can retrieve it through GetOverview.
         var getCorrespondenceOverviewResponse2 = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{resultObj.CorrespondenceId}/content");
         Assert.True(getCorrespondenceOverviewResponse2.IsSuccessStatusCode);
     }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
@@ -101,7 +101,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
 
             // Verify that individual background jobs were created for each correspondence
             _mockBackgroundJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Method.Name == "MakeCorrespondenceAvailableInDialogportenAndApi"),
+                It.Is<Job>(job => job.Method.Name == "ScheduleMakeCorrespondenceAvailableInDialogportenAndApiAtPublishTime"),
                 It.IsAny<IState>()), 
                 Times.Exactly(10000));
 
@@ -580,7 +580,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             {
                 _mockBackgroundJobClient.Verify(x => x.Create(
                     It.Is<Job>(job => 
-                        job.Method.Name == "MakeCorrespondenceAvailableInDialogportenAndApi" &&
+                        job.Method.Name == "ScheduleMakeCorrespondenceAvailableInDialogportenAndApiAtPublishTime" &&
                         job.Args.Count > 0 &&
                         job.Args[0].Equals(correspondenceId)),
                     It.IsAny<IState>()), 

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -47,7 +47,7 @@ public class MigrateCorrespondenceHandler(
             string dialogId = "";
             if (request.MakeAvailable)
             {
-                var makeAvailableJob = backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.LiveMigration, (handler) => handler.MakeCorrespondenceAvailableInDialogportenAndApi(correspondence.Id, CancellationToken.None, null, true));
+                var makeAvailableJob = backgroundJobClient.Enqueue<HangfireScheduleHelper>(HangfireQueues.LiveMigration, (helper) => helper.ScheduleMakeCorrespondenceAvailableInDialogportenAndApiAtPublishTime(correspondence.Id, CancellationToken.None));
                 backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(makeAvailableJob, HangfireQueues.LiveMigration, (helper) => helper.SchedulePublishAtPublishTime(correspondence.Id, CancellationToken.None));
             }
             
@@ -160,7 +160,7 @@ public class MigrateCorrespondenceHandler(
                 var correspondences = await correspondenceRepository.GetCandidatesForMigrationToDialogporten(request.BatchSize ?? 0, request.BatchOffset ?? 0, cancellationToken);
                 foreach(var correspondence in correspondences)
                 {
-                    backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.Migration, handler => handler.MakeCorrespondenceAvailableInDialogportenAndApi(correspondence.Id));
+                    backgroundJobClient.Enqueue<HangfireScheduleHelper>(HangfireQueues.Migration, (helper) => helper.ScheduleMakeCorrespondenceAvailableInDialogportenAndApiAtPublishTime(correspondence.Id, CancellationToken.None));
                 }
             }
         }


### PR DESCRIPTION
Added scheduling of MakeCorrespondenceAvailableInDialogportenAndApi so that it occurs at requested Publish time.

This is to support the case of migrated messages where migration occurs before requested Publish time.

## Description
Before this fix, the existence of a "Published" event with a future date lead to a Dialogporten dialog being created that had a "UpdatedAt" with a future time. This caused CreateDialog to fail validation.

This fix avoids this by scheduling the MakeCorrespondenceAvailableInDialogportenAndApi, and thus the Create Dialog to happen after RequestedPublishTime.

## Related Issue(s)
- #1391

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for setting a requested publish time when migrating correspondence. Availability is now scheduled to become accessible at the specified publish time (hidden until then) across relevant channels.

- **Tests**
  - Extended test coverage for future requested publish times, verifying visibility transitions before and after the scheduled publish time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->