### PR TITLE
Prefix notification order sender references with corr-

### DIFF
--- a/src/Altinn.Correspondence.Application/CreateNotificationOrder/CreateNotificationOrderHandler.cs
+++ b/src/Altinn.Correspondence.Application/CreateNotificationOrder/CreateNotificationOrderHandler.cs
@@ -133,7 +133,7 @@ public class CreateNotificationOrderHandler(
         {
             var notificationOrder = new NotificationOrderRequestV2
             {
-                SendersReference = correspondence.SendersReference,
+                SendersReference = $"corr-{correspondence.SendersReference}",
                 RequestedSendTime = correspondence.RequestedPublishTime.UtcDateTime <= DateTime.UtcNow
                     ? DateTime.UtcNow.AddMinutes(5)
                     : correspondence.RequestedPublishTime.UtcDateTime.AddMinutes(5),
@@ -147,7 +147,7 @@ public class CreateNotificationOrderHandler(
                 [
                     new ReminderV2
                     {
-                        SendersReference = correspondence.SendersReference,
+                        SendersReference = $"corr-{correspondence.SendersReference}",
                         DelayDays = hostEnvironment.IsProduction() ? 7 : 1,
                         ConditionEndpoint = CreateConditionEndpoint(correspondence.Id.ToString())?.ToString(),
                         Recipient = CreateRecipientOrderV2FromRecipient(recipient, notificationRequest, contents.First(), correspondence, isReminder: true)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR prefixes sender references on the notification orders from correspondence with 'corr-'. This is usefull when searching for correspondence notifications in the notification database.

## Related Issue(s)
- #1480

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sender reference formatting in notification orders to ensure consistent identification across all notification communications and reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->