### PR TITLE
Added Better handling of MessageTitle to improve Dialogporten integration

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
@@ -101,6 +101,12 @@ namespace Altinn.Correspondence.Tests.Factories
             return this;
         }
 
+        public MigrateCorrespondenceBuilder WithMessageTitle(string messageTitle)
+        {
+            _migratedCorrespondence.CorrespondenceData.Correspondence.Content.MessageTitle = messageTitle;
+            return this;
+        }
+
         public MigrateCorrespondenceBuilder WithSummary(string summary)
         {
             _migratedCorrespondence.CorrespondenceData.Correspondence.Content.MessageSummary = summary;

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -579,6 +579,30 @@ public class MigrationControllerTests : MigrationTestBase
         Assert.False(initializeCorrespondenceResponse.IsSuccessStatusCode, result);
     }
 
+    [Fact]
+    public async Task InitializeMigrateCorrespondence_NullTitle_FailsValidation()
+    {
+        var migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
+            .CreateMigrateCorrespondence()
+            .WithMessageTitle(null)
+            .Build();
+
+        var response = await _migrationClient.PostAsJsonAsync(migrateCorrespondenceUrl, migrateCorrespondenceExt);
+        Assert.False(response.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task InitializeMigrateCorrespondence_WhitespaceTitle_FailsValidation()
+    {
+        var migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
+            .CreateMigrateCorrespondence()
+            .WithMessageTitle("   ")
+            .Build();
+
+        var response = await _migrationClient.PostAsJsonAsync(migrateCorrespondenceUrl, migrateCorrespondenceExt);
+        Assert.False(response.IsSuccessStatusCode);
+    }
+
     private static void SetNotificationHistory(MigrateCorrespondenceExt migrateCorrespondenceExt)
     {
         migrateCorrespondenceExt.NotificationHistory =

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -561,7 +561,24 @@ public class MigrationControllerTests : MigrationTestBase
         Assert.NotNull(correspondence);
         Assert.True(correspondence.IsMigrating);
     }
-    
+
+    [Fact]
+    public async Task InitializeMigrateCorrespondence_EmptyTitle_Failsvalidation()
+    {
+        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
+            .CreateMigrateCorrespondence()
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Read, new DateTime(2024, 1, 6))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Archived, new DateTime(2024, 1, 7))
+            .WithMessageTitle(String.Empty)
+            .Build();
+
+        SetNotificationHistory(migrateCorrespondenceExt);
+
+        var initializeCorrespondenceResponse = await _migrationClient.PostAsJsonAsync(migrateCorrespondenceUrl, migrateCorrespondenceExt);
+        string result = await initializeCorrespondenceResponse.Content.ReadAsStringAsync();
+        Assert.False(initializeCorrespondenceResponse.IsSuccessStatusCode, result);
+    }
+
     private static void SetNotificationHistory(MigrateCorrespondenceExt migrateCorrespondenceExt)
     {
         migrateCorrespondenceExt.NotificationHistory =

--- a/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
@@ -25,97 +25,7 @@ public class CreateDialogRequestMapperTests
         Assert.Single(result.Content.Title.Value);
         Assert.Equal("Short title", result.Content.Title.Value[0].Value);
     }
