### PR TITLE
Disallow colon in emails

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingUtility/RecipientListAttributeTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/RecipientListAttributeTests.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using Altinn.Correspondence.API.Models;
+
+namespace Altinn.Correspondence.Tests.TestingUtility;
+
+public class RecipientListAttributeTests
+{
+    private readonly RecipientListAttribute _attribute = new();
+    private readonly ValidationContext _validationContext = new(new object())
+    {
+        DisplayName = "Recipients"
+    };
+
+    [Fact]
+    public void IsValid_ReturnsSuccess_For_Valid_IdPorten_Email_Urn()
+    {
+        var result = _attribute.GetValidationResult(
+            new List<string> { "urn:altinn:person:idporten-email:test@example.com" },
+            _validationContext);
+
+        Assert.Equal(ValidationResult.Success, result);
+    }
+
+    [Fact]
+    public void IsValid_ReturnsError_For_Legacy_IdPorten_Email_SubPrefix()
+    {
+        var result = _attribute.GetValidationResult(
+            new List<string> { "urn:altinn:person:idporten-email:epost:test@example.com" },
+            _validationContext);
+
+        Assert.NotEqual(ValidationResult.Success, result);
+        Assert.Equal("The given Recipient email address is not valid", result?.ErrorMessage);
+    }
+}

--- a/Test/Altinn.Correspondence.Tests/TestingUtility/StringExtensionsTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/StringExtensionsTests.cs
@@ -44,6 +44,32 @@ namespace Altinn.Correspondence.Tests.TestingUtility
         }
 
         [Fact]
+        public void IsEmailAddress_ReturnsTrue_For_Valid_IdPortenEmailUrn()
+        {
+            // Arrange
+            string emailUrn = "urn:altinn:person:idporten-email:test@example.com";
+
+            // Act
+            bool isValid = emailUrn.IsEmailAddress();
+
+            // Assert
+            Assert.True(isValid);
+        }
+
+        [Fact]
+        public void IsEmailAddress_ReturnsFalse_For_IdPortenEmailUrn_With_ExtraColon()
+        {
+            // Arrange
+            string emailUrn = "urn:altinn:person:idporten-email:epost:test@example.com";
+
+            // Act
+            bool isValid = emailUrn.IsEmailAddress();
+
+            // Assert
+            Assert.False(isValid);
+        }
+
+        [Fact]
         public void SanitizeForLogging_ReturnsEmpty_WhenInputIsEmpty()
         {
             // Arrange

--- a/src/Altinn.Correspondence.Common/Helpers/StringExtensions.cs
+++ b/src/Altinn.Correspondence.Common/Helpers/StringExtensions.cs
@@ -215,8 +215,18 @@ public static class StringExtensions
         {
             return false;
         }
-        // Simple email validation: contains @ and has characters before and after @
-        var atIndex = identifier.IndexOf('@');
-        return atIndex > 0 && atIndex < identifier.Length - 1 && identifier.IndexOf('@', atIndex + 1) == -1;
+        var emailValue = identifier;
+        var emailUrnPrefix = $"{UrnConstants.PersonIdPortenEmailAttribute}:";
+        if (identifier.StartsWith(emailUrnPrefix, StringComparison.Ordinal))
+        {
+            emailValue = identifier[emailUrnPrefix.Length..];
+        }
+        if (emailValue.Contains(':'))
+        {
+            return false;
+        }
+        // Simple email validation: contains @ and has characters before and after @, and that there is no other @
+        var atIndex = emailValue.IndexOf('@');
+        return atIndex > 0 && atIndex < emailValue.Length - 1 && emailValue.IndexOf('@', atIndex + 1) == -1;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes it so additional colons are not allowed after the Si email user urn. This makes it so urn:altinn:person:idporten-email:epost:test@example.com is not allowed but urn:altinn:person:idporten-email:test@example.com is.

## Related Issue(s)
- #1827 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email validation for recipient addresses to properly handle id-porten email URN format and reject legacy formats.

* **Tests**
  * Added validation tests for recipient email address formats, including valid and invalid URN variants.
  * Added tests for email address validation with URN prefix handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->