### PR TITLE
Corrected attachment event sources

### DIFF
--- a/src/Altinn.Correspondence.Application/ExpireAttachment/ExpireAttachmentHandler.cs
+++ b/src/Altinn.Correspondence.Application/ExpireAttachment/ExpireAttachmentHandler.cs
@@ -96,7 +96,7 @@ public class ExpireAttachmentHandler(
                 AltinnEventType.AttachmentExpired,
                 attachment.ResourceId,
                 attachment.Id.ToString(),
-                "Expiration",
+                "attachment",
                 attachment.Sender,
                 CancellationToken.None));
 

--- a/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
+++ b/src/Altinn.Correspondence.Application/MalwareScanResult/MalwareScanResultHandler.cs
@@ -65,7 +65,7 @@ public class MalwareScanResultHandler(
                     AltinnEventType.AttachmentPublished, 
                     attachment.ResourceId, 
                     attachmentIdFromBlobUri, 
-                    "Attachment Published", 
+                    "attachment", 
                     attachment.Sender, 
                     CancellationToken.None));
                 logger.LogInformation("Successfully processed clean scan result for attachment {AttachmentId} with filename {FileName}", 
@@ -95,7 +95,7 @@ public class MalwareScanResultHandler(
                     AltinnEventType.AttachmentUploadFailed, 
                     attachment.ResourceId, 
                     attachmentIdFromBlobUri, 
-                    "Malware scan", 
+                    "attachment", 
                     attachment.Sender, 
                     CancellationToken.None));
                 logger.LogWarning("Malicious content detected in attachment {AttachmentId} with filename {FileName}: {ScanResultType} - {ScanResultDetails}", 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The event sources for some of the attachment events were not URI's. This PR makes them uri's and makes them consistent with the other event sources from the API.

## Related Issue(s)
- #https://github.com/Altinn/altinn-correspondence/issues/1852

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized event status identifiers for attachment operations to improve system consistency and reliability in event tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->