### PR TITLE
Change to use URN prefix in event subject

### DIFF
--- a/src/Altinn.Correspondence.Core/Services/IEventBus.cs
+++ b/src/Altinn.Correspondence.Core/Services/IEventBus.cs
@@ -4,5 +4,5 @@ namespace Altinn.Correspondence.Core.Services;
 
 public interface IEventBus
 {
-    Task Publish(AltinnEventType type, string resourceId, string itemId, string eventSource, string? recipientId = null, CancellationToken cancellationToken = default);
+    Task Publish(AltinnEventType type, string resourceId, string itemId, string eventSource, string recipientId = null, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/Events/AltinnEventBus.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Events/AltinnEventBus.cs
@@ -16,17 +16,15 @@ public class AltinnEventBus : IEventBus
     private readonly GeneralSettings _generalSettings;
     private readonly HttpClient _httpClient;
     private readonly ILogger<AltinnEventBus> _logger;
-    private readonly IAltinnRegisterService _altinnRegisterService;
 
-    public AltinnEventBus(HttpClient httpClient, IAltinnRegisterService altinnRegisterService, IOptions<GeneralSettings> generalSettings, ILogger<AltinnEventBus> logger)
+    public AltinnEventBus(HttpClient httpClient, IOptions<GeneralSettings> generalSettings, ILogger<AltinnEventBus> logger)
     {
         _httpClient = httpClient;
         _generalSettings = generalSettings.Value;
-        _altinnRegisterService = altinnRegisterService;
         _logger = logger;
     }
 
-    public async Task Publish(AltinnEventType type, string resourceId, string itemId, string eventSource, string? party, CancellationToken cancellationToken = default)
+    public async Task Publish(AltinnEventType type, string resourceId, string itemId, string eventSource, string party, CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Publishing cloud event {type} for resource {resourceId} with event source {eventSource} and item ID {itemId}. Recipient is {recipient}.", type, resourceId, eventSource, itemId, party);
 
@@ -43,12 +41,8 @@ public class AltinnEventBus : IEventBus
         }
     }
 
-    private CloudEvent CreateCloudEvent(AltinnEventType type, string resourceId, string itemId, string? party, string eventSource)
+    private CloudEvent CreateCloudEvent(AltinnEventType type, string resourceId, string itemId, string party, string eventSource)
     {
-        if (party == null)
-        {
-            throw new ArgumentException("Either partyId or alternativeSubject must be set");
-        }
         var alternativeSubjectFormated = handleAlternativeSubject(party);
         CloudEvent cloudEvent = new CloudEvent()
         {


### PR DESCRIPTION
## Description
Change to use URN prefix in event subject for consistency with other publishers

## Related Issue(s)
- #1334 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event publishing now uses a "party" identifier instead of "recipientId"; callers must pass the new identifier.
  * Event metadata, logging, cloud event subject, and alternative-subject handling now derive from the party value.
  * Publish API nullability contract changed: recipient/party parameter is no longer nullable by contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->