### PR TITLE
Set content-disposition:inline for specified file-types

### DIFF
--- a/src/Altinn.Correspondence.API/Helpers/FileDownloadResponseHelper.cs
+++ b/src/Altinn.Correspondence.API/Helpers/FileDownloadResponseHelper.cs
@@ -1,0 +1,37 @@
+using Microsoft.Net.Http.Headers;
+using System.Net.Mime;
+
+namespace Altinn.Correspondence.API.Helpers;
+
+public static class FileDownloadResponseHelper
+{
+    public static string GetContentTypeFromFileName(string? fileName)
+    {
+        var extension = Path.GetExtension(fileName)?.ToLowerInvariant();
+        return extension switch
+        {
+            ".pdf" => "application/pdf",
+            ".png" => "image/png",
+            ".jpg" => "image/jpeg",
+            ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".bmp" => "image/bmp",
+            ".txt" => "text/plain; charset=utf-8",
+            ".csv" => "text/csv; charset=utf-8",
+            ".json" => "application/json",
+            ".xml" => "application/xml",
+            ".html" => "text/html; charset=utf-8",
+            _ => MediaTypeNames.Application.Octet
+        };
+    }
+
+    public static void SetInlineContentDisposition(HttpResponse response, string fileName)
+    {
+        var contentDisposition = new ContentDispositionHeaderValue("inline")
+        {
+            FileNameStar = fileName
+        };
+
+        response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+    }
+}

--- a/src/Altinn.Correspondence.Application/ApplicationConstants.cs
+++ b/src/Altinn.Correspondence.Application/ApplicationConstants.cs
@@ -23,6 +23,19 @@ public static class ApplicationConstants
         ".json",
         ".csv"
     ];
+
+    /// <summary>
+    /// File types that may be served with Content-Disposition: inline, allowing the browser to render them.
+    /// </summary>
+    public static readonly List<string> InlineFileTypes =
+    [
+        ".pdf",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".bmp"
+    ];
     public static readonly List<string> RequiredOrganizationRolesForCorrespondenceRecipient = 
     [
         "bestyrende-reder",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently when downloading attachments with filetypes like pdf they are not automatic opened in browser. Having the attachment be opened in browser when downloaded would improve user experience especially for mobile users. This PR adds content-disposition:inline when downloading attachments for filetypes that are sensible to be open in browser.

## Related Issue(s)
- #1632 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inline preview support for attachments: PDFs and images in correspondence attachments now display in the browser instead of downloading, allowing for quick preview without interrupting workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->