### PR TITLE
Fix broken test application workflow

### DIFF
--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -33,7 +33,7 @@ jobs:
           timeout 5m bash -c 'while !  docker ps | grep "(healthy)"; do sleep 1; done'
 
       - name: Install EF Core CLI
-        run: dotnet tool install --global dotnet-ef --version 9.0.x
+        run: dotnet tool install --global dotnet-ef --version 9.0.*
         shell: bash
         
       - name: Run migrations


### PR DESCRIPTION
## Description
Dotnet released a 10.0 version which caused our pipeline to fail due to our workflow using the most recent ef tools version leading to a mismatch between dotnet version and ef nuget. Tried updating to dotnet 10.0.x in the workflow but this caused other issues as our runtime version = 9.0.x.

For now the solution is to continue with ef-tools version 9.0.*
## Related Issue(s)
- #1515 1515

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->