### PR TITLE
allow search on soft deleted dialogs

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
@@ -362,7 +362,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
-        public async Task GetCorrespondences_WithoutStatusSpecified_AsSender_ReturnsAllExceptBlacklisted()
+        public async Task GetCorrespondences_WithoutStatusSpecified_AsSenderAndAsRecipient_ReturnsAllExceptBlacklisted()
         {
             // Arrange
             var resource = Guid.NewGuid().ToString();
@@ -375,17 +375,13 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Act
             var initializeCorrespondenceResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
             Assert.True(initializeCorrespondenceResponse.IsSuccessStatusCode, await initializeCorrespondenceResponse.Content.ReadAsStringAsync());
-            var correspondencesBeforeDeletion = await _senderClient.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resource}&role={"sender"}");
+            var searchAsRecipient = await _recipientClient.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resource}&role={"recipient"}");
             var response = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
 
-            await _senderClient.DeleteAsync($"correspondence/api/v1/correspondence/{response.Correspondences.FirstOrDefault().CorrespondenceId}/purge");
-            var correspondencesAfterDeletion = await _senderClient.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resource}&role={"sender"}");
-
+            var searchAsSender = await _senderClient.GetFromJsonAsync<GetCorrespondencesResponse>($"correspondence/api/v1/correspondence?resourceId={resource}&role={"sender"}");
             // Assert
-            var expectedBeforeDeletion = payload.Recipients.Count;
-            Assert.Equal(correspondencesBeforeDeletion?.Ids.Count, expectedBeforeDeletion);
-            var expectedAfterDeletion = payload.Recipients.Count - 1; // One was deleted
-            Assert.Equal(expectedAfterDeletion, correspondencesAfterDeletion?.Ids.Count);
+            Assert.Equal(searchAsRecipient?.Ids.Count, payload.Recipients.Count-1); // ReadyForPublish is blacklisted for recipient
+            Assert.Equal(searchAsSender?.Ids.Count, payload.Recipients.Count); // ReadyForPublish is not blacklisted for sender
         }
 
         [Fact]

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -23,16 +23,12 @@ namespace Altinn.Correspondence.Persistence.Helpers
             var blacklistSender = new List<CorrespondenceStatus?>
             {
                 CorrespondenceStatus.Archived,
-                CorrespondenceStatus.PurgedByAltinn,
-                CorrespondenceStatus.PurgedByRecipient,
             };
 
             var blacklistRecipient = new List<CorrespondenceStatus?>
             {
                 CorrespondenceStatus.Initialized,
                 CorrespondenceStatus.ReadyForPublish,
-                CorrespondenceStatus.PurgedByAltinn,
-                CorrespondenceStatus.PurgedByRecipient,
                 CorrespondenceStatus.Failed,
             };
 


### PR DESCRIPTION
## Description
Removed purged from blacklisted statuses for the search endpoint and rework test to accomodate the update.

## Related Issue(s)
- #1796 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correspondence search results now correctly include purged correspondences when querying by sender or recipient role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->