### PR TITLE
show sendername in confidential reminder

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
@@ -2,9 +2,9 @@ using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.GetUnreadConfidentialCorrespondences;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Tests.Factories;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Moq;
 using System.Security.Claims;
 
@@ -14,6 +14,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
 {
     private readonly Mock<ICorrespondenceRepository> _correspondenceRepositoryMock;
     private readonly Mock<IAltinnAuthorizationService> _altinnAuthorizationServiceMock;
+    private readonly Mock<IAltinnRegisterService> _altinnRegisterServiceMock;
     private readonly Mock<IHostEnvironment> _hostEnvironmentMock;
     private readonly GetUnreadConfidentialCorrespondencesHandler _handler;
 
@@ -21,12 +22,14 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
     {
         _correspondenceRepositoryMock = new Mock<ICorrespondenceRepository>();
         _altinnAuthorizationServiceMock = new Mock<IAltinnAuthorizationService>();
+        _altinnRegisterServiceMock = new Mock<IAltinnRegisterService>();
         _hostEnvironmentMock = new Mock<IHostEnvironment>();
         _hostEnvironmentMock.Setup(x => x.EnvironmentName).Returns("Development");
 
         _handler = new GetUnreadConfidentialCorrespondencesHandler(
             _correspondenceRepositoryMock.Object,
             _altinnAuthorizationServiceMock.Object,
+            _altinnRegisterServiceMock.Object,
             _hostEnvironmentMock.Object);
     }
 

--- a/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
@@ -49,10 +49,25 @@ public class GetUnreadConfidentialCorrespondencesHandler(
 
     var sortedCorrespondences = correspondences.OrderBy(c => c.Published).ToList();
     var senderNames = await Task.WhenAll(
-        sortedCorrespondences.Select(c =>
-            !string.IsNullOrWhiteSpace(c.MessageSender)
-                ? Task.FromResult<string?>(c.MessageSender)
-                : altinnRegisterService.LookUpName(c.Sender.WithoutPrefix(), cancellationToken))
+        sortedCorrespondences.Select(async c =>
+        {
+            if (!string.IsNullOrWhiteSpace(c.MessageSender))
+            {
+                return c.MessageSender;
+            }
+            try
+            {
+                return await altinnRegisterService.LookUpName(c.Sender.WithoutPrefix(), cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                return null;
+            }
+        })
     );
 
     var lines = sortedCorrespondences

--- a/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
@@ -2,8 +2,8 @@ using System.Security.Claims;
 using Altinn.Correspondence.Application.UnreadConfidentialCorrespondenceReminder;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using OneOf;
 
 namespace Altinn.Correspondence.Application.GetUnreadConfidentialCorrespondences;
@@ -11,8 +11,8 @@ namespace Altinn.Correspondence.Application.GetUnreadConfidentialCorrespondences
 public class GetUnreadConfidentialCorrespondencesHandler(
     ICorrespondenceRepository correspondenceRepository,
     IAltinnAuthorizationService altinnAuthorizationService,
+    IAltinnRegisterService altinnRegisterService,
     IHostEnvironment hostEnvironment
-
     )
 {
     public async Task<OneOf<GetUnreadConfidentialCorrespondencesResponse, Error>> Process(ClaimsPrincipal user, CancellationToken cancellationToken = default)
@@ -47,9 +47,16 @@ public class GetUnreadConfidentialCorrespondencesHandler(
 
     var defaultText = "Under ligger en oversikt over hvilke meldinger som er uåpnet og viser til avsender, dato meldingen ble publisert og hvilken tilgang som kreves. Hovedadministrator må delegere denne tilgangen for at noen i din virksomhet skal kunne se meldingene. Se mer informasjon på våre hjelpesider: https://info.altinn.no/nyheter/tilgang-til-taushetsbelagt-post/";
 
-    var lines = correspondences
-        .OrderBy(c => c.Published)
-        .Select((c, i) => $"{i + 1}. Melding fra avsender {c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krever tilgang til {c.ResourceId}")
+    var sortedCorrespondences = correspondences.OrderBy(c => c.Published).ToList();
+    var senderNames = await Task.WhenAll(
+        sortedCorrespondences.Select(c =>
+            !string.IsNullOrWhiteSpace(c.MessageSender)
+                ? Task.FromResult<string?>(c.MessageSender)
+                : altinnRegisterService.LookUpName(c.Sender.WithoutPrefix(), cancellationToken))
+    );
+
+    var lines = sortedCorrespondences
+        .Select((c, i) => $"{i + 1}. Melding fra avsender {senderNames[i] ?? c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krever tilgang til {c.ResourceId}")
         .ToList();
 
     var ending = "NB! Dette varselet forsvinner når alle uleste taushetsbelagte meldinger er åpnet.";

--- a/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
+++ b/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
@@ -45,7 +45,6 @@ public class UnreadConfidentialCorrespondenceHandler(
             Recipient = correspondence.Recipient.WithUrnPrefix(),
             ResourceId = "ttd-reminder-unopened-confidential-correspondences",
             SendersReference = "Digdir",
-            MessageSender = "Digitaliseringsdirektoratet",
             Created = DateTimeOffset.UtcNow,
             Status = "RequiresAttention",
             PropertyList = new Dictionary<string, string>{}


### PR DESCRIPTION
## Description
Removed the messageSender field in the confidential reminder.
Added a check whether the unopened correspondence uses messageSender, if it does use this field. If messageSender is not given make a call to register to retrieve the name of the organization.

## Related Issue(s)
- #1834 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sender name resolution to show registered display names when available, falling back to sender identifiers when not found.
  * Removed hardcoded default sender value from confidential correspondence reminders.

* **Tests**
  * Updated handler tests to mock the register service for sender name lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->