### PR TITLE
Add handling of DeleteEvents for Migration

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
+++ b/Test/Altinn.Correspondence.Tests/Factories/MigrateCorrespondenceBuilder.cs
@@ -120,7 +120,7 @@ namespace Altinn.Correspondence.Tests.Factories
         }
 
         public MigrateCorrespondenceBuilder WithStatusEvent(MigrateCorrespondenceStatusExt status, DateTime occurred, Guid? userPartyUuid = null, Guid? userUuid = null)
-        {
+         {
             if (userPartyUuid == null)
             {
                 userPartyUuid = _defaultUserPartyUuid;

--- a/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Migration/MigrationControllerTests.cs
@@ -382,6 +382,30 @@ public class MigrationControllerTests : MigrationTestBase
     }
 
     [Fact]
+    public async Task MakeCorrespondenceAvailable_SoftDeleted_OnCall()
+    {
+        MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()
+            .CreateMigrateCorrespondence()
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Read, new DateTime(2024, 1, 12, 14, 20, 11))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Confirmed, new DateTime(2024, 1, 12, 14, 21, 05))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.Archived, new DateTime(2024, 1, 22, 09, 55, 20))
+            .WithStatusEvent(MigrateCorrespondenceStatusExt.SoftDeletedByRecipient, new DateTime(2024, 1, 25, 10, 00, 00))
+            .WithCreatedAt(new DateTime(2024, 1, 1, 03, 09, 21))
+            .WithRecipient("urn:altinn:person:identifier-no:29909898925")
+            .WithResourceId("skd-migratedcorrespondence-5229-1")
+            .Build();
+        SetNotificationHistory(migrateCorrespondenceExt);
+
+        migrateCorrespondenceExt.MakeAvailable = true;
+
+        var initializeCorrespondenceResponse = await _migrationClient.PostAsJsonAsync(migrateCorrespondenceUrl, migrateCorrespondenceExt);
+        string result = await initializeCorrespondenceResponse.Content.ReadAsStringAsync();
+        Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, result);
+        CorrespondenceMigrationStatusExt resultObj = JsonConvert.DeserializeObject<CorrespondenceMigrationStatusExt>(result);
+        Assert.NotNull(resultObj.DialogId);
+    }
+
+    [Fact]
     public async Task MakeCorrespondenceAvailable_OnCall_SelfIdentified_NotMadeAvailable()
     {
         MigrateCorrespondenceExt migrateCorrespondenceExt = new MigrateCorrespondenceBuilder()

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -47,6 +47,18 @@ public class MigrateCorrespondenceHandler(
         try
         {
             var correspondence = await correspondenceRepository.CreateCorrespondence(request.CorrespondenceEntity, cancellationToken);
+
+            // Save any delete events associated with the correspondence
+            if (request.DeleteEventEntities != null && request.DeleteEventEntities.Any())
+            {
+                foreach(var deleteEvent in request.DeleteEventEntities)
+                {
+                    deleteEvent.CorrespondenceId = correspondence.Id;
+                    deleteEvent.SyncedFromAltinn2 = DateTimeOffset.UtcNow;
+                    await correspondenceDeleteEventRepository.AddDeleteEvent(deleteEvent, cancellationToken);
+                }
+            }
+
             string dialogId = "";
             if (request.MakeAvailable)
             {

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceRequest.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceRequest.cs
@@ -8,4 +8,5 @@ public class MigrateCorrespondenceRequest
     public required CorrespondenceEntity CorrespondenceEntity { get; set; }
     public List<Guid> ExistingAttachments { get; set; }
     public bool MakeAvailable { get; set; } = false;
+    public List<CorrespondenceDeleteEventEntity> DeleteEventEntities { get; set;  } = new List<CorrespondenceDeleteEventEntity>();
 }


### PR DESCRIPTION
Added functionality to MigrateCorrespondence to handle migrated messages with Deletion events.

This is to support migration of messages that are soft deleted in A2, to prevent an issue where messages first softdeleted then restored were never migrated.

## Description
To fix an issue in the Migration process:
- Enduser Softdeletes a Correspondence
- Migration job skips softdeleted Correspondences
- User later Restores the Correspondence
- Migration job does not scan the old Correspondence
Hard deletes do not have this issue.
The migration job will be changed to migrate messages despite softdelete/restore status.
As a result we need to handle this corectly in inital migration and save the delete events to appropriate repository.

## Related Issue(s)
- https://github.com/Altinn/team-a2-infra-private/issues/50

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for migrating correspondence with delete event history, enabling soft-deleted correspondence to be made available through the migration process.

* **Tests**
  * Added test coverage for soft-deleted correspondence migration scenarios, including handling of restored and re-deleted correspondence during the migration workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->