### PR TITLE
Changed error message and code

### DIFF
--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -40,7 +40,7 @@ public static class CorrespondenceErrors
     public static Error InvalidIdempotencyKey = new Error(1033, "The idempotency key must be a valid non-empty GUID", HttpStatusCode.BadRequest);
     public static Error DuplicateInitCorrespondenceRequest = new Error(1034, "A correspondence with the same idempotent key already exists", HttpStatusCode.Conflict);
     public static Error InvalidReplyOptions = new Error(1035, "Reply options must be well-formed URIs and HTTPS with a max length of 255 characters", HttpStatusCode.BadRequest);
-    public static Error ServiceOwnerOrgNumberNotFound = new Error(1036, "Service owner/sender's organization number (9 digits) not found for resource", HttpStatusCode.InternalServerError);
+    public static Error InvalidResource = new Error(1036, "ResourceId must match an existing resource in the resource registry", HttpStatusCode.BadRequest);
     public static Error MessageTitleTooLong = new Error(1037, "Message title cannot exceed 255 characters", HttpStatusCode.BadRequest);
     public static Error AttachmentCountExceeded = new Error(1038, "A correspondence cannot contain more than 100 attachments in total", HttpStatusCode.BadRequest);
     public static Error MessageSenderIsNotPlainText = new Error(1039, "Message sender must be plain text", HttpStatusCode.BadRequest);

--- a/src/Altinn.Correspondence.Application/InitializeAttachment/InitializeAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeAttachment/InitializeAttachmentHandler.cs
@@ -31,9 +31,8 @@ public class InitializeAttachmentHandler(
         if (string.IsNullOrEmpty(serviceOwnerOrgNumber))
         {
             logger.LogError("Service owner/sender's organization number (9 digits) not found for resource {ResourceId}", sanitizedResourceId);
-            return CorrespondenceErrors.ServiceOwnerOrgNumberNotFound;
+            return CorrespondenceErrors.InvalidResource;
         }
-        
         var hasAccess = await altinnAuthorizationService.CheckAccessAsSender(
             user,
             request.Attachment.ResourceId,

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -64,7 +64,7 @@ public class InitializeCorrespondencesHandler(
         if (serviceOwnerOrgNumber is null || serviceOwnerOrgNumber == string.Empty)
         {
             logger.LogError("Service owner/sender's organization number (9 digits) not found for resource {ResourceId}", request.Correspondence.ResourceId);
-            return CorrespondenceErrors.ServiceOwnerOrgNumberNotFound;
+            return CorrespondenceErrors.InvalidResource;
         }
         validatedData.ServiceOwnerOrgNumber = serviceOwnerOrgNumber;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Invalid resourceId would give 500 response with message: Service owner/sender's organization number (9 digits) not found for resource.

This PR changes this error to 400 code with message 'ResourceId must match an existing resource in the resource registry'

## Related Issue(s)
- #1390 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)