### PR TITLE
Fixed rendering-as-markdown of some legacy cases using HTML

### DIFF
--- a/src/Altinn.Correspondence.Application/Helpers/MessageBodyHelpers.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/MessageBodyHelpers.cs
@@ -12,7 +12,7 @@ public static class MessageBodyHelpers
         var html = TextValidation.ConvertToHtml(input); // Normalizes to html
         var config = new Config
         {
-            UnknownTags = Config.UnknownTagsOption.Drop, 
+            UnknownTags = Config.UnknownTagsOption.Bypass, 
             GithubFlavored = true, 
             RemoveComments = true,
             SmartHrefHandling = true,


### PR DESCRIPTION
## Description
Using bypass instead so that the content of unknown html tags is still processed (just without the tags themselves). This ensures that nested elements inside unsupported elements are still rendered properly as markdown.

## Related Issue(s)
- #1616 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTML-to-markdown conversion to preserve unknown HTML tags during processing instead of removing them, improving content fidelity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->