### PR TITLE
Fix backup image publishing in CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -40,6 +40,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           dockerImageBaseName: ghcr.io/altinn/altinn-correspondence
           imageTag: ${{ needs.get-version.outputs.imageTag }}
+      - name: "Publish backup image"
+        uses: ./.github/actions/publish-image
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dockerImageBaseName: ghcr.io/altinn/altinn-correspondence-backup
+          imageTag: ${{ needs.get-version.outputs.imageTag }}
+          dockerfile: .azure/applications/backup/Dockerfile
+          context: .azure/applications/backup
 
   deploy-test:
     name: Internal test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Related Issue(s)
- #1714 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to publish an additional backup Docker image during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->