### PR TITLE
Handle case where notification was never sent in CheckNotificationDelivery

### DIFF
--- a/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
+++ b/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
@@ -113,6 +113,11 @@ public class CheckNotificationDeliveryHandler(
             }
             
             logger.LogWarning("Notification {NotificationId} not yet sent", notificationId);
+            if (correspondence.StatusHasBeen(Core.Models.Enums.CorrespondenceStatus.Read))
+            {
+                logger.LogInformation("Correspondence has been read. Hence no notification was sent");
+                return true;
+            }
             throw new InvalidOperationException("Notification not yet sent. Throwing to retry.");
         }
         catch (Exception ex)


### PR DESCRIPTION
## Description
Handle case where notification was not sent because correspondence was read

## Related Issue(s)
- #1598

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification delivery handling to successfully complete when correspondence has already been read, even if notification delivery is pending, reducing unnecessary processing attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->