### PR TITLE
IdempotencyKey is not supported for multiple recipients

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -1918,6 +1918,24 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Clean up
             customFactory.Dispose();
         }
+
+        [Fact]
+        public async Task InitializeCorrespondence_WithIdempotentKeyAndMultipleRecipients_ReturnsBadRequest()
+        {
+            // Arrange
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithMessageTitle("First Title")
+                .WithIdempotentKey(Guid.NewGuid())
+                .WithRecipients(["26818099001", "07827199405"])
+                .Build();
+
+            // Act
+            var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+        }
     }
 }
 

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -73,7 +73,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
         /// <li>1045: Transmission correspondences only support one recipient</li>
         /// <li>1046: The recipient of the correspondence must be equal to the recipient of the transmission</li>
-        /// <li>1047: IdempotencyKey cannot be used when sending to multiple recipients</li>
+        /// <li>1047: IdempotencyKey is not supported for requests with multiple recipients</li>
         /// <li>3001: The requested notification template with the given language was not found</li>
         /// <li>3002: Email body and subject must be provided when sending email notifications</li>
         /// <li>3003: Reminder email body and subject must be provided when sending reminder email notifications</li>
@@ -173,7 +173,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
         /// <li>1045: Transmission correspondences only support one recipient</li>
         /// <li>1046: The recipient of the correspondence must be equal to the recipient of the transmission</li>
-        /// <li>1047: IdempotencyKey cannot be used when sending to multiple recipients</li>
+        /// <li>1047: IdempotencyKey is not supported for requests with multiple recipients</li>
         /// <li>2001: The requested attachment was not found</li>
         /// <li>2004: File must have content and has a max file size of 2GB</li>
         /// <li>2008: Checksum mismatch</li>

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -71,6 +71,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1039: Message sender must be plain text</li>
         /// <li>1042: Message summary, if not null, must be between 0 and 255 characters long</li>
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
+        /// <li>1047: IdempotencyKey cannot be used when sending to multiple recipients</li>
         /// <li>3001: The requested notification template with the given language was not found</li>
         /// <li>3002: Email body and subject must be provided when sending email notifications</li>
         /// <li>3003: Reminder email body and subject must be provided when sending reminder email notifications</li>
@@ -168,6 +169,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1039: Message sender must be plain text</li>
         /// <li>1042: Message summary, if not null, must be between 0 and 255 characters long</li>
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
+        /// <li>1047: IdempotencyKey cannot be used when sending to multiple recipients</li>
         /// <li>2001: The requested attachment was not found</li>
         /// <li>2004: File must have content and has a max file size of 2GB</li>
         /// <li>2008: Checksum mismatch</li>

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -70,7 +70,10 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1038: A correspondence cannot contain more than 100 attachments in total</li>
         /// <li>1039: Message sender must be plain text</li>
         /// <li>1042: Message summary, if not null, must be between 0 and 255 characters long</li>
+        /// <li>1043: Cannot purge correspondence linked to a Dialogporten Transmission</li>
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
+        /// <li>1045: Transmission correspondences only support one recipient</li>
+        /// <li>1046: The recipient of the correspondence must be equal to the recipient of the transmission</li>
         /// <li>1047: IdempotencyKey cannot be used when sending to multiple recipients</li>
         /// <li>3001: The requested notification template with the given language was not found</li>
         /// <li>3002: Email body and subject must be provided when sending email notifications</li>
@@ -168,7 +171,10 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1038: A correspondence cannot contain more than 100 attachments in total</li>
         /// <li>1039: Message sender must be plain text</li>
         /// <li>1042: Message summary, if not null, must be between 0 and 255 characters long</li>
