### PR TITLE
Implement idempotency for dialog with id

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
@@ -262,40 +262,6 @@ public class CreateDialogRequestMapperTests
     }
 
     [Fact]
-    public void CreateCorrespondenceDialog_WithCreatedMoreThan15SecondsInFuture_LogsWarningAndFallsBackToRandomUuidV7()
-    {
-        // Arrange
-        var currentUtcNow = DateTimeOffset.Parse("2026-01-15T10:11:30.000Z");
-        var correspondence = new CorrespondenceEntityBuilder()
-            .WithId(Guid.NewGuid())
-            .Build();
-        correspondence.Created = currentUtcNow.AddSeconds(16);
-        var loggerMock = new Mock<ILogger>();
-        var baseUrl = "https://example.com";
-
-        // Act
-        var firstResult = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, logger: loggerMock.Object, currentUtcNow: currentUtcNow);
-        var secondResult = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, logger: loggerMock.Object, currentUtcNow: currentUtcNow);
-
-        // Assert
-        Assert.NotEqual(firstResult.Id, secondResult.Id);
-        Assert.Equal(7, GetUuidVersion(Guid.Parse(firstResult.Id)));
-        Assert.Equal(7, GetUuidVersion(Guid.Parse(secondResult.Id)));
-
-        loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) =>
-                    v.ToString()!.Contains("Created is more than 15 seconds in the future") &&
-                    v.ToString()!.Contains(correspondence.Id.ToString()) &&
-                    v.ToString()!.Contains(firstResult.Id)),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.AtLeastOnce());
-    }
-
-    [Fact]
     public void CreateCorrespondenceDialog_WithEmailNotifications_ShouldCreateCorrectActivities()
     {
         // Arrange

--- a/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
@@ -2,6 +2,8 @@ using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Integrations.Dialogporten.Mappers;
 using Altinn.Correspondence.Tests.Factories;
 using Altinn.Correspondence.Core.Models.Entities;
+using Microsoft.Extensions.Logging;
+using Moq;
 
 namespace Altinn.Correspondence.Tests.TestingUtility;
 
@@ -215,6 +217,85 @@ public class CreateDialogRequestMapperTests
     }
 
     [Fact]
