### PR TITLE
Fixed some issues with idporten issued si-user token handling

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Idporten/IdPortenXacmlMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Idporten/IdPortenXacmlMapper.cs
@@ -50,6 +50,10 @@ namespace Altinn.Correspondence.Integrations.Idporten
                         {
                             return minimumAuthLevel <= 2;
                         }
+                        else if (userAuthLevelClaim.Value == "selfregistered-email")
+                        {
+                            return minimumAuthLevel <= 0;
+                        }
                         else
                         {
                             return false;
@@ -131,6 +135,10 @@ namespace Altinn.Correspondence.Integrations.Idporten
                 return CreateSubjectCategoryFromPid(pidClaim);
             }
             var emailClaim = user.Claims.FirstOrDefault(claim => claim.Type == "email");
+            if (emailClaim is null)
+            {
+                emailClaim = user.Claims.FirstOrDefault(claim => claim.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier");
+            }
             if (emailClaim is null)
             {
                 throw new SecurityTokenException("Idporten token does not contain the required pid or email claim");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Was missing selfregistered-email case when validating idporten authorization response. Also the email claim has the type 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier' and not 'email' like in the example response from the documentation ([Idporten SI doc](https://docs.digdir.no/docs/idporten/oidc/oidc_func_emaillogin.html)). This should fix it so attachments can be downloaded from AF.

## Related Issue(s)
- #1686 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended authentication method support to include selfregistered-email authentication with appropriate security level requirements

* **Bug Fixes**
  * Improved subject identification robustness with fallback logic to alternate identifiers when email claim is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->