### PR TITLE
Skip slack notification for exceptions on the migration endpoints

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingIntegrations/Slack/SlackExceptionNotificationHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingIntegrations/Slack/SlackExceptionNotificationHandlerTests.cs
@@ -16,6 +16,9 @@ namespace Altinn.Correspondence.Tests.TestingIntegrations.Slack
             // Arrange
             var logger = new Mock<ILogger<SlackExceptionNotificationHandler>>();
             var slackClient = new Mock<ISlackClient>(MockBehavior.Strict);
+            slackClient
+                .Setup(x => x.PostAsync(It.IsAny<SlackMessage>()))
+                .Returns(Task.FromResult(true));
             var problemDetailsService = new Mock<IProblemDetailsService>();
             var hostEnvironment = new Mock<IHostEnvironment>();
             var slackSettings = new SlackSettings(hostEnvironment.Object);
@@ -46,6 +49,9 @@ namespace Altinn.Correspondence.Tests.TestingIntegrations.Slack
             // Arrange
             var logger = new Mock<ILogger<SlackExceptionNotificationHandler>>();
             var slackClient = new Mock<ISlackClient>(MockBehavior.Strict);
+            slackClient
+                .Setup(x => x.PostAsync(It.IsAny<SlackMessage>()))
+                .Returns(Task.FromResult(true));
             var problemDetailsService = new Mock<IProblemDetailsService>();
             var hostEnvironment = new Mock<IHostEnvironment>();
             var slackSettings = new SlackSettings(hostEnvironment.Object);

--- a/Test/Altinn.Correspondence.Tests/TestingIntegrations/Slack/SlackExceptionNotificationHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingIntegrations/Slack/SlackExceptionNotificationHandlerTests.cs
@@ -1,0 +1,75 @@
+using Altinn.Correspondence.Integrations.Slack;
+using Altinn.Correspondence.Core.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Slack.Webhooks;
+
+namespace Altinn.Correspondence.Tests.TestingIntegrations.Slack
+{
+    public class SlackExceptionNotificationHandlerTests
+    {
+        [Fact]
+        public async Task TryHandleAsync_OnMigrationPath_DoesNotSendSlackMesssage()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<SlackExceptionNotificationHandler>>();
+            var slackClient = new Mock<ISlackClient>(MockBehavior.Strict);
+            var problemDetailsService = new Mock<IProblemDetailsService>();
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            var slackSettings = new SlackSettings(hostEnvironment.Object);
+
+            var handler = new SlackExceptionNotificationHandler(
+                logger.Object,
+                slackClient.Object,
+                problemDetailsService.Object,
+                hostEnvironment.Object,
+                slackSettings);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/correspondence/api/v1/migration/correspondence/syncStatusEvent";
+
+            var exception = new Exception("test");
+
+            // Act
+            var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+            // Assert
+            Assert.True(handled);
+            slackClient.Verify(x => x.PostAsync(It.IsAny<SlackMessage>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task TryHandleAsync_OnNonMigrationPath_SendsSlackMessage()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<SlackExceptionNotificationHandler>>();
+            var slackClient = new Mock<ISlackClient>(MockBehavior.Strict);
+            var problemDetailsService = new Mock<IProblemDetailsService>();
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            var slackSettings = new SlackSettings(hostEnvironment.Object);
+
+            var handler = new SlackExceptionNotificationHandler(
+                logger.Object,
+                slackClient.Object,
+                problemDetailsService.Object,
+                hostEnvironment.Object,
+                slackSettings);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/correspondence/api/v1/correspondence/";
+
+            var exception = new Exception("test");
+
+            // Act
+            var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+            // Assert
+            Assert.True(handled);
+            slackClient.Verify(x => x.PostAsync(It.IsAny<SlackMessage>()), Times.Once);
+        }
+    }
+}
+
+

--- a/Test/Altinn.Correspondence.Tests/TestingIntegrations/Slack/SlackExceptionNotificationHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingIntegrations/Slack/SlackExceptionNotificationHandlerTests.cs
@@ -11,7 +11,7 @@ namespace Altinn.Correspondence.Tests.TestingIntegrations.Slack
     public class SlackExceptionNotificationHandlerTests
     {
         [Fact]
-        public async Task TryHandleAsync_OnMigrationPath_DoesNotSendSlackMesssage()
+        public async Task TryHandleAsync_OnMigrationPath_DoesNotSendSlackMessage()
         {
             // Arrange
             var logger = new Mock<ILogger<SlackExceptionNotificationHandler>>();

--- a/src/Altinn.Correspondence.Integrations/Slack/SlackExceptionNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Integrations/Slack/SlackExceptionNotificationHandler.cs
@@ -44,7 +44,7 @@ public class SlackExceptionNotificationHandler(
             }
             else
             {
-                logger.LogWarning("Skipping Slack notification for migration endpoint");
+                logger.LogWarning("Skipping Slack notification for exception on migration endpoint");
             }
             var statusCode = HttpStatusCode.InternalServerError;
             var problemDetails = new ProblemDetails

--- a/src/Altinn.Correspondence.Integrations/Slack/SlackExceptionNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Integrations/Slack/SlackExceptionNotificationHandler.cs
@@ -23,6 +23,12 @@ public class SlackExceptionNotificationHandler(
         Exception exception,
         CancellationToken cancellationToken)
     {
+        var requestPath = httpContext.Request.Path.ToString();
+        if (requestPath.StartsWith("/correspondence/api/v1/migration", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogError(exception, "Unhandled exception on migration endpoint {Path}. Skipping Slack notification.", requestPath);
+            return true;
+        }
         var exceptionMessage = FormatExceptionMessage(exception, httpContext);
         var sanitizedPath = httpContext.Request.Path.ToString().Replace("\n", "").Replace("\r", "");
         logger.LogError(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pr filters out all exceptions that occur on the migration endpoints (does not include exceptions in background jobs) from being sendt on slack. The migration endpoints are monitored by another team.

## Related Issue(s)
- #1385 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Suppresses Slack alerts for migration-related API requests (case-insensitive path match), reducing noisy notifications while still recording a warning for those exceptions. Regular non-migration requests continue to trigger Slack notifications as before.

- Tests
  - Added unit tests confirming notifications are skipped for migration paths and sent for other paths, ensuring the alerting behavior is validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->