### PR TITLE
Map correct mediatype for transmission attachments

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -437,7 +437,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             return correspondence.Content?.Attachments.Select((correspondenceAttachment, index) =>
             {
                 var attachmentFileName = correspondenceAttachment?.Attachment?.FileName;
-                var mediaType = GetDialogportenAttachmentMediaTypeForFileName(attachmentFileName);
+                var mediaType = DialogportenAttachmentMediaTypeMapper.GetDialogportenAttachmentMediaTypeForFileName(attachmentFileName);
 
                 var attachment = new Attachment
                 {
@@ -468,40 +468,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
                 return attachment;
             }).ToList() ?? new List<Attachment>();
-        }
-
-        private static string? GetDialogportenAttachmentMediaTypeForFileName(string? fileName)
-        {
-            if (string.IsNullOrWhiteSpace(fileName))
-            {
-                return null;
-            }
-
-            var ext = Path.GetExtension(fileName)?.ToLowerInvariant();
-            return ext switch
-            {
-                ".pdf" => "application/pdf",
-                ".xml" => "application/xml",
-                ".html" => "text/html",
-                ".json" => "application/json",
-                ".jpg" => "image/jpeg",
-                ".png" => "image/png",
-                ".csv" => "text/csv",
-                ".txt" => "text/plain",
-                ".zip" => "application/zip",
-                ".doc" => "application/msword",
-                ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                ".xls" => "application/vnd.ms-excel",
-                ".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-
-                // Supported by correspondence, but not in Dialogporten's attachment media type list
-                ".ppt" => "PPT",
-                ".pps" => "PPS",
-                ".gif" => "GIF",
-                ".bmp" => "BMP",
-
-                _ => null
-            };
         }
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogTransmissionMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogTransmissionMapper.cs
@@ -97,6 +97,9 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             var baseTimestamp = DateTimeOffset.UtcNow;
             return correspondence.Content?.Attachments.Select((correspondenceAttachment, index) =>
             {
+                var attachmentFileName = correspondenceAttachment?.Attachment?.FileName;
+                var mediaType = DialogportenAttachmentMediaTypeMapper.GetDialogportenAttachmentMediaTypeForFileName(attachmentFileName);
+
                 var transmissionAttachment = new TransmissionAttachment
                 {
                     Id = Guid.CreateVersion7(baseTimestamp.AddMilliseconds(index)).ToString(),
@@ -113,7 +116,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                         new TransmissionUrl
                         {
                             ConsumerType = "Gui",
-                            MediaType = "application/vnd.dialogporten.frontchannelembed-url;type=text/markdown",
+                            MediaType = mediaType,
                             Url = GetDownloadAttachmentEndpoint(baseUrl, correspondence.Id, correspondenceAttachment.AttachmentId)
                         }
                     }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenAttachmentMediaTypeMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenAttachmentMediaTypeMapper.cs
@@ -1,0 +1,39 @@
+namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers;
+
+internal static class DialogportenAttachmentMediaTypeMapper
+{
+    internal static string? GetDialogportenAttachmentMediaTypeForFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        var ext = Path.GetExtension(fileName)?.ToLowerInvariant();
+        return ext switch
+        {
+            ".pdf" => "application/pdf",
+            ".xml" => "application/xml",
+            ".html" => "text/html",
+            ".json" => "application/json",
+            ".jpg" => "image/jpeg",
+            ".png" => "image/png",
+            ".csv" => "text/csv",
+            ".txt" => "text/plain",
+            ".zip" => "application/zip",
+            ".doc" => "application/msword",
+            ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ".xls" => "application/vnd.ms-excel",
+            ".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+
+            // Supported by correspondence, but not in Dialogporten's attachment media type list
+            ".ppt" => "PPT",
+            ".pps" => "PPS",
+            ".gif" => "GIF",
+            ".bmp" => "BMP",
+
+            _ => null
+        };
+    }
+}
+

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Models/CreateTransmissionRequest.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Models/CreateTransmissionRequest.cs
@@ -122,7 +122,8 @@ public class TransmissionAttachment
         public string Url { get; set; }
 
         [JsonPropertyName("mediaType")]
-        public string MediaType { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? MediaType { get; set; }
 
         [JsonPropertyName("consumerType")]
         public string ConsumerType { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tranmsission attachments did not map to the correct mediatype value. This PR adds the same mediatype mapping to tranmission attachments as is used for dialog attachments.

## Related Issue(s)
- #1696 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced attachment handling in Dialogporten integration by automatically determining media types based on file extensions, ensuring more accurate attachment processing.
  * Made attachment media type optional in transmission requests, allowing for more flexible data handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->