### PR TITLE
When using cursorCreated, it should take precedence over "to" filter 

### DIFF
--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -264,21 +264,15 @@ namespace Altinn.Correspondence.Persistence.Repositories
             
             if (cursorCreated.HasValue)
             {
-                if (cursorId.HasValue)
-                {
-                    query = query.Where(c => c.Created < cursorCreated.Value);
-                }
-                else
-                {
-                    query = query.Where(c => c.Created < cursorCreated.Value);
-                }
-            } else if (createdTo.HasValue)
+                query = query.Where(c => c.Created < cursorCreated.Value);
+            }
+            else if (createdTo.HasValue)
             {
                 query = query.Where(c => c.Created < createdTo.Value);
             }
             else
             {
-                query = query.Where(c => c.Created <= DateTimeOffset.UtcNow.AddMonths(-1));
+                throw new InvalidOperationException("Either cursorCreated or createdTo must be provided");
             }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and clarified migration paging logic: stricter boundary handling, simplified cursor comparisons, and clearer precedence between cursor and date bounds.
  * Added a guard to require a paging cursor or an upper date bound.
  * Preserves existing ordering and batch-size behavior while improving reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->