### PR TITLE
Skip sending notifications for A2 correspondences from live-migration

### DIFF
--- a/src/Altinn.Correspondence.Application/SendNotificationOrder/SendNotificationOrderHandler.cs
+++ b/src/Altinn.Correspondence.Application/SendNotificationOrder/SendNotificationOrderHandler.cs
@@ -41,6 +41,11 @@ public class SendNotificationOrderHandler(
             logger.LogError("Correspondence not found for correspondence {CorrespondenceId} when sending notification orders", correspondenceId);
             throw new Exception($"The correspondence {correspondenceId} was not found");
         }
+        if (correspondence.Altinn2CorrespondenceId is not null)
+        {
+            logger.LogInformation("Correspondence {CorrespondenceId} is an Altinn 2 correspondence, skipping sending notification orders as they are sent from there", correspondenceId);
+            return;
+        }
 
         var allSuccessful = true;
         foreach (var notificationOrder in notificationOrders)


### PR DESCRIPTION
## Description
They ended up throwing exceptions before they would be sent anyway so no clean-up necessary, but Slack got noisy.

## Related Issue(s)
- #1412 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed notification order handling to prevent unnecessary notifications for specific correspondence types. The system now correctly skips notification generation in these cases, improving system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->