### PR TITLE
Also schedule continuation jobs on the migration queue to avoid it affecting A3 operations

### DIFF
--- a/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
@@ -5,6 +5,7 @@ using Altinn.Correspondence.Core.Models.Notifications;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
+using Altinn.Correspondence.Integrations.Hangfire;
 using Hangfire;
 using Microsoft.Extensions.Logging;
 
@@ -18,7 +19,7 @@ namespace Altinn.Correspondence.Application.Helpers
 
         public void SchedulePublishAfterDialogCreated(Guid correspondenceId, string dialogJobId, CancellationToken cancellationToken)
         {
-            backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(dialogJobId, (helper) => helper.SchedulePublishAtPublishTime(correspondenceId, cancellationToken));
+            backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(dialogJobId, HangfireQueues.LiveMigration, (helper) => helper.SchedulePublishAtPublishTime(correspondenceId, cancellationToken));
         }
 
         public async Task SchedulePublishAfterDialogCreated(Guid correspondenceId, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description
When correspondences are live-migrated we first schedule a dialog creation job on the migration queue and then schedule a continuation job to publish it. This continuation job was scheduled on default queue leading to competing with normal A3 operations on default queue. This leads to delayed publishes which especially affects use case tests.

## Related Issue(s)
- #1637 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved background job routing to ensure dialog-related processing tasks are directed to the appropriate processing queue for more reliable execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->