### PR TITLE
Always allow backtick in title, summary and body

### DIFF
--- a/src/Altinn.Correspondence.Common/Helpers/TextValidation.cs
+++ b/src/Altinn.Correspondence.Common/Helpers/TextValidation.cs
@@ -29,10 +29,6 @@ public class TextValidation
 
     public static bool ValidateMarkdown(string markdown)
     {
-        // Ignore backticks in the comparison so backticks are always accepted. 
-        // This is to make the validation consistent with how we allow ambiguous use of * and _ in markdown. 
-        // E.g lenient markdown validation.
-        var normalizedMarkdown = markdown.Replace("`", "");
         var config = new ReverseMarkdown.Config
         {
             CleanupUnnecessarySpaces = false,
@@ -40,14 +36,16 @@ public class TextValidation
         };
         var converter = new ReverseMarkdown.Converter(config);
         // change all codeblocks to <code> to keep html content in codeblocks
-        var markdownWithCodeBlocks = ReplaceMarkdownCodeWithHtmlCode(normalizedMarkdown);
+        var markdownWithCodeBlocks = ReplaceMarkdownCodeWithHtmlCode(markdown);
         string result = converter.Convert(markdownWithCodeBlocks);
 
         // needs to decode the text twice as some encoded characters contains encoded characters, such as emdash &#8212;
-        var text = WebUtility.HtmlDecode(WebUtility.HtmlDecode(normalizedMarkdown));
+        var text = WebUtility.HtmlDecode(WebUtility.HtmlDecode(markdown));
         result = WebUtility.HtmlDecode(WebUtility.HtmlDecode(result));
 
-        return ReplaceWhitespaceAndEscapeCharacters(text) == ReplaceWhitespaceAndEscapeCharacters(result);
+        // Ignore backticks in the comparison so backticks are always accepted. 
+        // This is to make the validation consistent with how we allow ambiguous use of * and _ in markdown (lenient markdown validation).
+        return ReplaceWhitespaceAndEscapeCharacters(text.Replace("`", "")) == ReplaceWhitespaceAndEscapeCharacters(result.Replace("`", ""));
     }
 
     public static string ReplaceWhitespaceAndEscapeCharacters(string text)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Dialogporten does not support numerical entities in the plain text fields like summary and title. Currently our validation for the title and summary does not allow backticks in some cases because it is annotation for text as code in markdown. This is problematic because users have no way of using backticks in the title as normal backticks are not allowed since its used for markdown and numerical entities are not rendered as symbols in plain text.

This PR filters backticks from the plain text validation so its always allowed

For our markdown validation we allow ambigous use of * and _, but we do not allow ambigous backticks. Backticks must be correctly used as text for code anotation. To have a consistently lenient markdown validation this PR also makes it so bakcticks are always allowed in the markdown validation, e.g ambigous backticks in the body don't give bad request.

## Related Issue(s)
- #1701 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text validation to consistently handle content with backticks by normalizing and ignoring backticks during comparison, preventing spurious validation failures and making validation of plaintext and markdown more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->