### PR TITLE
Validate enum definition and made NotificationChannel required

### DIFF
--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
@@ -3,6 +3,7 @@ using Altinn.Correspondence.Core.Models.Enums;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using System.ComponentModel;
+using Altinn.Correspondence.API.ValidationAttributes;
 
 namespace Altinn.Correspondence.API.Models
 {

--- a/src/Altinn.Correspondence.API/ValidationAttributes/OptionalEnumAttribute.cs
+++ b/src/Altinn.Correspondence.API/ValidationAttributes/OptionalEnumAttribute.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace Altinn.Correspondence.API.Models;
+namespace Altinn.Correspondence.API.ValidationAttributes;
 
 public class OptionalEnumAttribute : ValidationAttribute
 {

--- a/src/Altinn.Correspondence.API/ValidationAttributes/RequiredEnumAttribute.cs
+++ b/src/Altinn.Correspondence.API/ValidationAttributes/RequiredEnumAttribute.cs
@@ -1,19 +1,17 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace Altinn.Correspondence.API.Models;
+namespace Altinn.Correspondence.API.ValidationAttributes;
 public class RequiredEnumAttribute : ValidationAttribute
 {
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         var fieldName = validationContext.DisplayName;
 
-        // Missing value
         if (value is null)
         {
             return new ValidationResult($"The {fieldName} field is required.");
         }
 
-        // Present but not a defined enum value
         if (!Enum.IsDefined(value.GetType(), value))
         {
             return new ValidationResult($"The {fieldName} field must be a defined value.");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NotificationChannel is currently not set as required and when null would default to the default enum value 0, which is Email. It is also missing validation for whether a numeric enum value maps to a defined value, e.g the value 50 would pass the validation because it is a valid enum even if not defined. This PR makes NotificationChannel required instead of defaulting to 0 and validates that the given enum value is a defined value.

## Related Issue(s)
- #1578 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional enum fields for correspondence notifications now accept empty/null values where appropriate.

* **Bug Fixes**
  * Improved validation and clearer error messages for notification settings, ensuring required fields are enforced and invalid enum values are reported more precisely.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->