### PR TITLE
add debouncing on fetches

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Security.Claims;
-using System.Text;
 
 namespace Altinn.Correspondence.Tests.TestingHandler
 {
@@ -40,15 +39,16 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _cacheMock = new Mock<IHybridCacheWrapper>();
             _loggerMock = new Mock<ILogger<GetCorrespondenceOverviewHandler>>();
 
-            // Default: cache always returns a miss
+            // Default: cache miss — invoke the factory so the fetch event is persisted
             _cacheMock
-                .Setup(x => x.GetOrCreateAsync<byte[]>(
+                .Setup(x => x.GetOrCreateAsync(
                     It.IsAny<string>(),
-                    It.IsAny<Func<CancellationToken, ValueTask<byte[]>>>(),
+                    It.IsAny<Func<CancellationToken, ValueTask<bool>>>(),
                     It.IsAny<HybridCacheEntryOptions>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync((byte[])null!);
+                .Returns((string key, Func<CancellationToken, ValueTask<bool>> factory, HybridCacheEntryOptions opts, IEnumerable<string> tags, CancellationToken ct) =>
+                    factory(ct).AsTask());
 
             _handler = new GetCorrespondenceOverviewHandler(
                 _altinnAuthorizationServiceMock.Object,
@@ -597,15 +597,6 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
                 .ReturnsAsync(correspondence);
 
-            _cacheMock
-                .Setup(x => x.GetOrCreateAsync<byte[]>(
-                    It.IsAny<string>(),
-                    It.IsAny<Func<CancellationToken, ValueTask<byte[]>>>(),
-                    It.IsAny<HybridCacheEntryOptions>(),
-                    It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync((byte[])null!);
-
             // Act
             await _handler.Process(request, user, CancellationToken.None);
 
@@ -615,15 +606,6 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     It.Is<CorrespondenceStatusFetchedEntity>(s =>
                         s.CorrespondenceId == correspondenceId &&
                         s.PartyUuid == partyUuid),
-                    It.IsAny<CancellationToken>()),
-                Times.Once);
-
-            _cacheMock.Verify(
-                x => x.SetAsync(
-                    It.Is<string>(k => k.Contains(correspondenceId.ToString())),
-                    It.IsAny<byte[]>(),
-                    It.IsAny<HybridCacheEntryOptions>(),
-                    It.IsAny<IEnumerable<string>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Once);
         }
@@ -659,32 +641,22 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
                 .ReturnsAsync(correspondence);
 
-            var cachedBytes = Encoding.UTF8.GetBytes("true");
             _cacheMock
-                .Setup(x => x.GetOrCreateAsync<byte[]>(
+                .Setup(x => x.GetOrCreateAsync(
                     It.IsAny<string>(),
-                    It.IsAny<Func<CancellationToken, ValueTask<byte[]>>>(),
+                    It.IsAny<Func<CancellationToken, ValueTask<bool>>>(),
                     It.IsAny<HybridCacheEntryOptions>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(cachedBytes);
+                .ReturnsAsync(true);
 
             // Act
             await _handler.Process(request, user, CancellationToken.None);
 
-            // Assert 
+            // Assert
             _correspondenceStatusRepositoryMock.Verify(
                 x => x.AddCorrespondenceStatusFetched(
                     It.IsAny<CorrespondenceStatusFetchedEntity>(),
-                    It.IsAny<CancellationToken>()),
-                Times.Never);
-
-            _cacheMock.Verify(
-                x => x.SetAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<byte[]>(),
-                    It.IsAny<HybridCacheEntryOptions>(),
-                    It.IsAny<IEnumerable<string>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Never);
         }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
@@ -1,14 +1,17 @@
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.GetCorrespondenceOverview;
+using Altinn.Correspondence.Common.Caching;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Tests.Factories;
 using Hangfire;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Security.Claims;
+using System.Text;
 
 namespace Altinn.Correspondence.Tests.TestingHandler
 {
@@ -21,6 +24,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         private readonly Mock<IBackgroundJobClient> _backgroundJobClientMock;
         private readonly Mock<IDialogportenService> _dialogportenServiceMock;
         private readonly Mock<IConfidentialReminderRepository> _confidentialReminderRepositoryMock;
+        private readonly Mock<IHybridCacheWrapper> _cacheMock;
         private readonly Mock<ILogger<GetCorrespondenceOverviewHandler>> _loggerMock;
         private readonly GetCorrespondenceOverviewHandler _handler;
 
@@ -33,7 +37,18 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _backgroundJobClientMock = new Mock<IBackgroundJobClient>();
             _dialogportenServiceMock = new Mock<IDialogportenService>();
             _confidentialReminderRepositoryMock = new Mock<IConfidentialReminderRepository>();
+            _cacheMock = new Mock<IHybridCacheWrapper>();
             _loggerMock = new Mock<ILogger<GetCorrespondenceOverviewHandler>>();
+
+            // Default: cache always returns a miss
+            _cacheMock
+                .Setup(x => x.GetOrCreateAsync<byte[]>(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<CancellationToken, ValueTask<byte[]>>>(),
+                    It.IsAny<HybridCacheEntryOptions>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((byte[])null!);
 
             _handler = new GetCorrespondenceOverviewHandler(
                 _altinnAuthorizationServiceMock.Object,
@@ -43,6 +58,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 _correspondenceStatusRepositoryMock.Object,
                 _backgroundJobClientMock.Object,
                 _dialogportenServiceMock.Object,
+                _cacheMock.Object,
                 _loggerMock.Object);
         }
 
@@ -547,6 +563,129 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             // Assert - dialog is NOT soft-deleted because there was no dialog ID to delete
             _dialogportenServiceMock.Verify(
                 x => x.TrySoftDeleteDialog(It.IsAny<string>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task Process_WhenCacheMiss_AddsFetchedStatusAndPopulatesCache()
+        {
+            // Arrange
+            var correspondenceId = Guid.NewGuid();
+            var partyUuid = Guid.NewGuid();
+            var correspondence = new CorrespondenceEntityBuilder()
+                .WithStatus(CorrespondenceStatus.Published)
+                .Build();
+            correspondence.Id = correspondenceId;
+
+            var user = new ClaimsPrincipal();
+            var request = new GetCorrespondenceOverviewRequest
+            {
+                CorrespondenceId = correspondenceId,
+                OnlyGettingContent = false
+            };
+
+            _altinnAuthorizationServiceMock
+                .Setup(x => x.CheckAccessAsRecipient(It.IsAny<ClaimsPrincipal>(), It.IsAny<CorrespondenceEntity>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            _altinnAuthorizationServiceMock
+                .Setup(x => x.CheckAccessAsSender(It.IsAny<ClaimsPrincipal>(), It.IsAny<CorrespondenceEntity>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+            _altinnRegisterServiceMock
+                .Setup(x => x.LookUpPartyById(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = partyUuid });
+            _correspondenceRepositoryMock
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .ReturnsAsync(correspondence);
+
+            _cacheMock
+                .Setup(x => x.GetOrCreateAsync<byte[]>(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<CancellationToken, ValueTask<byte[]>>>(),
+                    It.IsAny<HybridCacheEntryOptions>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((byte[])null!);
+
+            // Act
+            await _handler.Process(request, user, CancellationToken.None);
+
+            // Assert
+            _correspondenceStatusRepositoryMock.Verify(
+                x => x.AddCorrespondenceStatusFetched(
+                    It.Is<CorrespondenceStatusFetchedEntity>(s =>
+                        s.CorrespondenceId == correspondenceId &&
+                        s.PartyUuid == partyUuid),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+
+            _cacheMock.Verify(
+                x => x.SetAsync(
+                    It.Is<string>(k => k.Contains(correspondenceId.ToString())),
+                    It.IsAny<byte[]>(),
+                    It.IsAny<HybridCacheEntryOptions>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Process_WhenCacheHit_DoesNotAddFetchedStatus()
+        {
+            // Arrange
+            var correspondenceId = Guid.NewGuid();
+            var partyUuid = Guid.NewGuid();
+            var correspondence = new CorrespondenceEntityBuilder()
+                .WithStatus(CorrespondenceStatus.Published)
+                .Build();
+            correspondence.Id = correspondenceId;
+
+            var user = new ClaimsPrincipal();
+            var request = new GetCorrespondenceOverviewRequest
+            {
+                CorrespondenceId = correspondenceId,
+                OnlyGettingContent = false
+            };
+
+            _altinnAuthorizationServiceMock
+                .Setup(x => x.CheckAccessAsRecipient(It.IsAny<ClaimsPrincipal>(), It.IsAny<CorrespondenceEntity>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            _altinnAuthorizationServiceMock
+                .Setup(x => x.CheckAccessAsSender(It.IsAny<ClaimsPrincipal>(), It.IsAny<CorrespondenceEntity>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+            _altinnRegisterServiceMock
+                .Setup(x => x.LookUpPartyById(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Party { PartyUuid = partyUuid });
+            _correspondenceRepositoryMock
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .ReturnsAsync(correspondence);
+
+            var cachedBytes = Encoding.UTF8.GetBytes("true");
+            _cacheMock
+                .Setup(x => x.GetOrCreateAsync<byte[]>(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<CancellationToken, ValueTask<byte[]>>>(),
+                    It.IsAny<HybridCacheEntryOptions>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(cachedBytes);
+
+            // Act
+            await _handler.Process(request, user, CancellationToken.None);
+
+            // Assert 
+            _correspondenceStatusRepositoryMock.Verify(
+                x => x.AddCorrespondenceStatusFetched(
+                    It.IsAny<CorrespondenceStatusFetchedEntity>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+
+            _cacheMock.Verify(
+                x => x.SetAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<byte[]>(),
+                    It.IsAny<HybridCacheEntryOptions>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Never);
         }
     }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Common.Caching;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
@@ -6,6 +7,7 @@ using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
 using Hangfire;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Security.Claims;
@@ -20,6 +22,7 @@ public class GetCorrespondenceOverviewHandler(
     ICorrespondenceStatusRepository correspondenceStatusRepository,
     IBackgroundJobClient backgroundJobClient,
     IDialogportenService dialogportenService,
+    IHybridCacheWrapper cache,
     ILogger<GetCorrespondenceOverviewHandler> logger) : IHandler<GetCorrespondenceOverviewRequest, GetCorrespondenceOverviewResponse>
 {
     public async Task<OneOf<GetCorrespondenceOverviewResponse, Error>> Process(GetCorrespondenceOverviewRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
@@ -77,14 +80,20 @@ public class GetCorrespondenceOverviewHandler(
                     logger.LogWarning("Rejected because correspondence not available for recipient in current state.");
                     return CorrespondenceErrors.CorrespondenceNotFound;
                 }
-                await correspondenceStatusRepository.AddCorrespondenceStatusFetched(new CorrespondenceStatusFetchedEntity
+                var cacheKey = $"Correspondence_Fetched_Debounce:{correspondence.Id}-{partyUuid}";
+                var alreadyFetched = await CacheHelpers.GetObjectFromCacheAsync<bool>(cacheKey, cache, cancellationToken);
+                if (alreadyFetched != true)
                 {
-                    CorrespondenceId = correspondence.Id,
-                    Status = CorrespondenceStatus.Fetched,
-                    StatusText = CorrespondenceStatus.Fetched.ToString(),
-                    StatusChanged = operationTimestamp,
-                    PartyUuid = partyUuid
-                }, cancellationToken);
+                    await CacheHelpers.StoreObjectInCacheAsync(cacheKey, true, cache, new HybridCacheEntryOptions { Expiration = TimeSpan.FromSeconds(15) }, cancellationToken);
+                    await correspondenceStatusRepository.AddCorrespondenceStatusFetched(new CorrespondenceStatusFetchedEntity
+                    {
+                        CorrespondenceId = correspondence.Id,
+                        Status = CorrespondenceStatus.Fetched,
+                        StatusText = CorrespondenceStatus.Fetched.ToString(),
+                        StatusChanged = operationTimestamp,
+                        PartyUuid = partyUuid
+                    }, cancellationToken);
+                }
                 if (request.OnlyGettingContent)
                 {
                     if (!correspondence.StatusHasBeen(CorrespondenceStatus.Read)) { 

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -81,19 +81,23 @@ public class GetCorrespondenceOverviewHandler(
                     return CorrespondenceErrors.CorrespondenceNotFound;
                 }
                 var cacheKey = $"Correspondence_Fetched_Debounce:{correspondence.Id}-{partyUuid}";
-                var alreadyFetched = await CacheHelpers.GetObjectFromCacheAsync<bool>(cacheKey, cache, cancellationToken);
-                if (alreadyFetched != true)
-                {
-                    await CacheHelpers.StoreObjectInCacheAsync(cacheKey, true, cache, new HybridCacheEntryOptions { Expiration = TimeSpan.FromSeconds(15) }, cancellationToken);
-                    await correspondenceStatusRepository.AddCorrespondenceStatusFetched(new CorrespondenceStatusFetchedEntity
+                await cache.GetOrCreateAsync(
+                    cacheKey,
+                    async cancellationToken =>
                     {
-                        CorrespondenceId = correspondence.Id,
-                        Status = CorrespondenceStatus.Fetched,
-                        StatusText = CorrespondenceStatus.Fetched.ToString(),
-                        StatusChanged = operationTimestamp,
-                        PartyUuid = partyUuid
-                    }, cancellationToken);
-                }
+                        await correspondenceStatusRepository.AddCorrespondenceStatusFetched(new CorrespondenceStatusFetchedEntity
+                        {
+                            CorrespondenceId = correspondence.Id,
+                            Status = CorrespondenceStatus.Fetched,
+                            StatusText = CorrespondenceStatus.Fetched.ToString(),
+                            StatusChanged = operationTimestamp,
+                            PartyUuid = partyUuid
+                        }, cancellationToken);
+                        return true;
+                    },
+                    new HybridCacheEntryOptions { Expiration = TimeSpan.FromMinutes(3) },
+                    null,
+                    cancellationToken);
                 if (request.OnlyGettingContent)
                 {
                     if (!correspondence.StatusHasBeen(CorrespondenceStatus.Read)) { 

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -95,7 +95,7 @@ public class GetCorrespondenceOverviewHandler(
                         }, cancellationToken);
                         return true;
                     },
-                    new HybridCacheEntryOptions { Expiration = TimeSpan.FromMinutes(3) },
+                    new HybridCacheEntryOptions { Expiration = TimeSpan.FromSeconds(15) },
                     null,
                     cancellationToken);
                 if (request.OnlyGettingContent)


### PR DESCRIPTION
## Description
Added caching logic on fetches which stores the correspondenceId along with the calling party as the key. Subsequent fetcehs from the same correspondence/party combination will not be written to the database. TTL on 15 seconds.

## Related Issue(s)
- #1800 
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debounced correspondence status recording using a short-lived hybrid cache to prevent duplicate status entries.

* **Tests**
  * Added tests confirming a cache miss triggers status recording and a cache hit prevents duplicate recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->