### PR TITLE
Increased email subject and email reminder subject max length from 128 to 512

### DIFF
--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs
@@ -21,11 +21,10 @@ namespace Altinn.Correspondence.API.Models
 
         /// <summary>
         /// The emails subject for the main notification.
-        /// Maximum length is 128 characters, this is recommended by the Altinn Notifications service,
-        /// to make sure the email subject is displayed correctly in the email client.
+        /// Maximum length is 512 characters.
         /// </summary>
         [JsonPropertyName("emailSubject")]
-        [StringLength(128, MinimumLength = 0)]
+        [StringLength(512, MinimumLength = 0)]
         public string? EmailSubject { get; set; }
 
         /// <summary>
@@ -60,11 +59,10 @@ namespace Altinn.Correspondence.API.Models
 
         /// <summary>
         /// The email subject to use for the reminder notification
-        /// Maximum length is 128 characters, this is recommended by the Altinn Notifications service,
-        /// to make sure the email subject is displayed correctly in the email client.
+        /// Maximum length is 512 characters.
         /// </summary>
         [JsonPropertyName("reminderEmailSubject")]
-        [StringLength(128, MinimumLength = 0)]
+        [StringLength(512, MinimumLength = 0)]
         public string? ReminderEmailSubject { get; set; }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was a request to increase the max limit for email subjects on notifications. This PR increases it from 128 to 512.

## Related Issue(s)
- #1636 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maximum email subject line character limits have been increased to 512 characters for both correspondence notifications and reminder emails, a significant increase from the previous 128-character limit. This enhancement allows users to compose longer, more detailed subject lines with greater context and information in their correspondence communications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->