### PR TITLE
Truncate long attachment names in DownloadStarted activity

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingUtility/DialogportenTextTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/DialogportenTextTests.cs
@@ -1,0 +1,56 @@
+using Altinn.Correspondence.Core.Services.Enums;
+using Altinn.Correspondence.Integrations.Dialogporten.Enums;
+using Altinn.Correspondence.Integrations.Dialogporten.Mappers;
+
+namespace Altinn.Correspondence.Tests.TestingUtility;
+
+public class DialogportenTextTests
+{
+    [Fact]
+    public void GetDialogportenText_DownloadStarted_WithLongFileName_TruncatesToSupportedLength()
+    {
+        // 221 + 4 extension = 225, which previously produced a 256-char EN message.
+        var fileName = new string('a', 221) + ".pdf";
+
+        var nbText = DialogportenText.GetDialogportenText(
+            DialogportenTextType.DownloadStarted,
+            DialogportenLanguageCode.NB,
+            fileName);
+        var enText = DialogportenText.GetDialogportenText(
+            DialogportenTextType.DownloadStarted,
+            DialogportenLanguageCode.EN,
+            fileName);
+
+        Assert.True(nbText.Length <= 255, $"Expected NB text length <= 255, got {nbText.Length}");
+        Assert.True(enText.Length <= 255, $"Expected EN text length <= 255, got {enText.Length}");
+        Assert.Contains("....pdf", enText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetDialogportenText_DownloadStarted_WithLongFileName_KeepsExtension()
+    {
+        var fileName = new string('b', 260) + ".docx";
+
+        var enText = DialogportenText.GetDialogportenText(
+            DialogportenTextType.DownloadStarted,
+            DialogportenLanguageCode.EN,
+            fileName);
+
+        Assert.EndsWith(".docx", enText, StringComparison.Ordinal);
+        Assert.Contains("...", enText, StringComparison.Ordinal);
+        Assert.True(enText.Length <= 255, $"Expected EN text length <= 255, got {enText.Length}");
+    }
+
+    [Fact]
+    public void GetDialogportenText_DownloadStarted_WithShortFileName_DoesNotChangeValue()
+    {
+        const string fileName = "document-22.04.2026.pdf";
+
+        var nbText = DialogportenText.GetDialogportenText(
+            DialogportenTextType.DownloadStarted,
+            DialogportenLanguageCode.NB,
+            fileName);
+
+        Assert.Equal("Startet nedlastning av vedlegg document-22.04.2026.pdf", nbText);
+    }
+}

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/DialogportenText.cs
@@ -6,6 +6,10 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
     public static class DialogportenText
     {
+        private const int MaxActivityDescriptionLength = 255;
+        private const string DownloadStartedNbPrefix = "Startet nedlastning av vedlegg ";
+        private const string DownloadStartedEnPrefix = "Started downloading attachment ";
+
         public static string GetDialogportenText(DialogportenTextType type, DialogportenLanguageCode languageCode, params string[] tokens)
         {
             var normalizedTokens = NormalizeTokens(type, languageCode, tokens);
@@ -66,6 +70,11 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
         private static string[] NormalizeTokens(DialogportenTextType type, DialogportenLanguageCode languageCode, string[] tokens)
         {
+            if (type == DialogportenTextType.DownloadStarted && tokens.Length >= 1)
+            {
+                return NormalizeDownloadStartedTokens(tokens);
+            }
+
             if (type is not (DialogportenTextType.NotificationSent or DialogportenTextType.NotificationReminderSent) || tokens.Length < 2)
             {
                 return tokens;
@@ -74,6 +83,48 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             var destination = tokens[0];
             var channel = NormalizeNotificationChannel(channel: tokens[1], languageCode);
             return [destination, channel];
+        }
+
+        private static string[] NormalizeDownloadStartedTokens(string[] tokens)
+        {
+            var normalized = (string[])tokens.Clone();
+            var maxPrefixLength = Math.Max(DownloadStartedNbPrefix.Length, DownloadStartedEnPrefix.Length);
+            var maxFileNameLength = MaxActivityDescriptionLength - maxPrefixLength;
+            normalized[0] = TruncateFileNameKeepingExtension(normalized[0], maxFileNameLength);
+            return normalized;
+        }
+
+        private static string TruncateFileNameKeepingExtension(string? fileName, int maxLength)
+        {
+            var value = fileName ?? string.Empty;
+            if (value.Length <= maxLength)
+            {
+                return value;
+            }
+
+            if (maxLength <= 3)
+            {
+                return value[..maxLength];
+            }
+
+            var dotIndex = value.LastIndexOf('.');
+            var hasExtension = dotIndex > 0 && dotIndex < value.Length - 1;
+
+            if (!hasExtension)
+            {
+                return value[..(maxLength - 3)] + "...";
+            }
+
+            var extension = value[dotIndex..];
+            var baseNameMaxLength = maxLength - extension.Length - 3;
+
+            if (baseNameMaxLength <= 0)
+            {
+                return value[..(maxLength - 3)] + "...";
+            }
+
+            var baseNameLength = Math.Min(baseNameMaxLength, dotIndex);
+            return value[..baseNameLength] + "..." + extension;
         }
 
         private static string NormalizeNotificationChannel(string channel, DialogportenLanguageCode languageCode)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a Dialogporten 400 BadRequest caused by DownloadStarted activity descriptions exceeding the 255 character limit for long attachment names.

This change truncates long attachment names before building the activity text, while preserving the file extension where possible, and adds tests for the new behavior.

## Related Issue(s)
- #1797 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced filename handling in download notifications to properly truncate long filenames while preserving file extensions, ensuring text remains within character limits.
  * Improved multilingual support for text truncation with consistent formatting across languages.

* **Tests**
  * Added comprehensive test coverage validating filename truncation behavior, extension preservation, and language-specific text generation for various file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->