### PR TITLE
Add prefix for instance id

### DIFF
--- a/src/Altinn.Correspondence.API/ValidationAttributes/RecipientListAttribute.cs
+++ b/src/Altinn.Correspondence.API/ValidationAttributes/RecipientListAttribute.cs
@@ -33,6 +33,10 @@ internal class RecipientListAttribute : ValidationAttribute
 
         foreach (var recipient in recipients)
         {
+            if (string.IsNullOrWhiteSpace(recipient))
+            {
+                return new ValidationResult("Recipients can not contain null or empty values");
+            }
             var orgRegex = new Regex($@"^(?:0192:|{UrnConstants.OrganizationNumberAttribute}:)\d{{9}}$");
             var personRegex = new Regex($@"^(?:{UrnConstants.PersonIdAttribute}:)?\d{{11}}$");
             var emailUrnRegex = new Regex($@"^{Regex.Escape(UrnConstants.PersonIdPortenEmailAttribute)}:.+$");

--- a/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
@@ -304,7 +304,7 @@ public class AltinnAuthorizationService : IAltinnAuthorizationService
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(correspondenceId) && !correspondenceId.StartsWith("urn:altinn:correspondence-id:"))
+        if (!string.IsNullOrWhiteSpace(correspondenceId) && !correspondenceId.StartsWith("urn:altinn:correspondence-id:", StringComparison.Ordinal))
         {
             correspondenceId = "urn:altinn:correspondence-id:" + correspondenceId;
         }

--- a/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
@@ -304,6 +304,11 @@ public class AltinnAuthorizationService : IAltinnAuthorizationService
             }
         }
 
+        if (instanceId is not null && !instanceId.StartsWith("urn:altinn:correspondence-id:"))
+        {
+            instanceId = "urn:altinn:correspondence-id:" + instanceId;
+        }
+
         if (issuer == _dialogportenSettings.Issuer)
         {
             return await DialogTokenXacmlMapper.CreateDialogportenDecisionRequest(user, _altinnRegisterService, resourceId, resolvedParty, instanceId, cancellationToken);

--- a/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
@@ -290,7 +290,7 @@ public class AltinnAuthorizationService : IAltinnAuthorizationService
         return responseContent;
     }
 
-    private async Task<XacmlJsonRequestRoot> CreateDecisionRequest(ClaimsPrincipal user, string resourceId, string party, string? instanceId, List<string> actionTypes, CancellationToken cancellationToken)
+    private async Task<XacmlJsonRequestRoot> CreateDecisionRequest(ClaimsPrincipal user, string resourceId, string party, string? correspondenceId, List<string> actionTypes, CancellationToken cancellationToken)
     {
         var issuer = user.Claims.FirstOrDefault(c => c.Type == "iss")?.Value;
 
@@ -304,21 +304,21 @@ public class AltinnAuthorizationService : IAltinnAuthorizationService
             }
         }
 
-        if (instanceId is not null && !instanceId.StartsWith("urn:altinn:correspondence-id:"))
+        if (correspondenceId is not null && !correspondenceId.StartsWith("urn:altinn:correspondence-id:"))
         {
-            instanceId = "urn:altinn:correspondence-id:" + instanceId;
+            correspondenceId = "urn:altinn:correspondence-id:" + correspondenceId;
         }
 
         if (issuer == _dialogportenSettings.Issuer)
         {
-            return await DialogTokenXacmlMapper.CreateDialogportenDecisionRequest(user, _altinnRegisterService, resourceId, resolvedParty, instanceId, cancellationToken);
+            return await DialogTokenXacmlMapper.CreateDialogportenDecisionRequest(user, _altinnRegisterService, resourceId, resolvedParty, correspondenceId, cancellationToken);
         }
         if (issuer == _idPortenSettings.Issuer)
         {
-            return await IdportenXacmlMapper.CreateIdPortenDecisionRequest(user, _altinnRegisterService, actionTypes, resourceId, resolvedParty, instanceId, cancellationToken);
+            return await IdportenXacmlMapper.CreateIdPortenDecisionRequest(user, _altinnRegisterService, actionTypes, resourceId, resolvedParty, correspondenceId, cancellationToken);
         }
 
-        return AltinnTokenXacmlMapper.CreateAltinnDecisionRequest(user, actionTypes, resourceId, resolvedParty, instanceId);
+        return AltinnTokenXacmlMapper.CreateAltinnDecisionRequest(user, actionTypes, resourceId, resolvedParty, correspondenceId);
     }
 
     private XacmlJsonRequestRoot CreateDecisionRequestForLegacy(ClaimsPrincipal user, string subjectUserId, List<string> actionTypes, string resourceId, string onBehalfOfPartyId)

--- a/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs
@@ -304,7 +304,7 @@ public class AltinnAuthorizationService : IAltinnAuthorizationService
             }
         }
 
-        if (correspondenceId is not null && !correspondenceId.StartsWith("urn:altinn:correspondence-id:"))
+        if (!string.IsNullOrWhiteSpace(correspondenceId) && !correspondenceId.StartsWith("urn:altinn:correspondence-id:"))
         {
             correspondenceId = "urn:altinn:correspondence-id:" + correspondenceId;
         }


### PR DESCRIPTION
## Description
Our instances should be namespaced to Correspondence, and this is also how DP adds it to authorization. Also fixed a bug where 500 was thrown if a recipient was null.

## Related Issue(s)
- #531 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced recipient validation to immediately reject null, empty, or whitespace values in recipient lists.

* **Chores**
  * Updated authorization service to properly handle correspondence identifiers with standardized formatting during request creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->