### PR TITLE
Added validations for emailAndSms notification channel

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -92,6 +92,8 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>3017: Custom recipient with multiple recipients is not allowed</li>
         /// <li>3018: Custom recipient with multiple identifiers is not allowed</li>
         /// <li>3019: Custom recipient without identifier is not allowed</li>
+        /// <li>3024: Email body, subject and SMS body must be provided when sending email and SMS notifications</li>
+        /// <li>3025: Reminder email body, subject and SMS body must be provided when sending reminder email and SMS notifications</li>
         /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li>
         /// <li>4009: Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService</li>
         /// </ul></response>
@@ -205,6 +207,8 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>3017: Custom recipient with multiple recipients is not allowed</li>
         /// <li>3018: Custom recipient with multiple identifiers is not allowed</li>
         /// <li>3019: Custom recipient without identifier is not allowed</li>
+        /// <li>3024: Email body, subject and SMS body must be provided when sending email and SMS notifications</li>
+        /// <li>3025: Reminder email body, subject and SMS body must be provided when sending reminder email and SMS notifications</li>
         /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li>
         /// <li>4009: Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService</li>
         /// </ul></response>

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -101,6 +101,8 @@ public static class NotificationErrors
     public static Error NotificationDetailsNotFound = new Error(3021, "Cannot retrieve notification details from Altinn Notification API", HttpStatusCode.NotFound);
     public static Error OverrideRegisteredContactInformationRequiresCustomRecipients = new Error(3022, "OverrideRegisteredContactInformation flag can only be used when CustomRecipients is provided", HttpStatusCode.BadRequest);
     public static Error InvalidNotificationTemplate = new Error(3023, "Invalid notification template", HttpStatusCode.BadRequest);
+    public static Error MissingEmailAndSmsContent = new Error(3024, "Email body, subject and SMS body must be provided when sending email and SMS notifications", HttpStatusCode.BadRequest);
+    public static Error MissingEmailAndSmsReminderContent = new Error(3025, "Reminder email body, subject and SMS body must be provided when sending reminder email and SMS notifications", HttpStatusCode.BadRequest);
 }
 public static class AuthorizationErrors
 {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -170,6 +170,16 @@ namespace Altinn.Correspondence.Application.Helpers
             {
                 return NotificationErrors.MissingPreferredReminderChannel;
             }
+            if ((notification.NotificationChannel == NotificationChannel.EmailAndSms) &&
+                (string.IsNullOrEmpty(notification.EmailBody) || string.IsNullOrEmpty(notification.EmailSubject) || string.IsNullOrEmpty(notification.SmsBody)))
+            {
+                return NotificationErrors.MissingEmailAndSmsContent;
+            }
+            if ((reminderNotificationChannel == NotificationChannel.EmailAndSms) &&
+                notification.SendReminder && (string.IsNullOrEmpty(notification.ReminderEmailBody) || string.IsNullOrEmpty(notification.ReminderEmailSubject) || string.IsNullOrEmpty(notification.ReminderSmsBody)))
+            {
+                return NotificationErrors.MissingEmailAndSmsReminderContent;
+            }
             return null;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When sending a correspondence with EmailAndSms, emailBody, EmailSubject and SmsBody are required. However this validation was missing. This PR adds this missing validation.

## Related Issue(s)
- #1566 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)