### PR TITLE
add WithoutPrefix to ValidateDialogRecipientMatch

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -559,7 +559,7 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
     {
 
         CreateDialogRequest? dialog = await GetDialog(dialogId);
-        return dialog.Party == expectedRecipient;
+        return dialog.Party.WithoutPrefix() == expectedRecipient.WithoutPrefix();
     }
 
     public async Task<bool> DialogValidForTransmission(string dialogId, string transmissionResourceId, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Description
A mismatch between prefix (ex: 0192 or urn) would fail the transmission validation. Validate the recipient without prefix.

## Related Issue(s)
- #1537 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dialog recipient validation logic to correctly identify and match recipients regardless of prefix variations, improving the reliability of recipient matching in dialog transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->