### PR TITLE
Fix/increase timeout for krr calls

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingIntegrations/KRR/ContactReservationRegistryServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingIntegrations/KRR/ContactReservationRegistryServiceTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using Altinn.Correspondence.Integrations.Altinn.ContactReservationRegistry;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+namespace Altinn.Correspondence.Tests.KRR;
+
+public class ContactReservationRegistryServiceTests
+{
+    private readonly Mock<ILogger<ContactReservationRegistryService>> _mockLogger;
+    private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+    private readonly HttpClient _httpClient;
+    private readonly ContactReservationRegistryService _service;
+
+    public ContactReservationRegistryServiceTests()
+    {
+        _mockLogger = new Mock<ILogger<ContactReservationRegistryService>>();
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_mockHttpMessageHandler.Object)
+        {
+            BaseAddress = new Uri("https://example.com")
+        };
+        _service = new ContactReservationRegistryService(_httpClient, _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetReservedRecipients_WithTimeout_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var recipients = new List<string> { "12345678901" };
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(async (HttpRequestMessage request, CancellationToken cancellationToken) =>
+            {
+                // Simulate a delay longer than the 2-second timeout in order to get the correct exception message
+                await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => 
+            _service.GetReservedRecipients(recipients));
+        
+        Assert.Contains("Timeout while calling the KRR API", exception.Message);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Timeout while calling the KRR API after")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task GetReservedRecipients_WithinTimeLimit_ReturnsSuccess()
+    {
+        // Arrange
+        var recipients = new List<string> { "12345678901" };
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(async (HttpRequestMessage request, CancellationToken cancellationToken) =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+                var response = new ContactReservationPersonResponse
+                {
+                    Personer = new List<ContactReservationPerson>
+                    {
+                        new() { Personidentifikator = "12345678901", Reservasjon = "JA" }
+                    }
+                };
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(response))
+                };
+            });
+
+        // Act & Assert
+        var result = await _service.GetReservedRecipients(recipients);
+        
+        Assert.Equal(recipients, result);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error while calling the KRR API")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never());
+    }
+}


### PR DESCRIPTION
## Description
Increased the timeout for calls to KRR from 1 second to 2 seconds. Also added appropriate handling of timeouts by throwing a 504 Gateway Timeout with a relevant error message.

## Related Issue(s)
- #1414

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)