+        /// <li>1043: Cannot purge correspondence linked to a Dialogporten Transmission</li>
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
+        /// <li>1045: Transmission correspondences only support one recipient</li>
+        /// <li>1046: The recipient of the correspondence must be equal to the recipient of the transmission</li>
         /// <li>1047: IdempotencyKey cannot be used when sending to multiple recipients</li>
         /// <li>2001: The requested attachment was not found</li>
         /// <li>2004: File must have content and has a max file size of 2GB</li>

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -70,7 +70,6 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1038: A correspondence cannot contain more than 100 attachments in total</li>
         /// <li>1039: Message sender must be plain text</li>
         /// <li>1042: Message summary, if not null, must be between 0 and 255 characters long</li>
-        /// <li>1043: Cannot purge correspondence linked to a Dialogporten Transmission</li>
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
         /// <li>1045: Transmission correspondences only support one recipient</li>
         /// <li>1046: The recipient of the correspondence must be equal to the recipient of the transmission</li>
@@ -171,7 +170,6 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1038: A correspondence cannot contain more than 100 attachments in total</li>
         /// <li>1039: Message sender must be plain text</li>
         /// <li>1042: Message summary, if not null, must be between 0 and 255 characters long</li>
-        /// <li>1043: Cannot purge correspondence linked to a Dialogporten Transmission</li>
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
         /// <li>1045: Transmission correspondences only support one recipient</li>
         /// <li>1046: The recipient of the correspondence must be equal to the recipient of the transmission</li>
@@ -508,6 +506,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1014: Correspondence has already been purged</li>
         /// <li>1015: Could not retrieve highest status for correspondence</li>
         /// <li>1026: Cannot archive or delete a correspondence which has not been confirmed when confirmation is required</li>
+        /// <li>1043: Cannot purge correspondence linked to a Dialogporten Transmission</li>
         /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li> 
         /// </ul></response>
         /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and organization in Altinn Authorization</response>

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -73,7 +73,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
         /// <li>1045: Transmission correspondences only support one recipient</li>
         /// <li>1046: The recipient of the correspondence must be equal to the recipient of the transmission</li>
-        /// <li>1047: IdempotencyKey is not supported for requests with multiple recipients</li>
+        /// <li>1047: Idempotency key is not supported for requests with multiple recipients</li>
         /// <li>3001: The requested notification template with the given language was not found</li>
         /// <li>3002: Email body and subject must be provided when sending email notifications</li>
         /// <li>3003: Reminder email body and subject must be provided when sending reminder email notifications</li>
@@ -173,7 +173,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>1044: The following recipients lack required roles to read the correspondence: {recipients}</li>
         /// <li>1045: Transmission correspondences only support one recipient</li>
         /// <li>1046: The recipient of the correspondence must be equal to the recipient of the transmission</li>
-        /// <li>1047: IdempotencyKey is not supported for requests with multiple recipients</li>
+        /// <li>1047: Idempotency key is not supported for requests with multiple recipients</li>
         /// <li>2001: The requested attachment was not found</li>
         /// <li>2004: File must have content and has a max file size of 2GB</li>
         /// <li>2008: Checksum mismatch</li>

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -51,6 +51,7 @@ public static class CorrespondenceErrors
     public static Error RecipientLacksRequiredRolesForCorrespondence(List<string> recipients) { return new Error(1044, $"The following recipients lack required roles to read the correspondence: {string.Join(", ", recipients)}", HttpStatusCode.BadRequest); }
     public static Error TransmissionOnlyAllowsOneRecipient = new Error(1045, "Transmission correspondences only support one recipient", HttpStatusCode.BadRequest);
     public static Error RecipientMismatch = new Error(1046, "The recipient of the correspondence must be equal to the recipient of the transmission", HttpStatusCode.BadRequest);
+    public static Error IdempotencyNotAllowedWithMultipleRecipients = new Error(1047, "IdempotencyKey cannot be used when sending to multiple recipients", HttpStatusCode.BadRequest);
 }
 
 public static class AttachmentErrors

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -51,7 +51,7 @@ public static class CorrespondenceErrors
     public static Error RecipientLacksRequiredRolesForCorrespondence(List<string> recipients) { return new Error(1044, $"The following recipients lack required roles to read the correspondence: {string.Join(", ", recipients)}", HttpStatusCode.BadRequest); }
     public static Error TransmissionOnlyAllowsOneRecipient = new Error(1045, "Transmission correspondences only support one recipient", HttpStatusCode.BadRequest);
     public static Error RecipientMismatch = new Error(1046, "The recipient of the correspondence must be equal to the recipient of the transmission", HttpStatusCode.BadRequest);
