### PR TITLE
Fixed duplicate external references for dialog

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/MigrateCorrespondenceExternalReferencesTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/MigrateCorrespondenceExternalReferencesTests.cs
@@ -1,0 +1,69 @@
+using Altinn.Correspondence.Application.MigrateCorrespondence;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Tests.Factories;
+using Altinn.Correspondence.Tests.Helpers;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Altinn.Correspondence.Tests.TestingFeature;
+
+public class MigrateCorrespondenceExternalReferencesTests
+{
+    [Fact]
+    public async Task MakeCorrespondenceAvailable_AddsSingleDialogportenExternalReference()
+    {
+        // Arrange
+        var mockDialogportenService = new Mock<Core.Services.IDialogportenService>();
+        mockDialogportenService
+            .Setup(x => x.CreateCorrespondenceDialogForMigratedCorrespondence(
+                It.IsAny<Guid>(),
+                It.IsAny<CorrespondenceEntity>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync("dialog-123");
+
+        var mockBackgroundJobClient = new Mock<IBackgroundJobClient>();
+        mockBackgroundJobClient
+            .Setup(x => x.Create(It.IsAny<Job>(), It.IsAny<IState>()))
+            .Returns(() => Guid.NewGuid().ToString());
+
+        using var factory = new UnitWebApplicationFactory((IServiceCollection services) =>
+        {
+            services.AddSingleton(mockDialogportenService.Object);
+            services.AddSingleton(mockBackgroundJobClient.Object);
+        });
+
+        using var scope = factory.Services.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<ICorrespondenceRepository>();
+        var handler = scope.ServiceProvider.GetRequiredService<MigrateCorrespondenceHandler>();
+
+        var entity = new CorrespondenceEntityBuilder()
+            .WithStatus(CorrespondenceStatus.Initialized)
+            .Build();
+
+        var created = await repository.CreateCorrespondence(entity, CancellationToken.None);
+
+        // Act
+        var dialogId = await handler.MakeCorrespondenceAvailableInDialogportenAndApi(created.Id, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("dialog-123", dialogId);
+
+        var persisted = await repository.GetCorrespondenceById(created.Id, true, true, false, CancellationToken.None);
+        Assert.NotNull(persisted);
+
+        var dialogRefs = persisted!.ExternalReferences
+            .Where(r => r.ReferenceType == ReferenceType.DialogportenDialogId)
+            .ToList();
+
+        Assert.Single(dialogRefs);
+        Assert.Equal("dialog-123", dialogRefs[0].ReferenceValue);
+    }
+}
+
+

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -198,7 +198,6 @@ public class MigrateCorrespondenceHandler(
         var updateResult = await TransactionWithRetriesPolicy.Execute<string>(async (cancellationToken) =>
         {
             await correspondenceRepository.AddExternalReference(correspondenceId, ReferenceType.DialogportenDialogId, dialogId);
-            correspondence.ExternalReferences.Add(new ExternalReferenceEntity() { ReferenceType = ReferenceType.DialogportenDialogId, ReferenceValue = dialogId });
             await SetIsMigrating(correspondenceId, false, cancellationToken);
             return dialogId;
         }, logger, cancellationToken);


### PR DESCRIPTION
## Description
Duplicate rows added to external references table because entity framework tracked changes.

To correct data
1. Determine extent:
```SELECT COUNT(DISTINCT "CorrespondenceId") as affected_correspondences
FROM (
    SELECT "CorrespondenceId"
    FROM "correspondence"."ExternalReferences"
    WHERE "ReferenceType" = 3
    GROUP BY "CorrespondenceId", "ReferenceType"
    HAVING COUNT(*) > 1
) duplicates;
```

2. Fix


```BEGIN;

-- Delete duplicates, keeping only the row with the smallest Id for each (CorrespondenceId, ReferenceType = 3) combination
DELETE FROM "correspondence"."ExternalReferences"
WHERE "Id" IN (
    SELECT "Id"
    FROM (
        SELECT 
            "Id",
            ROW_NUMBER() OVER (
                PARTITION BY "CorrespondenceId", "ReferenceType" 
                ORDER BY "Id"
            ) as rn
        FROM "correspondence"."ExternalReferences"
        WHERE "ReferenceType" = 3
    ) ranked
    WHERE rn > 1
);

-- Check how many rows would be deleted (run this before COMMIT to verify)
SELECT COUNT(*) as rows_to_delete
FROM (
    SELECT 
        "Id",
        ROW_NUMBER() OVER (
            PARTITION BY "CorrespondenceId", "ReferenceType" 
            ORDER BY "Id"
        ) as rn
    FROM "correspondence"."ExternalReferences"
    WHERE "ReferenceType" = 3
) ranked
WHERE rn > 1;

-- If everything looks good:
COMMIT;
-- If something looks wrong:
-- ROLLBACK;
```

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate external references during migration, ensuring the dialog ID is linked once and persisted reliably.
  * Improves stability when making correspondence available to external services.

* **Tests**
  * Added end-to-end coverage verifying migration returns the expected dialog ID and persists a single external reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->