### PR TITLE
Create read event when reading correspondence using correspondece/content

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -290,7 +290,8 @@ public class DialogportenTests
         Assert.IsType<GetCorrespondenceOverviewResponse>(result.Value);
 
         // Assert
-        Assert.Single(hangfireBackgroundJobClient.Invocations);
+        Assert.Equal(2, hangfireBackgroundJobClient.Invocations.Count);
         Assert.Contains(hangfireBackgroundJobClient.Invocations, invocation => invocation.Arguments[0].ToString() == "IDialogportenService.CreateOpenedActivity");
+        Assert.Contains(hangfireBackgroundJobClient.Invocations, invocation => invocation.Arguments[0].ToString() == "IEventBus.Publish");
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
@@ -5,8 +5,11 @@ using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
+using Altinn.Correspondence.Core.Services.Enums;
 using Altinn.Correspondence.Tests.Factories;
 using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -112,13 +115,12 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     It.IsAny<CancellationToken>()),
                 Times.Once);
 
-            _backgroundJobClientMock.Verify(
-                x => x.Enqueue(
-                    It.Is<System.Linq.Expressions.Expression<System.Action<IEventBus>>>(expr =>
-                        expr.ToString().Contains("CorrespondenceReceiverRead")
-                    )
-                ),
-                Times.Once);
+            _backgroundJobClientMock.Verify(x => x.Create(
+                It.Is<Job>(job =>
+                    job.Type == typeof(IEventBus) &&
+                    job.Method.Name == nameof(IEventBus.Publish) &&
+                    (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceReceiverRead),
+                It.Is<IState>(state => state is EnqueuedState)), Times.Once);
         }
 
         [Fact]

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
@@ -111,6 +111,14 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                         s.Status == CorrespondenceStatus.Read),
                     It.IsAny<CancellationToken>()),
                 Times.Once);
+
+            _backgroundJobClientMock.Verify(
+                x => x.Enqueue(
+                    It.Is<System.Linq.Expressions.Expression<System.Action<IEventBus>>>(expr =>
+                        expr.ToString().Contains("CorrespondenceReceiverRead")
+                    )
+                ),
+                Times.Once);
         }
 
         [Fact]

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -109,6 +109,13 @@ public class GetCorrespondenceOverviewHandler(
                             StatusChanged = operationTimestamp,
                             PartyUuid = partyUuid
                         }, cancellationToken);
+                        backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(
+                            AltinnEventType.CorrespondenceReceiverRead,
+                            correspondence.ResourceId,
+                            correspondence.Id.ToString(),
+                            "correspondence",
+                            correspondence.Sender,
+                            CancellationToken.None));
                         if (correspondence.Altinn2CorrespondenceId.HasValue && correspondence.Altinn2CorrespondenceId > 0)
                         {
                             backgroundJobClient.Enqueue<IAltinnStorageService>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The markAsRead endpoint creates a correspondenceReceiverrEad event as intended, but the correspondence/content endpoint does not create a read event currently even though it does set the correspondence to read. This PR makes the /content endpoint also send an event when the correspondence is read using this endpoint.

## Related Issue(s)
- #1860

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marking correspondence as read now enqueues a background event to record receiver read activity.

* **Tests**
  * Improved tests to verify background jobs are enqueued for receiver-read events.
  * Tests updated to expect two background job invocations: one for creating an "opened" activity and one for publishing the corresponding event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->