### PR TITLE
Fix Email normalization in dialogportenText instead

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -233,12 +233,10 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             var textType = notification.IsReminder ? DialogportenTextType.NotificationReminderSent : DialogportenTextType.NotificationSent;
 
             
-            string[] tokensNO = [];
-            string[] tokensEN = [];
+            string[] tokens = [];
             if (notification.NotificationAddress != null)
             {
-                tokensNO = [notification.NotificationAddress, notification.NotificationChannel == NotificationChannel.Email ? "e-post" : "SMS"];
-                tokensEN = [notification.NotificationAddress, notification.NotificationChannel == NotificationChannel.Email ? "Email" : "SMS"];
+                tokens = [notification.NotificationAddress, notification.NotificationChannel == NotificationChannel.Email ? "Email" : "SMS"];
             }
 
             activity.Description =
@@ -246,17 +244,17 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 new ()
                 {
                     LanguageCode = "nb",
-                    Value = DialogportenText.GetDialogportenText(textType, Enums.DialogportenLanguageCode.NB, tokensNO)
+                    Value = DialogportenText.GetDialogportenText(textType, Enums.DialogportenLanguageCode.NB, tokens)
                 },
                 new ()
                 {
                     LanguageCode = "nn",
-                    Value = DialogportenText.GetDialogportenText(textType, Enums.DialogportenLanguageCode.NN, tokensNO)
+                    Value = DialogportenText.GetDialogportenText(textType, Enums.DialogportenLanguageCode.NN, tokens)
                 },
                 new ()
                 {
                     LanguageCode = "en",
-                    Value = DialogportenText.GetDialogportenText(textType, Enums.DialogportenLanguageCode.EN, tokensEN)
+                    Value = DialogportenText.GetDialogportenText(textType, Enums.DialogportenLanguageCode.EN, tokens)
                 },
             ];
 

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Correspondence.Core.Services.Enums;
+using Altinn.Correspondence.Core.Services.Enums;
 using Altinn.Correspondence.Integrations.Dialogporten.Enums;
 
 namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
@@ -6,13 +6,18 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
     public static class DialogportenText
     {
-        public static string GetDialogportenText(DialogportenTextType type, DialogportenLanguageCode languageCode, params string[] tokens) => languageCode switch
+        public static string GetDialogportenText(DialogportenTextType type, DialogportenLanguageCode languageCode, params string[] tokens)
         {
-            DialogportenLanguageCode.NB => GetNBText(type, tokens),
-            DialogportenLanguageCode.NN => GetNNText(type, tokens),
-            DialogportenLanguageCode.EN => GetENText(type, tokens),
-            _ => throw new ArgumentException("Invalid language code")
-        };
+            var normalizedTokens = NormalizeTokens(type, languageCode, tokens);
+
+            return languageCode switch
+            {
+                DialogportenLanguageCode.NB => GetNBText(type, normalizedTokens),
+                DialogportenLanguageCode.NN => GetNNText(type, normalizedTokens),
+                DialogportenLanguageCode.EN => GetENText(type, normalizedTokens),
+                _ => throw new ArgumentException("Invalid language code")
+            };
+        }
 
         private static string GetNBText(DialogportenTextType type, params string[] tokens) => type switch
         {
@@ -49,5 +54,41 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             DialogportenTextType.CorrespondenceConfirmed => "Message confirmed.",
             _ => throw new ArgumentException("Invalid text type")
         };
+
+        private static string[] NormalizeTokens(DialogportenTextType type, DialogportenLanguageCode languageCode, string[] tokens)
+        {
+            if (type is not (DialogportenTextType.NotificationSent or DialogportenTextType.NotificationReminderSent) || tokens.Length < 2)
+            {
+                return tokens;
+            }
+
+            var destination = tokens[0];
+            var channel = NormalizeNotificationChannel(channel: tokens[1], languageCode);
+            return [destination, channel];
+        }
+
+        private static string NormalizeNotificationChannel(string channel, DialogportenLanguageCode languageCode)
+        {
+            var isEmail =
+                string.Equals(channel, "Email", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(channel, "e-post", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(channel, "epost", StringComparison.OrdinalIgnoreCase);
+
+            if (isEmail)
+            {
+                return languageCode == DialogportenLanguageCode.EN ? "Email" : "e-post";
+            }
+
+            var isSms =
+                string.Equals(channel, "Sms", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(channel, "SMS", StringComparison.OrdinalIgnoreCase);
+
+            if (isSms)
+            {
+                return "SMS";
+            }
+
+            return channel;
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I only normalized email to e-post in norwiegan in one class in a previous PR, but the text was used from two places. This PR makes it so the tokens are normalized in the DialogportenText class instead so Email text is normalized for all paths and with the normalization code in one place.

## Related Issue(s)
- #1479 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced notification message handling for improved consistency across supported languages and communication channels (Email/SMS).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->