-
-    [Fact]
-    public void CreateCorrespondenceDialog_WithTitleAt252Characters_PreservesTitle()
-    {
-        // Arrange
-        var title252 = new string('A', 252); // Exactly 252 characters
-        var correspondence = new CorrespondenceEntityBuilder()
-            .WithMessageTitle(title252)
-            .Build();
-        var baseUrl = "https://example.com";
-
-        // Act
-        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
-
-        // Assert
-        Assert.NotNull(result.Content);
-        Assert.NotNull(result.Content.Title);
-        Assert.Single(result.Content.Title.Value);
-        Assert.Equal(title252, result.Content.Title.Value[0].Value);
-        Assert.Equal(252, result.Content.Title.Value[0].Value.Length);
-    }
-
-    [Fact]
-    public void CreateCorrespondenceDialog_WithTitleAt255Characters_PreservesTitle()
-    {
-        // Arrange
-        var title255 = new string('A', 255); // 255 characters - should be preserved as-is
-        var correspondence = new CorrespondenceEntityBuilder()
-            .WithMessageTitle(title255)
-            .Build();
-        var baseUrl = "https://example.com";
-
-        // Act
-        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
-
-        // Assert
-        Assert.NotNull(result.Content);
-        Assert.NotNull(result.Content.Title);
-        Assert.Single(result.Content.Title.Value);
-        Assert.Equal(title255, result.Content.Title.Value[0].Value);
-        Assert.Equal(255, result.Content.Title.Value[0].Value.Length);
-    }
-
-    [Fact]
-    public void CreateCorrespondenceDialog_WithTitleAt256Characters_TruncatesTitle()
-    {
-        // Arrange
-        var title256 = new string('A', 256); // 256 characters - should be truncated (first length to exceed 255)
-        var correspondence = new CorrespondenceEntityBuilder()
-            .WithMessageTitle(title256)
-            .Build();
-        var baseUrl = "https://example.com";
-
-        // Act
-        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
-
-        // Assert
-        Assert.NotNull(result.Content);
-        Assert.NotNull(result.Content.Title);
-        Assert.Single(result.Content.Title.Value);
-
-        var resultTitle = result.Content.Title.Value[0].Value;
-        Assert.Equal(255, resultTitle.Length); // 252 + 3 for "..."
-        Assert.EndsWith("...", resultTitle);
-        Assert.StartsWith(new string('A', 252), resultTitle);
-    }
-
-    [Fact]
-    public void CreateCorrespondenceDialog_WithVeryLongTitle_TruncatesCorrectly()
-    {
-        // Arrange
-        var veryLongTitle = new string('A', 500); // Very long title - should be truncated to exactly 255
-        var correspondence = new CorrespondenceEntityBuilder()
-            .WithMessageTitle(veryLongTitle)
-            .Build();
-        var baseUrl = "https://example.com";
-
-        // Act
-        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl);
-
-        // Assert
-        Assert.NotNull(result.Content);
-        Assert.NotNull(result.Content.Title);
-        Assert.Single(result.Content.Title.Value);
-
-        var resultTitle = result.Content.Title.Value[0].Value;
-        Assert.Equal(255, resultTitle.Length); // Should be exactly 255 (252 + "...")
-        Assert.EndsWith("...", resultTitle);
-        Assert.StartsWith(new string('A', 252), resultTitle);
-    }
-
+    
     [Fact]
     public void CreateCorrespondenceDialog_WithNullTitle_HandlesGracefully()
     {
@@ -132,7 +42,7 @@ public class CreateDialogRequestMapperTests
         Assert.NotNull(result.Content);
         Assert.NotNull(result.Content.Title);
         Assert.Single(result.Content.Title.Value);
-        Assert.Equal("", result.Content.Title.Value[0].Value);
+        Assert.Equal("", result.Content.Title.Value[0].Value);  // The mapper will handle this gracefully, but DP will not accept empty titles, but this should not be possible to reach this point with null title
     }
 
     [Fact]
@@ -151,7 +61,7 @@ public class CreateDialogRequestMapperTests
         Assert.NotNull(result.Content);
         Assert.NotNull(result.Content.Title);
         Assert.Single(result.Content.Title.Value);
-        Assert.Equal("", result.Content.Title.Value[0].Value);
+        Assert.Equal("", result.Content.Title.Value[0].Value); // The mapper will handle this gracefully, but DP will not accept empty titles, but this should not be possible to reach this point with empty title
     }
 
     [Fact]

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -222,6 +222,11 @@ public class MigrateCorrespondenceHandler(
             return CorrespondenceErrors.MissingContent;
         }
 
+        if (string.IsNullOrWhiteSpace(content.MessageTitle))
+        {
+            return CorrespondenceErrors.MessageTitleEmpty;
+        }
+
         if (!IsLanguageValid(content.Language))
         {
             return CorrespondenceErrors.InvalidLanguage;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -110,7 +110,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 Value = new List<DialogValue> {
                     new DialogValue()
                     {
-                        Value = TruncateTitleForDialogporten(correspondence.Content!.MessageTitle ?? ""),
+                        Value = correspondence.Content!.MessageTitle ?? "", // A required field, DP will throw validation error if empty, but should not be possible to reach this point with empty title
                         LanguageCode = correspondence.Content.Language
                     }
                 }
@@ -470,22 +470,5 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 }
             }).ToList() ?? new List<Attachment>();
         }