-    public static Error IdempotencyNotAllowedWithMultipleRecipients = new Error(1047, "IdempotencyKey is not supported for requests with multiple recipients", HttpStatusCode.BadRequest);
+    public static Error IdempotencyKeyNotAllowedWithMultipleRecipients = new Error(1047, "Idempotency key is not supported for requests with multiple recipients", HttpStatusCode.BadRequest);
 }
 
 public static class AttachmentErrors

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -51,7 +51,7 @@ public static class CorrespondenceErrors
     public static Error RecipientLacksRequiredRolesForCorrespondence(List<string> recipients) { return new Error(1044, $"The following recipients lack required roles to read the correspondence: {string.Join(", ", recipients)}", HttpStatusCode.BadRequest); }
     public static Error TransmissionOnlyAllowsOneRecipient = new Error(1045, "Transmission correspondences only support one recipient", HttpStatusCode.BadRequest);
     public static Error RecipientMismatch = new Error(1046, "The recipient of the correspondence must be equal to the recipient of the transmission", HttpStatusCode.BadRequest);
-    public static Error IdempotencyNotAllowedWithMultipleRecipients = new Error(1047, "IdempotencyKey cannot be used when sending to multiple recipients", HttpStatusCode.BadRequest);
+    public static Error IdempotencyNotAllowedWithMultipleRecipients = new Error(1047, "IdempotencyKey is not supported for requests with multiple recipients", HttpStatusCode.BadRequest);
 }
 
 public static class AttachmentErrors

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -273,7 +273,7 @@ public class InitializeCorrespondencesHandler(
             if (request.Recipients != null && request.Recipients.Count > 1)
             {
                 logger.LogWarning("IdempotencyKey cannot be used with multiple recipients");
-                return CorrespondenceErrors.IdempotencyNotAllowedWithMultipleRecipients;
+                return CorrespondenceErrors.IdempotencyKeyNotAllowedWithMultipleRecipients;
             }
             logger.LogInformation("Checking idempotency key {Key}", request.IdempotentKey.Value);
             var result = await TransactionWithRetriesPolicy.Execute<OneOf<InitializeCorrespondencesResponse, Error>>(async (cancellationToken) =>

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -270,6 +270,11 @@ public class InitializeCorrespondencesHandler(
 
         if (request.IdempotentKey.HasValue)
         {
+            if (request.Recipients != null && request.Recipients.Count > 1)
+            {
+                logger.LogWarning("IdempotencyKey cannot be used with multiple recipients");
+                return CorrespondenceErrors.IdempotencyNotAllowedWithMultipleRecipients;
+            }
             logger.LogInformation("Checking idempotency key {Key}", request.IdempotentKey.Value);
             var result = await TransactionWithRetriesPolicy.Execute<OneOf<InitializeCorrespondencesResponse, Error>>(async (cancellationToken) =>
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
IdempotentKey is currently not supported for correspondences with multiple recipients. Currently that causes a 500 internal server error. This PR adds a validation for idempotentKey with multiple recipients to give a 400 bad request response with a proper error message, instead of a 500 response.

## Related Issue(s)
- #1402

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Requests using an idempotency key with multiple recipients are rejected with HTTP 400.

- Documentation
  - API error docs updated:
    - 1045: Transmission correspondences support only one recipient.
    - 1046: Correspondence recipient must match transmission recipient.
    - 1047: Idempotency key cannot be used with multiple recipients.
    - 1043: Cannot purge correspondence linked to a Dialogporten transmission.

- Tests
  - Added test confirming HTTP 400 when idempotency key is supplied with multiple recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->