### PR TITLE
Handle deleted dialogs when checking for activity

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -272,7 +272,12 @@ public class DialogportenService(HttpClient _httpClient, ICorrespondenceReposito
             throw new ArgumentException($"No dialog found on correspondence with id {correspondenceId}");
         }
 
-        var dialog = await GetDialog(dialogId);
+        CreateDialogRequest? dialog = null;
+        try {
+            dialog = await GetDialog(dialogId);
+        } catch (DialogNotFoundException) {
+            return true; // Dialog not found, skipping.
+        }
         if (dialog.Activities is null || dialog.Activities.Count == 0)
         {
             return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The batch repair job to correct missing notification activities failed because some of the repair candidates has deleted dialogs. This caused an exception. This PR handles deleted dialogs by skipping them in the job.

## Related Issue(s)
- #1629 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the dialog verification process in the Dialogporten integration to gracefully handle scenarios where dialogs may be unavailable or missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->