### PR TITLE
Support Dialog tokens generated by system user

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogTokenXacmlMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogTokenXacmlMapper.cs
@@ -1,5 +1,6 @@
 ﻿using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Altinn.Common.PEP.Constants;
 using Altinn.Common.PEP.Helpers;
 using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Common.Helpers;
@@ -97,6 +98,12 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 {
                     list.Add(CreateXacmlJsonAttribute(UrnConstants.PersonIdAttribute, claim.Value.WithoutPrefix(), DefaultType, claim.Issuer));
                 }
+                else if (IsSystemUserClaim(claim.Type))
+                {
+                    list = new List<XacmlJsonAttribute>();
+                    list.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.SystemUserUuid, claim.Value.WithoutPrefix(), DefaultType, claim.Issuer));
+                    break;
+                }
             }
             xacmlJsonCategory.Attribute = list;
             return xacmlJsonCategory;
@@ -120,6 +127,11 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
         private static bool IsJtiClaim(string value)
         {
             return value.Equals("jti");
+        }
+
+        private static bool IsSystemUserClaim(string value)
+        {
+            return value.Equals("y");
         }
 
         public static bool ValidateDialogportenResult(XacmlJsonResponse response, ClaimsPrincipal user)


### PR DESCRIPTION
## Description
DialogTokens generated by system user has a system user claim that needs to be added to our PDP call.

## Related Issue(s)
- #1676 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for system user identification in the Dialogporten integration. System users are now properly recognized during subject creation, with system user attributes taking precedence over previously accumulated attributes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->