### PR TITLE
Improve performance of report generation by excluding old data from scanning

### DIFF
--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -474,7 +474,7 @@ namespace Altinn.Correspondence.Persistence.Repositories
             {
                 query = query
                     .Where(c => c.Altinn2CorrespondenceId == null)
-                    .Where(c => c.Created > new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)); // Performance optimization to avoid scanning old data
+                    .Where(c => c.Created > new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)); 
             }
 
             // Get all correspondence data needed for detailed statistics including ServiceOwnerId and AltinnVersion info


### PR DESCRIPTION
## Description
Should make it somewhat faster. In time we should offload this to a background job that fills up statistics tables asynchronously.

## Related Issue(s)
- #1682

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated correspondence report filtering: when legacy (Altinn2) items are excluded, results now also omit entries created before January 1, 2025, ensuring reports only include recent applicable correspondences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->