-
-        /// <summary>
-        /// Truncates titles longer than 255 characters to 252 characters and adds "..." to fit within Dialogporten's 255 character limit.
-        /// Titles 255 characters or shorter are sent as-is to Dialogporten.
-        /// This serves as a safety net for existing correspondence with long titles that failed Dialog Porten creation,
-        /// allowing them to retry successfully. New correspondence requests are validated to prevent titles > 255 chars.
-        /// </summary>
-        /// <param name="title">The original title</param>
-        /// <returns>The title truncated to fit Dialogporten's requirements</returns>
-        private static string TruncateTitleForDialogporten(string title)
-        {
-            if (string.IsNullOrEmpty(title))
-                return title;
-
-            // Dialogporten has a 255 character limit, so we truncate to 252 and add "..." only for titles > 255 chars
-            return title.Length <= 255 ? title : title.Substring(0, 252) + "...";
-        }       
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogTransmissionMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogTransmissionMapper.cs
@@ -44,7 +44,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     new TransmissionValue
                     {
                         Value = correspondence.Content!.MessageTitle ?? "", // A required field, DP will throw validation error if empty, but should not be possible to reach this point with empty title
-                        LanguageCode = "nb",
+                        LanguageCode = correspondence.Content.Language,
                     }
                 }
             },

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogTransmissionMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogTransmissionMapper.cs
@@ -43,7 +43,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 {
                     new TransmissionValue
                     {
-                        Value = TruncateTitleForDialogporten(correspondence.Content!.MessageTitle ?? "Ingen tittel"),
+                        Value = correspondence.Content!.MessageTitle ?? "", // A required field, DP will throw validation error if empty, but should not be possible to reach this point with empty title
                         LanguageCode = "nb",
                     }
                 }
@@ -72,25 +72,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             }
             }
         };
-
-
-        /// <summary>
-        /// Truncates titles longer than 255 characters to 252 characters and adds "..." to fit within Dialogporten's 255 character limit.
-        /// Titles 255 characters or shorter are sent as-is to Dialogporten.
-        /// This serves as a safety net for existing correspondence with long titles that failed Dialog Porten creation,
-        /// allowing them to retry successfully.
-        /// </summary>
-        /// <param name="title">The original title</param>
-        /// <returns>The title truncated to fit Dialogporten's requirements</returns>
-        private static string TruncateTitleForDialogporten(string title)
-        {
-            if (string.IsNullOrEmpty(title))
-                return title;
-
-            // Dialogporten has a 255 character limit, so we truncate to 252 and add "..." only for titles > 255 chars
-            return title.Length <= 255 ? title : title.Substring(0, 252) + "...";
-        }
-
 
         private static List<TransmissionAttachment> GetAttachmentsForCorrespondence(string baseUrl, CorrespondenceEntity correspondence)
         {


### PR DESCRIPTION

## Description
Added validation for MessageTitle in MigrateCorrespondenceHandler to prevent empty MessageTitle being migrated.
This validation already exists for navitive Altinn 3 Correspondences.

In order to preserve Altinn 2 migrated data, Dialogporten has expanded from 255 to 512 characters for the Title and Summary fields.
As a result, I have removed truncation of MessageTitle => Title when creating Dialog and Transmission.
Since truncation was not set up for MessageSummary => Summary this would fail if a MessageSummary was larger than 255 characters.

## Related Issue(s)
- #1410 
- #1418 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Added validation to reject migrations with null, empty or whitespace-only message titles.
  - Stopped auto-truncating titles before sending to the external dialog service; titles are forwarded as provided and validated downstream.

- Tests
  - Added tests ensuring null/empty/whitespace titles fail migration validation.
  - Removed obsolete tests covering extreme title-length truncation; minor assertion cleanups applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->