### PR TITLE
Made it so report is only sendt if the run usecase-tests step fails

### DIFF
--- a/Test/Altinn.Correspondence.UseCaseTests/case_initialize_correspondence.js
+++ b/Test/Altinn.Correspondence.UseCaseTests/case_initialize_correspondence.js
@@ -28,7 +28,6 @@ export const options = {
  */
 export default async function () {
     try {
-        throw new Error('Intentional failure for testing use case test step');
         const { correspondenceId, attachmentId } = await TC01_InitializeCorrespondenceWithAttachment();
         await TC02_GetCorrespondencePublishedAsRecipient(correspondenceId);
         await TC03_GetAttachmentOverviewAsSender(attachmentId);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We should only report test failure if the usecase-test step ran and failed. This is better than potentially falsly reporting that the api is down when the test did not run, because the checkout step failed. This pr makes it so the report is only sendt if the run usecase tests step failed.

## Related Issue(s)
- #1735 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced failure handling for test workflow steps to improve reliability of failure detection and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->