+    public void CreateCorrespondenceDialog_WithUuidV7CorrespondenceId_GeneratesDeterministicUuidV7WithSameTimestamp()
+    {
+        // Arrange
+        var created = DateTimeOffset.Parse("2026-01-15T10:11:12.345Z");
+        var correspondenceId = Guid.CreateVersion7(created);
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .Build();
+        correspondence.Created = created;
+        var baseUrl = "https://example.com";
+
+        // Act
+        var firstResult = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, currentUtcNow: created.AddSeconds(1));
+        var secondResult = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, currentUtcNow: created.AddSeconds(1));
+
+        // Assert
+        Assert.Equal(firstResult.Id, secondResult.Id);
+        Assert.NotEqual(correspondenceId.ToString(), firstResult.Id);
+        Assert.Equal(7, GetUuidVersion(Guid.Parse(firstResult.Id)));
+        Assert.Equal(GetTimestampFromUuidV7(correspondenceId), GetTimestampFromUuidV7(Guid.Parse(firstResult.Id)));
+    }
+
+    [Fact]
+    public void CreateCorrespondenceDialog_WithUuidV4CorrespondenceId_UsesCreatedForDeterministicUuidV7()
+    {
+        // Arrange
+        var currentUtcNow = DateTimeOffset.Parse("2026-01-15T10:11:30.000Z");
+        var created = DateTimeOffset.Parse("2026-01-15T10:11:12.123Z");
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(Guid.NewGuid())
+            .Build();
+        correspondence.Created = created;
+        var baseUrl = "https://example.com";
+
+        // Act
+        var firstResult = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, currentUtcNow: currentUtcNow);
+        var secondResult = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, currentUtcNow: currentUtcNow);
+
+        // Assert
+        Assert.Equal(firstResult.Id, secondResult.Id);
+        Assert.Equal(7, GetUuidVersion(Guid.Parse(firstResult.Id)));
+        Assert.Equal(created.ToUnixTimeMilliseconds(), GetTimestampFromUuidV7(Guid.Parse(firstResult.Id)).ToUnixTimeMilliseconds());
+    }
+
+    [Fact]
+    public void CreateCorrespondenceDialog_WithCreatedMoreThan15SecondsInFuture_LogsWarningAndFallsBackToRandomUuidV7()
+    {
+        // Arrange
+        var currentUtcNow = DateTimeOffset.Parse("2026-01-15T10:11:30.000Z");
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(Guid.NewGuid())
+            .Build();
+        correspondence.Created = currentUtcNow.AddSeconds(16);
+        var loggerMock = new Mock<ILogger>();
+        var baseUrl = "https://example.com";
+
+        // Act
+        var firstResult = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, logger: loggerMock.Object, currentUtcNow: currentUtcNow);
+        var secondResult = CreateDialogRequestMapper.CreateCorrespondenceDialog(correspondence, baseUrl, logger: loggerMock.Object, currentUtcNow: currentUtcNow);
+
+        // Assert
+        Assert.NotEqual(firstResult.Id, secondResult.Id);
+        Assert.Equal(7, GetUuidVersion(Guid.Parse(firstResult.Id)));
+        Assert.Equal(7, GetUuidVersion(Guid.Parse(secondResult.Id)));
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) =>
+                    v.ToString()!.Contains("Created is more than 15 seconds in the future") &&
+                    v.ToString()!.Contains(correspondence.Id.ToString()) &&
+                    v.ToString()!.Contains(firstResult.Id)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce());
+    }
+
+    [Fact]
     public void CreateCorrespondenceDialog_WithEmailNotifications_ShouldCreateCorrectActivities()
     {
         // Arrange
@@ -364,6 +445,18 @@ public class CreateDialogRequestMapperTests
         var reminderEnDescription = reminderActivity.Description.FirstOrDefault(d => d.LanguageCode == "en");
         Assert.NotNull(reminderEnDescription);
         Assert.Equal("Reminder notification about received message sent to +4712345678 on SMS.", reminderEnDescription.Value);
+    }
+
+    private static int GetUuidVersion(Guid guid)
+    {
+        return int.Parse(guid.ToString("N")[12].ToString(), System.Globalization.NumberStyles.HexNumber);
+    }
+
+    private static DateTimeOffset GetTimestampFromUuidV7(Guid uuidV7)
+    {
+        string hexValue = uuidV7.ToString("N");
+        long unixTimeMilliseconds = Convert.ToInt64(hexValue[..12], 16);
+        return DateTimeOffset.FromUnixTimeMilliseconds(unixTimeMilliseconds);
     }
 
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -93,20 +93,21 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
         private static string GetDialogId(CorrespondenceEntity correspondence, DateTimeOffset currentUtcNow, ILogger? logger)
         {
-            if (IsUuidV7(correspondence.Id))
+            var sourceTimestamp = IsUuidV7(correspondence.Id)
+                ? GetTimestampFromUuidV7(correspondence.Id)
+                : correspondence.Created;
+
+            if (sourceTimestamp > currentUtcNow.AddSeconds(15))
             {
-                var timestampFromCorrespondenceId = GetTimestampFromUuidV7(correspondence.Id);
-                return CreateDeterministicUuidV7(timestampFromCorrespondenceId, correspondence.Id).ToString();
+                logger?.LogWarning(
+                    "Dialog ID timestamp is more than 15 seconds in the future for correspondence {CorrespondenceId}. Clamping from {OriginalTimestamp:o} to {ClampedTimestamp:o}.",
+                    correspondence.Id,
+                    sourceTimestamp,
+                    currentUtcNow);
+                sourceTimestamp = currentUtcNow;
             }
 
-            if (correspondence.Created > currentUtcNow.AddSeconds(15))
-            {
-                var fallbackDialogId = Guid.CreateVersion7().ToString();
-                logger?.LogWarning(
-                    "Created is more than 15 seconds in the future for correspondence {CorrespondenceId}. Falling back to non-deterministic dialogId {DialogId}.",
-                    correspondence.Id,
-                    fallbackDialogId);
-                return fallbackDialogId;
+            return CreateDeterministicUuidV7(sourceTimestamp, correspondence.Id).ToString();
             }
 
             return CreateDeterministicUuidV7(correspondence.Created, correspondence.Id).ToString();

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -108,9 +108,6 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             }
 
             return CreateDeterministicUuidV7(sourceTimestamp, correspondence.Id).ToString();
-            }
-
-            return CreateDeterministicUuidV7(correspondence.Created, correspondence.Id).ToString();
         }
 
         private static bool IsUuidV7(Guid guid)

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -6,6 +6,8 @@ using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Services.Enums;
 using Altinn.Correspondence.Integrations.Dialogporten.Models;
 using Microsoft.Extensions.Logging;
+using System.Security.Cryptography;
+using System.Text;
 using UUIDNext;
 
 namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
