### PR TITLE
add default values for language and NotificationTemplate

### DIFF
--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceContentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceContentExt.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Text.Json.Serialization;
+using System.ComponentModel;
 
 namespace Altinn.Correspondence.API.Models
 {
@@ -14,8 +15,9 @@ namespace Altinn.Correspondence.API.Models
         /// Gets or sets the language of the correspondence, specified according to ISO 639-1 
         /// </summary>
         [JsonPropertyName("language")]
+        [DefaultValue("nb")]
         [ISO6391]
-        public required string Language { get; set; }
+        public string? Language { get; set; }
 
         /// <summary>
         /// Gets or sets the correspondence message title. Subject.

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
@@ -2,6 +2,7 @@
 using Altinn.Correspondence.Core.Models.Enums;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using System.ComponentModel;
 
 namespace Altinn.Correspondence.API.Models
 {
@@ -14,7 +15,8 @@ namespace Altinn.Correspondence.API.Models
         /// Which of the notification templates to use for this notification
         /// </summary>
         [JsonPropertyName("notificationTemplate")]
-        public required NotificationTemplateExt NotificationTemplate { get; set; }
+        [DefaultValue(NotificationTemplateExt.CustomMessage)]
+        public NotificationTemplateExt NotificationTemplate { get; set; }
 
         /// <summary>
         /// The emails subject for the main notification


### PR DESCRIPTION
## Description
Add default values for Language and NotificationTemplate. These values no longer require user input, while business logic does not allow these to be null. MessageSummary and Attachment.Sender have been updated prior to this PR.

## Related Issue(s)
- #1343 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)