### PR TITLE
Prevent Dialog with UpdatedAt in the future

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/CorrespondenceEntityBuilder.cs
@@ -85,6 +85,16 @@ namespace Altinn.Correspondence.Tests.Factories
             return this;
         }
 
+        public CorrespondenceEntityBuilder WithStatus(CorrespondenceStatus status, DateTimeOffset statusChanged)
+        {
+            _correspondenceEntity.Statuses.Add(new CorrespondenceStatusEntity
+            {
+                Status = status,
+                StatusChanged = statusChanged
+            });
+            return this;
+        }
+
         public CorrespondenceEntityBuilder WithStatus(CorrespondenceStatus status, DateTime statusChanged, Guid partyUuid)
         {
             _correspondenceEntity.Statuses.Add(new CorrespondenceStatusEntity

--- a/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
@@ -216,9 +216,8 @@ public class CreateDialogRequestMapperTests
         var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, currentUtcNow: currentUtcTime);
 
         // Assert
-        Assert.True(result.UpdatedAt.HasValue, "Expected UpdatedAt to be set.");
-        Assert.True(result.UpdatedAt.Value != futureUtcTime, "UpdatedAt set to Future Time.");
-        Assert.True(result.UpdatedAt.Value == currentUtcTime, "UpdatedAt Not set to Now.");
+        Assert.NotNull(result.UpdatedAt);
+        Assert.Equal(currentUtcTime, result.UpdatedAt.Value);
     }
 
     [Fact]
@@ -226,11 +225,11 @@ public class CreateDialogRequestMapperTests
     {
         // Arrange
         DateTimeOffset currentUtcTime = DateTimeOffset.UtcNow;
-        DateTimeOffset origninalPublishDate = currentUtcTime.AddHours(-1);
+        DateTimeOffset originalPublishDate = currentUtcTime.AddHours(-1);
 
         var correspondence = new CorrespondenceEntityBuilder()
-            .WithRequestedPublishTime(origninalPublishDate)
-            .WithStatus(CorrespondenceStatus.Published, origninalPublishDate)
+            .WithRequestedPublishTime(originalPublishDate)
+            .WithStatus(CorrespondenceStatus.Published, originalPublishDate)
             .Build();
 
         var baseUrl = "https://example.com";
@@ -238,9 +237,8 @@ public class CreateDialogRequestMapperTests
         // Act
         var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, currentUtcNow: currentUtcTime);
 
-        // Assert
-        Assert.True(result.UpdatedAt.HasValue, "Expected UpdatedAt to be set.");
-        Assert.True(result.UpdatedAt.Value == origninalPublishDate, "UpdatedAt Not set to Published Time.");
-        Assert.True(result.UpdatedAt.Value != currentUtcTime, "UpdatedAt set to Now.");
+        // Assert        
+        Assert.NotNull(result.UpdatedAt);
+        Assert.Equal(originalPublishDate, result.UpdatedAt.Value);
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -19,13 +19,15 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
     internal static class CreateDialogRequestMapper
     {
-        internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl, bool includeActivities = false, ILogger? logger = null, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, bool isSoftDeleted = false)
+        internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl, bool includeActivities = false, ILogger? logger = null, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, bool isSoftDeleted = false, DateTimeOffset? currentUtcNow = null)
         {
             var dialogId = Guid.CreateVersion7().ToString(); // Dialogporten requires time-stamped GUIDs
             DateTimeOffset? dueAt = correspondence.DueDateTime != default ? correspondence.DueDateTime : null;
 
+            DateTimeOffset currentDateTimeUtcNow = currentUtcNow ?? DateTimeOffset.UtcNow;
+
             // The problem of DueAt being in the past should only occur for migrated data, as such we are checking includeActivities flag first, since this is only set when making migrated correspondences available.
-            if (includeActivities && dueAt.HasValue && dueAt < DateTimeOffset.Now)
+            if (includeActivities && dueAt.HasValue && dueAt < currentDateTimeUtcNow)
             {
                 dueAt = null;
             }
@@ -36,8 +38,8 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 ServiceResource = UrnConstants.Resource + ":" + correspondence.ResourceId,
                 Party = correspondence.GetRecipientUrn(),
                 CreatedAt = correspondence.Created,
-                UpdatedAt = (correspondence.Statuses ?? []).Select(s => s.StatusChanged).Concat([correspondence.Created]).Max(),
-                VisibleFrom = correspondence.RequestedPublishTime < DateTime.UtcNow.AddMinutes(1) ? null : correspondence.RequestedPublishTime,
+                UpdatedAt = GetUpdatedAt(correspondence, currentDateTimeUtcNow),
+                VisibleFrom = correspondence.RequestedPublishTime < currentDateTimeUtcNow.AddMinutes(1) ? null : correspondence.RequestedPublishTime,
                 Process = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenProcessId)?.ReferenceValue,
                 DueAt = dueAt,
                 Status = GetDialogStatusForCorrespondence(correspondence),
@@ -51,6 +53,27 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 Transmissions = new List<Transmission>(),
                 SystemLabel = GetSystemLabelForCorrespondence(correspondence, isSoftDeleted)
             };
+        }
+
+        /// <summary>
+        /// Method to get appropriate UpdatedAt value for Dialogporten that is not in the future.
+        /// This is primarily to handle cases where a Migrated correspondence has a "Published" status in the future due to a future RequestedVisibleTime
+        /// </summary>
+        /// <param name="correspondence">The correspondence to get for</param>
+        /// <param name="currentUtcNow">Current UTCNow time, to enable unit testing</param>
+        /// <returns></returns>
+        private static DateTimeOffset GetUpdatedAt(CorrespondenceEntity correspondence, DateTimeOffset currentUtcNow)
+        {
+            var latestStatusChange = (correspondence.Statuses is { Count: > 0 })
+                ? correspondence.Statuses.Max(s => s.StatusChanged)
+                : correspondence.Created;
+
+            if (latestStatusChange > currentUtcNow)
+            {
+                latestStatusChange = currentUtcNow;
+            }
+
+            return latestStatusChange;
         }
 
         private static string GetSystemLabelForCorrespondence(CorrespondenceEntity correspondence, bool isSoftDeleted)


### PR DESCRIPTION
Added logic so that a CreateDialogRequest will never be created with a UpdatedAt timestamp in the future, as this would fail validation in CreateDialog in Dialogporten.

## Description
UpdatedAt will have a max value of DateTimeOffset.UtcNow at time of execution.

This is primarily to handle migrated correspondences with a Status Event for "Published" in the future, which occurres when the ServiceOwner creates a correspondence in Altinn 2 with a RequestedPublishTime that occurrs after migration and CreateDialog occurs.
Also made CreateDialogRequestMapper able to accept a value to specify UtcNow for unit testing purposes.

## Related Issue(s)
- #1391

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures UpdatedAt is never set in the future; clamps to current UTC when necessary and standardizes time comparisons for due date and visibility.

* **Tests**
  * Added tests covering UpdatedAt behavior for future and past publish times to prevent regressions and validate the new time-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->