@@ -21,10 +23,9 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
     {
         internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl, bool includeActivities = false, ILogger? logger = null, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, bool isSoftDeleted = false, DateTimeOffset? currentUtcNow = null)
         {
-            var dialogId = Guid.CreateVersion7().ToString(); // Dialogporten requires time-stamped GUIDs
-            DateTimeOffset? dueAt = correspondence.DueDateTime != default ? correspondence.DueDateTime : null;
-
             DateTimeOffset currentDateTimeUtcNow = currentUtcNow ?? DateTimeOffset.UtcNow;
+            var dialogId = GetDialogId(correspondence, currentDateTimeUtcNow, logger);
+            DateTimeOffset? dueAt = correspondence.DueDateTime != default ? correspondence.DueDateTime : null;
 
             // The problem of DueAt being in the past should only occur for migrated data, as such we are checking includeActivities flag first, since this is only set when making migrated correspondences available.
             if (includeActivities && dueAt.HasValue && dueAt < currentDateTimeUtcNow)
@@ -88,6 +89,57 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 Transmissions = new List<Transmission>(),
                 SystemLabel = SystemLabel.Default
             };
+        }
+
+        private static string GetDialogId(CorrespondenceEntity correspondence, DateTimeOffset currentUtcNow, ILogger? logger)
+        {
+            if (IsUuidV7(correspondence.Id))
+            {
+                var timestampFromCorrespondenceId = GetTimestampFromUuidV7(correspondence.Id);
+                return CreateDeterministicUuidV7(timestampFromCorrespondenceId, correspondence.Id).ToString();
+            }
+
+            if (correspondence.Created > currentUtcNow.AddSeconds(15))
+            {
+                var fallbackDialogId = Guid.CreateVersion7().ToString();
+                logger?.LogWarning(
+                    "Created is more than 15 seconds in the future for correspondence {CorrespondenceId}. Falling back to non-deterministic dialogId {DialogId}.",
+                    correspondence.Id,
+                    fallbackDialogId);
+                return fallbackDialogId;
+            }
+
+            return CreateDeterministicUuidV7(correspondence.Created, correspondence.Id).ToString();
+        }
+
+        private static bool IsUuidV7(Guid guid)
+        {
+            return guid.ToString("N")[12] == '7';
+        }
+
+        private static DateTimeOffset GetTimestampFromUuidV7(Guid uuidV7)
+        {
+            string hexValue = uuidV7.ToString("N");
+            long unixTimeMilliseconds = Convert.ToInt64(hexValue[..12], 16);
+            return DateTimeOffset.FromUnixTimeMilliseconds(unixTimeMilliseconds);
+        }
+
+        private static Guid CreateDeterministicUuidV7(DateTimeOffset timestamp, Guid correspondenceId)
+        {
+            long unixTimeMilliseconds = Math.Max(0, timestamp.ToUnixTimeMilliseconds());
+            ulong timestamp48Bit = (ulong)unixTimeMilliseconds & 0xFFFFFFFFFFFFUL;
+            string timestampHex = timestamp48Bit.ToString("x12");
+
+            byte[] seedBytes = Encoding.UTF8.GetBytes($"{correspondenceId:N}:{unixTimeMilliseconds}");
+            byte[] hash = SHA256.HashData(seedBytes);
+            string hashHex = Convert.ToHexString(hash).ToLowerInvariant();
+
+            string randA = hashHex[..3];
+            int variantNibble = (Convert.ToInt32(hashHex[3].ToString(), 16) & 0x3) | 0x8;
+            string clockSeq = $"{variantNibble:x}{hashHex.Substring(4, 3)}";
+            string node = hashHex.Substring(7, 12);
+
+            return Guid.Parse($"{timestampHex[..8]}-{timestampHex.Substring(8, 4)}-7{randA}-{clockSeq}-{node}");
         }
 
         private static string GetSystemLabelForCorrespondence(CorrespondenceEntity correspondence, bool isSoftDeleted)


### PR DESCRIPTION
## Description
Ensure against duplicate dialogs by setting dialog id deterministically from CorrespondenceId. Doing it this way instead of using IdempotentKey for performance reasons related to migration.

## Related Issue(s)
- #1847 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog IDs are now generated deterministically from correspondence timestamps for improved consistency.
  * If a correspondence timestamp is far in the future, the system logs a warning and falls back to non-deterministic ID generation while clamping the timestamp to the current time.

* **Tests**
  * Added unit tests covering deterministic ID generation, timestamp extraction, future-timestamp edge cases, and logging/fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->