### PR TITLE
Updated CreateDialog to include activites for ForwardingEvents

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
@@ -31,9 +31,9 @@ public class DialogportenServiceTests
                     m.RequestUri != null &&
                     m.RequestUri.AbsolutePath.EndsWith("/dialogporten/api/v1/serviceowner/dialogs")),
                 ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
             {
-                capturedRequestBody = await req.Content!.ReadAsStringAsync();
+                capturedRequestBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
             })
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -88,9 +88,9 @@ public class DialogportenServiceTests
                     m.RequestUri != null &&
                     m.RequestUri.AbsolutePath.EndsWith("/dialogporten/api/v1/serviceowner/dialogs")),
                 ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
             {
-                capturedRequestBody = await req.Content!.ReadAsStringAsync();
+                capturedRequestBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
             })
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {

--- a/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
@@ -313,6 +313,16 @@ public class DialogportenServiceTests
 
         Assert.NotNull(deserialized);
         Assert.NotNull(deserialized!.Activities);
+
+        var mailboxForwardingActivity = deserialized.Activities.FirstOrDefault(a => 
+            a.Type == "Information" && 
+            a.Description != null && 
+            a.Description.Any(d => d.LanguageCode == "nb" && d.Value.Contains("Digipost")));
+
+        Assert.NotNull(mailboxForwardingActivity);
+        var nbDescription = mailboxForwardingActivity!.Description.FirstOrDefault(d => d.LanguageCode == "nb");
+        Assert.NotNull(nbDescription);
+        Assert.Equal("sendte \"Default title\" til Digipost", nbDescription!.Value);
     }
 
     [Fact]

--- a/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
@@ -75,6 +75,68 @@ public class DialogportenServiceTests
         return (service, () => capturedRequestBody);
     }
 
+    private static (DialogportenService service, Mock<ICorrespondenceForwardingEventRepository> forwardingEventRepoMock, Mock<IAltinnRegisterService> altinnRegisterMock, Func<string> getLastRequestBody) CreateServiceWithForwardingEventSupport(CorrespondenceEntity correspondence)
+    {
+        var capturedRequestBody = string.Empty;
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Post &&
+                    m.RequestUri != null &&
+                    m.RequestUri.AbsolutePath.EndsWith("/dialogporten/api/v1/serviceowner/dialogs")),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                capturedRequestBody = await req.Content!.ReadAsStringAsync();
+            })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("\"dialog-id\"", Encoding.UTF8, "application/json")
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object)
+        {
+            BaseAddress = new Uri("https://dialogporten.example/")
+        };
+
+        var mockRepo = new Mock<ICorrespondenceRepository>();
+        mockRepo
+            .Setup(r => r.GetCorrespondenceById(correspondence.Id, true, true, false, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(correspondence);
+
+        var mockIdem = new Mock<IIdempotencyKeyRepository>();
+        mockIdem
+            .Setup(i => i.CreateAsync(It.IsAny<IdempotencyKeyEntity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyKeyEntity e, CancellationToken _) => e);
+        mockIdem
+            .Setup(i => i.CreateRangeAsync(It.IsAny<IEnumerable<IdempotencyKeyEntity>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var mockLogger = new Mock<ILogger<DialogportenService>>();
+        var mockResourceRegistryService = new Mock<IResourceRegistryService>();
+        var mockCorrespondenceForwardingEventRepository = new Mock<ICorrespondenceForwardingEventRepository>();
+        var mockAltinnRegisterService = new Mock<IAltinnRegisterService>();
+        var options = Options.Create(new GeneralSettings { CorrespondenceBaseUrl = "https://correspondence.example" });
+
+        // Setup forwarding event repository to track DialogActivityId assignments
+        mockCorrespondenceForwardingEventRepository
+            .Setup(r => r.SetDialogActivityId(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var service = new DialogportenService(httpClient,
+                                              mockRepo.Object,
+                                              mockCorrespondenceForwardingEventRepository.Object,
+                                              mockAltinnRegisterService.Object,
+                                              options,
+                                              mockLogger.Object,
+                                              mockIdem.Object,
+                                              mockResourceRegistryService.Object);
+        return (service, mockCorrespondenceForwardingEventRepository, mockAltinnRegisterService, () => capturedRequestBody);
+    }
+
     [Fact]
     public async Task CreateCorrespondenceDialog_TruncatesSearchTags_ToMax63AndSucceeds()
     {
@@ -111,6 +173,452 @@ public class DialogportenServiceTests
         var expectedTruncated = longValue.Substring(0, 63);
         Assert.Contains(deserialized.SearchTags, t => t.Value == expectedTruncated);
     }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialogForMigratedCorrespondence_WithEmailForwardingEvent_ShouldIncludeForwardingActivity()
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+        var delegatedUserPartyUuid = new Guid("358C48B4-74A7-461F-A86F-48801DEEC920");
+        var forwardedByUserUuid = new Guid("9ECDE07C-CF64-42B0-BEBD-035F195FB77E");
+        var forwardingEventId = Guid.NewGuid();
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow)
+            .WithForwardingEvents(new List<CorrespondenceForwardingEventEntity>
+            {
+                new CorrespondenceForwardingEventEntity
+                {
+                    Id = forwardingEventId,
+                    CorrespondenceId = correspondenceId,
+                    ForwardedOnDate = new DateTimeOffset(new DateTime(2024, 1, 6, 11, 0, 0)),
+                    ForwardedByPartyUuid = delegatedUserPartyUuid,
+                    ForwardedByUserId = 123,
+                    ForwardedByUserUuid = forwardedByUserUuid,
+                    ForwardedToEmailAddress = "user1@awesometestusers.com",
+                    ForwardingText = "Keep this as a backup in my email."
+                }
+            })
+            .Build();
+
+        // Set navigation properties
+        foreach (var fwdEvent in correspondence.ForwardingEvents)
+        {
+            fwdEvent.Correspondence = correspondence;
+        }
+
+        var (service, forwardingRepoMock, altinnRegisterMock, getBody) = CreateServiceWithForwardingEventSupport(correspondence);
+
+        // Setup party lookup
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(delegatedUserPartyUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = delegatedUserPartyUuid,
+                SSN = "12345678901",
+                PartyTypeName = PartyType.Person,
+                Name = "Test Person"
+            });
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialogForMigratedCorrespondence(correspondenceId, correspondence);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+
+        // Verify DialogActivityId was set
+        forwardingRepoMock.Verify(r => r.SetDialogActivityId(forwardingEventId, It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify party lookup was called
+        altinnRegisterMock.Verify(a => a.LookUpPartyByPartyUuid(delegatedUserPartyUuid, It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify the request body contains the forwarding activity
+        var capturedRequestBody = getBody();
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.Activities);
+
+        // Should have status activities + forwarding activity
+        var forwardingActivity = deserialized.Activities.FirstOrDefault(a => 
+            a.Description?.Any(d => d.Value.Contains("user1@awesometestusers.com")) == true);
+
+        Assert.NotNull(forwardingActivity);
+        Assert.Equal("Information", forwardingActivity!.Type);
+        Assert.Equal("PartyRepresentative", forwardingActivity.PerformedBy.ActorType);
+        Assert.Contains("urn:altinn:person:identifier-no:12345678901", forwardingActivity.PerformedBy.ActorId);
+    }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialogForMigratedCorrespondence_WithMailboxForwardingEvent_ShouldIncludeForwardingActivity()
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+        var delegatedUserPartyUuid = new Guid("358C48B4-74A7-461F-A86F-48801DEEC920");
+        var forwardedByUserUuid = new Guid("9ECDE07C-CF64-42B0-BEBD-035F195FB77E");
+        var forwardingEventId = Guid.NewGuid();
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow)
+            .WithForwardingEvents(new List<CorrespondenceForwardingEventEntity>
+            {
+                new CorrespondenceForwardingEventEntity
+                {
+                    Id = forwardingEventId,
+                    CorrespondenceId = correspondenceId,
+                    ForwardedOnDate = new DateTimeOffset(new DateTime(2024, 1, 6, 11, 5, 0)),
+                    ForwardedByPartyUuid = delegatedUserPartyUuid,
+                    ForwardedByUserId = 123,
+                    ForwardedByUserUuid = forwardedByUserUuid,
+                    MailboxSupplier = "urn:altinn:organization:identifier-no:984661185"
+                }
+            })
+            .Build();
+
+        foreach (var fwdEvent in correspondence.ForwardingEvents)
+        {
+            fwdEvent.Correspondence = correspondence;
+        }
+
+        var (service, forwardingRepoMock, altinnRegisterMock, getBody) = CreateServiceWithForwardingEventSupport(correspondence);
+
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(delegatedUserPartyUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = delegatedUserPartyUuid,
+                SSN = "12345678901",
+                PartyTypeName = PartyType.Person,
+                Name = "Test Person"
+            });
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialogForMigratedCorrespondence(correspondenceId, correspondence);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+
+        forwardingRepoMock.Verify(r => r.SetDialogActivityId(forwardingEventId, It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        var capturedRequestBody = getBody();
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.Activities);
+    }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialogForMigratedCorrespondence_WithInstanceDelegationEvent_ShouldIncludeForwardingActivity()
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+        var delegatedUserPartyUuid = new Guid("358C48B4-74A7-461F-A86F-48801DEEC920");
+        var forwardedByUserUuid = new Guid("9ECDE07C-CF64-42B0-BEBD-035F195FB77E");
+        var forwardedToUserUuid = new Guid("1D5FD16E-2905-414A-AC97-844929975F17");
+        var forwardingEventId = Guid.NewGuid();
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow)
+            .WithForwardingEvents(new List<CorrespondenceForwardingEventEntity>
+            {
+                new CorrespondenceForwardingEventEntity
+                {
+                    Id = forwardingEventId,
+                    CorrespondenceId = correspondenceId,
+                    ForwardedOnDate = new DateTimeOffset(new DateTime(2024, 1, 6, 12, 15, 0)),
+                    ForwardedByPartyUuid = delegatedUserPartyUuid,
+                    ForwardedByUserId = 123,
+                    ForwardedByUserUuid = forwardedByUserUuid,
+                    ForwardedToUserId = 456,
+                    ForwardedToUserUuid = forwardedToUserUuid,
+                    ForwardingText = "User2, - look into this for me please. - User1.",
+                    ForwardedToEmailAddress = "user2@awesometestusers.com"
+                }
+            })
+            .Build();
+
+        foreach (var fwdEvent in correspondence.ForwardingEvents)
+        {
+            fwdEvent.Correspondence = correspondence;
+        }
+
+        var (service, forwardingRepoMock, altinnRegisterMock, getBody) = CreateServiceWithForwardingEventSupport(correspondence);
+
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(delegatedUserPartyUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = delegatedUserPartyUuid,
+                SSN = "12345678901",
+                PartyTypeName = PartyType.Person,
+                Name = "Sender Person"
+            });
+
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(forwardedToUserUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = forwardedToUserUuid,
+                SSN = "98765432109",
+                PartyTypeName = PartyType.Person,
+                Name = "Recipient Person"
+            });
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialogForMigratedCorrespondence(correspondenceId, correspondence);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+
+        forwardingRepoMock.Verify(r => r.SetDialogActivityId(forwardingEventId, It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify both party lookups were called
+        altinnRegisterMock.Verify(a => a.LookUpPartyByPartyUuid(delegatedUserPartyUuid, It.IsAny<CancellationToken>()), Times.Once);
+        altinnRegisterMock.Verify(a => a.LookUpPartyByPartyUuid(forwardedToUserUuid, It.IsAny<CancellationToken>()), Times.Once);
+
+        var capturedRequestBody = getBody();
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.Activities);
+
+        var forwardingActivity = deserialized.Activities.FirstOrDefault(a =>
+            a.Description?.Any(d => d.Value.Contains("Recipient Person")) == true);
+
+        Assert.NotNull(forwardingActivity);
+        Assert.Equal("Information", forwardingActivity!.Type);
+    }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialogForMigratedCorrespondence_WithMultipleForwardingEvents_ShouldIncludeAllActivitiesInOrder()
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+        var delegatedUserPartyUuid = new Guid("358C48B4-74A7-461F-A86F-48801DEEC920");
+        var forwardedByUserUuid = new Guid("9ECDE07C-CF64-42B0-BEBD-035F195FB77E");
+        var forwardedToUserUuid = new Guid("1D5FD16E-2905-414A-AC97-844929975F17");
+
+        var emailDate = new DateTimeOffset(new DateTime(2024, 1, 6, 11, 0, 0));
+        var mailboxDate = new DateTimeOffset(new DateTime(2024, 1, 6, 11, 5, 0));
+        var delegationDate = new DateTimeOffset(new DateTime(2024, 1, 6, 12, 15, 0));
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow)
+            .WithForwardingEvents(new List<CorrespondenceForwardingEventEntity>
+            {
+                new CorrespondenceForwardingEventEntity
+                {
+                    Id = Guid.NewGuid(),
+                    CorrespondenceId = correspondenceId,
+                    ForwardedOnDate = emailDate,
+                    ForwardedByPartyUuid = delegatedUserPartyUuid,
+                    ForwardedByUserId = 123,
+                    ForwardedByUserUuid = forwardedByUserUuid,
+                    ForwardedToEmailAddress = "user1@awesometestusers.com",
+                    ForwardingText = "Keep this as a backup in my email."
+                },
+                new CorrespondenceForwardingEventEntity
+                {
+                    Id = Guid.NewGuid(),
+                    CorrespondenceId = correspondenceId,
+                    ForwardedOnDate = mailboxDate,
+                    ForwardedByPartyUuid = delegatedUserPartyUuid,
+                    ForwardedByUserId = 123,
+                    ForwardedByUserUuid = forwardedByUserUuid,
+                    MailboxSupplier = "urn:altinn:organization:identifier-no:984661185"
+                },
+                new CorrespondenceForwardingEventEntity
+                {
+                    Id = Guid.NewGuid(),
+                    CorrespondenceId = correspondenceId,
+                    ForwardedOnDate = delegationDate,
+                    ForwardedByPartyUuid = delegatedUserPartyUuid,
+                    ForwardedByUserId = 123,
+                    ForwardedByUserUuid = forwardedByUserUuid,
+                    ForwardedToUserId = 456,
+                    ForwardedToUserUuid = forwardedToUserUuid,
+                    ForwardingText = "User2, - look into this for me please. - User1.",
+                    ForwardedToEmailAddress = "user2@awesometestusers.com"
+                }
+            })
+            .Build();
+
+        foreach (var fwdEvent in correspondence.ForwardingEvents)
+        {
+            fwdEvent.Correspondence = correspondence;
+        }
+
+        var (service, forwardingRepoMock, altinnRegisterMock, getBody) = CreateServiceWithForwardingEventSupport(correspondence);
+
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(delegatedUserPartyUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = delegatedUserPartyUuid,
+                SSN = "12345678901",
+                PartyTypeName = PartyType.Person,
+                Name = "Forwarder"
+            });
+
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(forwardedToUserUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = forwardedToUserUuid,
+                SSN = "98765432109",
+                PartyTypeName = PartyType.Person,
+                Name = "Delegate"
+            });
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialogForMigratedCorrespondence(correspondenceId, correspondence);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+
+        // Verify DialogActivityId was set for all 3 events
+        forwardingRepoMock.Verify(r => r.SetDialogActivityId(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+
+        var capturedRequestBody = getBody();
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.Activities);
+
+        // Find forwarding activities (exclude status activities)
+        var forwardingActivities = deserialized.Activities
+            .Where(a => a.Description?.Any(d => 
+                d.Value.Contains("user1@awesometestusers.com") || 
+                d.Value.Contains("Digipost") || 
+                d.Value.Contains("Delegate")) == true)
+            .OrderBy(a => a.CreatedAt)
+            .ToList();
+
+        Assert.Equal(3, forwardingActivities.Count);
+
+        // Verify they are ordered by ForwardedOnDate
+        Assert.Equal(emailDate, forwardingActivities[0].CreatedAt);
+        Assert.Equal(mailboxDate, forwardingActivities[1].CreatedAt);
+        Assert.Equal(delegationDate, forwardingActivities[2].CreatedAt);
+    }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialogForMigratedCorrespondence_WithNoForwardingEvents_ShouldNotIncludeForwardingActivities()
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow)
+            .Build();
+
+        var (service, _, _, getBody) = CreateServiceWithForwardingEventSupport(correspondence);
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialogForMigratedCorrespondence(correspondenceId, correspondence);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+
+        var capturedRequestBody = getBody();
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.Activities);
+
+        // Should only have status activities, no forwarding activities
+        var forwardingActivities = deserialized.Activities
+            .Where(a => a.Type == "Information" && 
+                       a.Description?.Any(d => d.Value.Contains("@") || d.Value.Contains("Digipost") || d.Value.Contains("e-Boks")) == true)
+            .ToList();
+
+        Assert.Empty(forwardingActivities);
+    }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialogForMigratedCorrespondence_WithExistingDialogActivityId_ShouldNotReassignId()
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+        var forwardedByPartyUuid = Guid.NewGuid();
+        var existingDialogActivityId = Guid.NewGuid();
+        var forwardingEventId = Guid.NewGuid();
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow)
+            .WithForwardingEvents(new List<CorrespondenceForwardingEventEntity>
+            {
+                new CorrespondenceForwardingEventEntity
+                {
+                    Id = forwardingEventId,
+                    CorrespondenceId = correspondenceId,
+                    DialogActivityId = existingDialogActivityId, // Already has an ID
+                    ForwardedOnDate = new DateTimeOffset(new DateTime(2024, 1, 6, 11, 0, 0)),
+                    ForwardedByPartyUuid = forwardedByPartyUuid,
+                    ForwardedByUserId = 123,
+                    ForwardedByUserUuid = Guid.NewGuid(),
+                    ForwardedToEmailAddress = "test@example.com"
+                }
+            })
+            .Build();
+
+        foreach (var fwdEvent in correspondence.ForwardingEvents)
+        {
+            fwdEvent.Correspondence = correspondence;
+        }
+
+        var (service, forwardingRepoMock, altinnRegisterMock, getBody) = CreateServiceWithForwardingEventSupport(correspondence);
+
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(forwardedByPartyUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = forwardedByPartyUuid,
+                SSN = "12345678901",
+                PartyTypeName = PartyType.Person
+            });
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialogForMigratedCorrespondence(correspondenceId, correspondence);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+
+        // Should NOT call SetDialogActivityId since it already exists
+        forwardingRepoMock.Verify(r => r.SetDialogActivityId(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        var capturedRequestBody = getBody();
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        // Verify the existing DialogActivityId is used
+        var forwardingActivity = deserialized!.Activities.FirstOrDefault(a =>
+            a.Description?.Any(d => d.Value.Contains("test@example.com")) == true);
+
+        Assert.NotNull(forwardingActivity);
+        Assert.Equal(existingDialogActivityId.ToString(), forwardingActivity!.Id);
+    }
 }
-
-

--- a/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
@@ -517,12 +517,11 @@ public class DialogportenServiceTests
                 d.Value.Contains("user1@awesometestusers.com") || 
                 d.Value.Contains("Digipost") || 
                 d.Value.Contains("Delegate")) == true)
-            .OrderBy(a => a.CreatedAt)
             .ToList();
 
         Assert.Equal(3, forwardingActivities.Count);
 
-        // Verify they are ordered by ForwardedOnDate
+        // Verify they are in the correct emission order
         Assert.Equal(emailDate, forwardingActivities[0].CreatedAt);
         Assert.Equal(mailboxDate, forwardingActivities[1].CreatedAt);
         Assert.Equal(delegationDate, forwardingActivities[2].CreatedAt);

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
@@ -760,6 +760,127 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         }
 
         [Fact]
+        public async Task ProcessAndMakeAvailable_ForwardingEvents_OK()
+        {
+            // Arrange
+            var correspondenceId = Guid.NewGuid();
+            int altinn2CorrespondenceId = 12345;
+            var forwardedByUserUuid = new Guid("9ECDE07C-CF64-42B0-BEBD-035F195FB77E");
+            var forwardedToUserUuid = new Guid("1D5FD16E-2905-414A-AC97-844929975F17");
+
+            var correspondenceRequestObject = new CorrespondenceEntityBuilder()
+                    .WithResourceId("TTD-migratedCorrespondence-1-1")
+                    .WithId(Guid.Empty) // Not set before creation
+                    .WithAltinn2CorrespondenceId(altinn2CorrespondenceId)
+                    .WithStatus(CorrespondenceStatus.Initialized, DateTimeOffset.UtcNow.AddDays(-1).AddMinutes(-1))
+                    .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow.AddDays(-1))
+                    .WithForwardingEvents(new List<CorrespondenceForwardingEventEntity>() { new CorrespondenceForwardingEventEntity
+                    {
+                        // Example of Copy sent to own email address
+                        ForwardedOnDate = new DateTimeOffset(new DateTime(2024, 1, 6, 11, 0, 0)),
+                        ForwardedByPartyUuid = _defaultUserPartyUuid,
+                        ForwardedByUserId = 123,
+                        ForwardedByUserUuid = forwardedByUserUuid,
+                        ForwardedToEmailAddress = "user1@awesometestusers.com",
+                        ForwardingText = "Keep this as a backup in my email."
+                    },
+                    new CorrespondenceForwardingEventEntity
+                    {
+                        // Example of Copy sent to own digital mailbox
+                        ForwardedOnDate = new DateTimeOffset(new DateTime(2024, 1, 6, 11, 5, 0)),
+                        ForwardedByPartyUuid = _defaultUserPartyUuid,
+                        ForwardedByUserId = 123,
+                        ForwardedByUserUuid = forwardedByUserUuid,
+                        MailboxSupplier = "urn:altinn:organization:identifier-no:123456789"
+                    },
+                    new CorrespondenceForwardingEventEntity
+                    {
+                        // Example of Instance Delegation by User 1 to User2
+                        ForwardedOnDate = new DateTimeOffset(new DateTime(2024, 1, 6, 12, 15, 0)),
+                        ForwardedByPartyUuid = _defaultUserPartyUuid,
+                        ForwardedByUserId = 123,
+                        ForwardedByUserUuid = forwardedByUserUuid,
+                        ForwardedToUserId = 456,
+                        ForwardedToUserUuid = forwardedToUserUuid,
+                        ForwardingText = "User2, - look into this for me please. - User1.",
+                        ForwardedToEmailAddress  = "user2@awesometestusers.com"
+                    }})
+                    .Build();
+
+            var correspondenceMockReturn = new CorrespondenceEntity
+            {
+                Id = correspondenceId,
+                ResourceId = correspondenceRequestObject.ResourceId,
+                Recipient = correspondenceRequestObject.Recipient,
+                Sender = correspondenceRequestObject.Sender,
+                SendersReference = correspondenceRequestObject.SendersReference,
+                RequestedPublishTime = correspondenceRequestObject.RequestedPublishTime,
+                Statuses = correspondenceRequestObject.Statuses,
+                ExternalReferences = correspondenceRequestObject.ExternalReferences,
+                Created = correspondenceRequestObject.Created,
+                Altinn2CorrespondenceId = correspondenceRequestObject.Altinn2CorrespondenceId,
+                ForwardingEvents = correspondenceRequestObject.ForwardingEvents
+            };
+
+            // Set navigation properties for forwarding events
+            foreach (var fwdEvent in correspondenceMockReturn.ForwardingEvents)
+            {
+                fwdEvent.Correspondence = correspondenceMockReturn;
+                fwdEvent.CorrespondenceId = correspondenceId;
+            }
+
+            var request = new MigrateCorrespondenceRequest
+            {
+                Altinn2CorrespondenceId = altinn2CorrespondenceId,
+                CorrespondenceEntity = correspondenceRequestObject,
+                MakeAvailable = true
+            };
+
+            _correspondenceRepositoryMock.Setup(x => x.CreateCorrespondence(It.IsAny<CorrespondenceEntity>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(correspondenceMockReturn);
+            _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(
+                correspondenceId, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+                .ReturnsAsync(correspondenceMockReturn);
+
+            // The dialogporten service will call BuildForwardingActivities internally when creating the dialog
+            _dialogportenServiceMock.Setup(x => x.CreateCorrespondenceDialogForMigratedCorrespondence(
+                correspondenceId, It.IsAny<CorrespondenceEntity>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .ReturnsAsync($"dialog-{correspondenceId}");
+
+            // Act
+            var result = await _handler.Process(request, null, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsT0);
+
+            // Verify correspondence was created with all 3 forwarding events of different types
+            _correspondenceRepositoryMock.Verify(x => x.CreateCorrespondence(It.Is<CorrespondenceEntity>(c =>
+                c.Altinn2CorrespondenceId == altinn2CorrespondenceId &&
+                c.Statuses.Any(s => s.Status == CorrespondenceStatus.Published) &&
+                c.ForwardingEvents != null && c.ForwardingEvents.Count == 3 &&
+                c.ForwardingEvents.Any(fe => fe.ForwardedToEmailAddress == "user1@awesometestusers.com") &&
+                c.ForwardingEvents.Any(fe => fe.MailboxSupplier == "urn:altinn:organization:identifier-no:123456789") &&
+                c.ForwardingEvents.Any(fe => fe.ForwardedToUserUuid == forwardedToUserUuid)
+            ), It.IsAny<CancellationToken>()), Times.Once);
+
+            _correspondenceRepositoryMock.Verify(x => x.AddExternalReference(
+                correspondenceId, ReferenceType.DialogportenDialogId, $"dialog-{correspondenceId}", It.IsAny<CancellationToken>()), Times.Once);
+            _correspondenceRepositoryMock.Verify(x => x.UpdateIsMigrating(
+                correspondenceId, false, It.IsAny<CancellationToken>()), Times.Once);
+            _correspondenceRepositoryMock.VerifyNoOtherCalls();
+
+            // Verify dialog was created with the correspondence containing forwarding events
+            // Note: BuildForwardingActivities is called internally by CreateCorrespondenceDialogForMigratedCorrespondence
+            _dialogportenServiceMock.Verify(x => x.CreateCorrespondenceDialogForMigratedCorrespondence(
+                correspondenceId, 
+                It.Is<CorrespondenceEntity>(c => c.ForwardingEvents != null && c.ForwardingEvents.Count == 3), 
+                It.IsAny<bool>(), 
+                false), 
+                Times.Once);
+            _dialogportenServiceMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
         public async Task Remigrate_NewEventsInA3_NothingChanged()
         {
             // Arrange

--- a/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/CreateDialogRequestMapperTests.cs
@@ -1,7 +1,9 @@
+using Altinn.Correspondence.API.Models;
+using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Integrations.Dialogporten.Mappers;
+using Altinn.Correspondence.Integrations.Dialogporten.Models;
 using Altinn.Correspondence.Tests.Factories;
-using Altinn.Correspondence.Core.Models.Entities;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -411,6 +413,61 @@ public class CreateDialogRequestMapperTests
         var reminderEnDescription = reminderActivity.Description.FirstOrDefault(d => d.LanguageCode == "en");
         Assert.NotNull(reminderEnDescription);
         Assert.Equal("Reminder notification about received message sent to +4712345678 on SMS.", reminderEnDescription.Value);
+    }
+
+    [Fact]
+    public void CreateCorrespondenceDialog_WithForwardingActivities_ShouldIncludeInDialog()
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+        var fwdEventId = Guid.NewGuid();
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithMessageTitle("Test Message")
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow.AddDays(-1))
+            .WithForwardingEvents(
+            new List<CorrespondenceForwardingEventEntity>
+            {
+                new CorrespondenceForwardingEventEntity
+                {
+                    // Example of Copy sent to own email address
+                    ForwardedOnDate = new DateTimeOffset(new DateTime(2024, 1, 6, 11 ,0 ,0)),
+                    ForwardedByPartyUuid = new Guid("358C48B4-74A7-461F-A86F-48801DEEC920"),
+                    ForwardedByUserId = 123,
+                    ForwardedByUserUuid = new Guid("9ECDE07C-CF64-42B0-BEBD-035F195FB77E"),
+                    ForwardedToEmailAddress = "user1@awesometestusers.com",
+                    ForwardingText = "Keep this as a backup in my email."
+                }
+            })
+            .Build();
+
+        var forwardingActivities = new List<Activity>
+        {
+            new Activity
+            {
+                Id = fwdEventId.ToString(),
+                Type = "Information",
+                CreatedAt = DateTimeOffset.UtcNow.AddHours(-2),
+                PerformedBy = new PerformedBy { ActorId = "urn:altinn:person:identifier-no:12018012345", ActorType = "PartyRepresentative" },
+                Description = new List<Description>
+                {
+                    new Description { LanguageCode = "nb", Value = "Kopi av 'Test Message' ble videresendt til user1@awesometestusers.com. Melding: Keep this as a backup in my email." }
+                }
+            }
+        };
+
+        // Act
+        var result = CreateDialogRequestMapper.CreateCorrespondenceDialog(
+            correspondence,
+            "https://example.com",
+            includeActivities: true,
+            forwardingActivities: forwardingActivities);
+
+        // Assert
+        Assert.NotNull(result.Activities);
+        var forwardingActivity = result.Activities.FirstOrDefault(a => a.Type == "Information");
+        Assert.NotNull(forwardingActivity);
+        Assert.Contains("videresendt til user1@awesometestusers.com", forwardingActivity.Description[0].Value);
     }
 
     private static int GetUuidVersion(Guid guid)

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -255,7 +255,7 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
 
     public async Task<string> MakeCorrespondenceAvailableInDialogportenAndApi(Guid correspondenceId, CancellationToken cancellationToken, bool isPrepublished, CorrespondenceEntity ? correspondenceEntity = null, bool createEvents = false)
     {
-        var correspondence = correspondenceEntity ?? await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, false, cancellationToken, true);
+        var correspondence = correspondenceEntity ?? await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, true, cancellationToken, true);
         if (correspondence == null)
         {
             throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -1242,6 +1242,8 @@ public class DialogportenService(HttpClient _httpClient,
             PerformedBy = new PerformedBy
             {
                 ActorId = forwardedByUrn,
+                // ActorType is always "PartyRepresentative" for forwarding events since they are
+                // performed by a user forwarding on behalf of a party.                
                 ActorType = "PartyRepresentative"
             },
             CreatedAt = forwardingEvent.ForwardedOnDate,

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -1045,9 +1045,7 @@ public class DialogportenService(HttpClient _httpClient,
 
         // Post the activity to Dialogporten
         var correspondence = forwardingEvent.Correspondence!;
-
-        // Build the activity using shared logic
-        var activity = await BuildForwardingActivity(forwardingEvent, correspondence, cancellationToken);
+                
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
@@ -1058,7 +1056,10 @@ public class DialogportenService(HttpClient _httpClient,
             }
             throw new ArgumentException($"No dialog found on correspondence with id {correspondence.Id}");
         }
-        
+
+        // Build the activity using shared logic
+        var activity = await BuildForwardingActivity(forwardingEvent, correspondence, cancellationToken);
+
         // Convert the Activity to CreateDialogActivityRequest
         var createDialogActivityRequest = new CreateDialogActivityRequest
         {

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -1138,12 +1138,17 @@ public class DialogportenService(HttpClient _httpClient,
     /// </summary>
     private async Task<Activity> BuildForwardingActivity(CorrespondenceForwardingEventEntity forwardingEvent, CorrespondenceEntity correspondence, CancellationToken cancellationToken)
     {
-        // Ensure DialogActivityId exists
+        // Generate DialogActivityId if needed, but don't persist until validation succeeds
+        Guid dialogActivityId;
+        bool persistNewActivityId = false;
         if (forwardingEvent.DialogActivityId == null)
         {
-            var dialogActivityId = Uuid.NewDatabaseFriendly(Database.PostgreSql);
-            forwardingEvent.DialogActivityId = dialogActivityId;
-            await correspondenceForwardingEventRepository.SetDialogActivityId(forwardingEvent.Id, dialogActivityId, cancellationToken);
+            dialogActivityId = Uuid.NewDatabaseFriendly(Database.PostgreSql);
+            persistNewActivityId = true;
+        }
+        else
+        {
+            dialogActivityId = forwardingEvent.DialogActivityId.Value;
         }
 
         // Resolve forwardedBy party
@@ -1222,10 +1227,17 @@ public class DialogportenService(HttpClient _httpClient,
             throw new Exception($"Forwarding event {forwardingEvent.Id} has no valid forwarding target (no ForwardedToUserUuid, ForwardedToEmailAddress or MailboxSupplier)");
         }
 
+        // All validation and lookups succeeded, now persist the new DialogActivityId if needed
+        if (persistNewActivityId)
+        {
+            forwardingEvent.DialogActivityId = dialogActivityId;
+            await correspondenceForwardingEventRepository.SetDialogActivityId(forwardingEvent.Id, dialogActivityId, cancellationToken);
+        }
+
         // Build and return the Activity object
         return new Activity
         {
-            Id = forwardingEvent.DialogActivityId.Value.ToString(),
+            Id = dialogActivityId.ToString(),
             PerformedBy = new PerformedBy
             {
                 ActorId = forwardedByUrn,

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -1119,7 +1119,7 @@ public class DialogportenService(HttpClient _httpClient,
                     forwardingActivities.Add(activity);
                 }
             }
-            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException || cancellationToken.IsCancellationRequested)
+            catch (Exception ex) when (ex is OperationCanceledException || cancellationToken.IsCancellationRequested)
             {
                 throw;
             }
@@ -1231,8 +1231,8 @@ public class DialogportenService(HttpClient _httpClient,
         // All validation and lookups succeeded, now persist the new DialogActivityId if needed
         if (persistNewActivityId)
         {
-            forwardingEvent.DialogActivityId = dialogActivityId;
             await correspondenceForwardingEventRepository.SetDialogActivityId(forwardingEvent.Id, dialogActivityId, cancellationToken);
+            forwardingEvent.DialogActivityId = dialogActivityId;
         }
 
         // Build and return the Activity object

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -1042,15 +1042,20 @@ public class DialogportenService(HttpClient _httpClient,
     public async Task AddForwardingEvent(Guid forwardingEventId, CancellationToken cancellationToken)
     {
         var forwardingEvent = await correspondenceForwardingEventRepository.GetForwardingEvent(forwardingEventId, cancellationToken);
-        
-        // Build the activity using shared logic
-        var activity = await BuildForwardingActivity(forwardingEvent, cancellationToken);
-        
+
         // Post the activity to Dialogporten
         var correspondence = forwardingEvent.Correspondence!;
+
+        // Build the activity using shared logic
+        var activity = await BuildForwardingActivity(forwardingEvent, correspondence, cancellationToken);
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
         if (dialogId is null)
         {
+            if (correspondence.IsMigrating)
+            {
+                logger.LogWarning("Skipping adding forwarding event for correspondence {correspondenceId} as it is an Altinn2 correspondence without Dialogporten dialog", correspondence.Id);
+                return;
+            }
             throw new ArgumentException($"No dialog found on correspondence with id {correspondence.Id}");
         }
         
@@ -1107,11 +1112,15 @@ public class DialogportenService(HttpClient _httpClient,
         {
             try
             {
-                var activity = await BuildForwardingActivity(forwardingEvent, cancellationToken);
+                var activity = await BuildForwardingActivity(forwardingEvent, correspondence, cancellationToken);
                 if (activity != null)
                 {
                     forwardingActivities.Add(activity);
                 }
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException || cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -1127,14 +1136,8 @@ public class DialogportenService(HttpClient _httpClient,
     /// Builds a complete Activity object for a single forwarding event.
     /// Performs all necessary party lookups and determines forwarding type.
     /// </summary>
-    private async Task<Activity> BuildForwardingActivity(CorrespondenceForwardingEventEntity forwardingEvent, CancellationToken cancellationToken)
+    private async Task<Activity> BuildForwardingActivity(CorrespondenceForwardingEventEntity forwardingEvent, CorrespondenceEntity correspondence, CancellationToken cancellationToken)
     {
-        if (forwardingEvent.Correspondence == null)
-        {
-            throw new ArgumentException($"Forwarding event {forwardingEvent.Id} has no correspondence loaded", nameof(forwardingEvent));
-        }
-        
-        var correspondence = forwardingEvent.Correspondence;
         // Ensure DialogActivityId exists
         if (forwardingEvent.DialogActivityId == null)
         {

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -1039,11 +1039,11 @@ public class DialogportenService(HttpClient _httpClient,
         }
         throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
     }
+
     public async Task AddForwardingEvent(Guid forwardingEventId, CancellationToken cancellationToken)
     {
         var forwardingEvent = await correspondenceForwardingEventRepository.GetForwardingEvent(forwardingEventId, cancellationToken);
-
-        // Post the activity to Dialogporten
+        
         var correspondence = forwardingEvent.Correspondence!;
                 
         var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -899,6 +899,8 @@ public class DialogportenService(HttpClient _httpClient,
         var (OpenedId, ConfirmedId) = await CreateIdempotencyKeysForCorrespondence(correspondence, cancellationToken);
         var dialogParty = await GetDialogParty(correspondence);
 
+        var forwardingActivities = await BuildForwardingActivities(correspondence, cancellationToken);
+
         var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(
             correspondence: correspondence,
             baseUrl: generalSettings.Value.CorrespondenceBaseUrl,
@@ -907,7 +909,8 @@ public class DialogportenService(HttpClient _httpClient,
             openedActivityIdempotencyKey: OpenedId.ToString(),
             confirmedActivityIdempotencyKey: ConfirmedId?.ToString(),
             isSoftDeleted: isSoftDeleted,
-            dialogParty: dialogParty);
+            dialogParty: dialogParty,
+            forwardingActivities: forwardingActivities);
         string updateType = enableEvents ? "" : "?IsSilentUpdate=true";
         var response = await _httpClient.PostAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs{updateType}", createDialogRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
@@ -1039,13 +1042,108 @@ public class DialogportenService(HttpClient _httpClient,
     public async Task AddForwardingEvent(Guid forwardingEventId, CancellationToken cancellationToken)
     {
         var forwardingEvent = await correspondenceForwardingEventRepository.GetForwardingEvent(forwardingEventId, cancellationToken);
-        if (forwardingEvent.DialogActivityId is null)
+        
+        // Build the activity using shared logic
+        var activity = await BuildForwardingActivity(forwardingEvent, cancellationToken);
+        
+        // Post the activity to Dialogporten
+        var correspondence = forwardingEvent.Correspondence!;
+        var dialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
+        if (dialogId is null)
+        {
+            throw new ArgumentException($"No dialog found on correspondence with id {correspondence.Id}");
+        }
+        
+        // Convert the Activity to CreateDialogActivityRequest
+        var createDialogActivityRequest = new CreateDialogActivityRequest
+        {
+            Id = activity.Id,
+            CreatedAt = activity.CreatedAt,
+            Type = Enum.Parse<ActivityType>(activity.Type),
+            PerformedBy = new ActivityPerformedBy
+            {
+                ActorId = activity.PerformedBy.ActorId,
+                ActorName = activity.PerformedBy.ActorName,
+                ActorType = activity.PerformedBy.ActorType
+            },
+            Description = activity.Description.Select(d => new ActivityDescription
+            {
+                Value = d.Value,
+                LanguageCode = d.LanguageCode
+            }).ToList()
+        };
+        
+        var response = await _httpClient.PostAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}/activities?isSilentUpdate=true", createDialogActivityRequest, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync();
+                if (errorContent.Contains("already exists"))
+                {
+                    logger.LogWarning("Activity already exists for correspondence {correspondenceId} and dialog {dialogId}", correspondence.Id, dialogId);
+                    return;
+                }
+            }
+            throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+        }
+    }
+
+    /// <summary>
+    /// Builds forwarding activities for migrated correspondence.
+    /// Handles party lookups, DialogActivityId management, and mailbox supplier resolution.
+    /// Returns complete Activity objects ready to be included in dialog creation.
+    /// </summary>
+    private async Task<List<Activity>> BuildForwardingActivities(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
+    {
+        var forwardingActivities = new List<Activity>();
+        
+        if (correspondence.ForwardingEvents == null || !correspondence.ForwardingEvents.Any())
+        {
+            return forwardingActivities;
+        }
+
+        foreach (var forwardingEvent in correspondence.ForwardingEvents.OrderBy(fe => fe.ForwardedOnDate))
+        {
+            try
+            {
+                var activity = await BuildForwardingActivity(forwardingEvent, cancellationToken);
+                if (activity != null)
+                {
+                    forwardingActivities.Add(activity);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to build forwarding activity for event {ForwardingEventId} on correspondence {CorrespondenceId}. Skipping this event.", 
+                    forwardingEvent.Id, correspondence.Id);
+            }
+        }
+
+        return forwardingActivities;
+    }
+
+    /// <summary>
+    /// Builds a complete Activity object for a single forwarding event.
+    /// Performs all necessary party lookups and determines forwarding type.
+    /// </summary>
+    private async Task<Activity> BuildForwardingActivity(CorrespondenceForwardingEventEntity forwardingEvent, CancellationToken cancellationToken)
+    {
+        if (forwardingEvent.Correspondence == null)
+        {
+            throw new ArgumentException($"Forwarding event {forwardingEvent.Id} has no correspondence loaded", nameof(forwardingEvent));
+        }
+        
+        var correspondence = forwardingEvent.Correspondence;
+        // Ensure DialogActivityId exists
+        if (forwardingEvent.DialogActivityId == null)
         {
             var dialogActivityId = Uuid.NewDatabaseFriendly(Database.PostgreSql);
             forwardingEvent.DialogActivityId = dialogActivityId;
             await correspondenceForwardingEventRepository.SetDialogActivityId(forwardingEvent.Id, dialogActivityId, cancellationToken);
         }
 
+        // Resolve forwardedBy party
         var forwardedByParty = await altinnRegisterService
             .LookUpPartyByPartyUuid(forwardingEvent.ForwardedByPartyUuid, cancellationToken);
         if (forwardedByParty == null)
@@ -1060,12 +1158,16 @@ public class DialogportenService(HttpClient _httpClient,
         }
         else if (forwardedByParty.PartyTypeName == PartyType.SelfIdentified)
         {
-            forwardedByUrn = await GetDialogParty(forwardingEvent?.Correspondence);
+            forwardedByUrn = await GetDialogParty(correspondence);
         }
         else
         {
             throw new Exception($"Unsupported party type {forwardedByParty.PartyTypeName} for ForwardedByPartyUuid {forwardingEvent.ForwardedByPartyUuid} in forwarding event {forwardingEvent.Id}");
         }
+
+        // Determine forwarding type and create appropriate activity
+        DialogportenTextType textType;
+        string[] tokens;
 
         if (forwardingEvent.ForwardedToUserUuid is not null)
         {
@@ -1075,40 +1177,24 @@ public class DialogportenService(HttpClient _httpClient,
             {
                 throw new Exception($"Could not find party for ForwardedToUserUuid {forwardingEvent.ForwardedToUserUuid} in forwarding event {forwardingEvent.Id}");
             }
-            string[] tokens =
+            textType = DialogportenTextType.CorrespondenceInstanceDelegated;
+            tokens = new[]
             {
-                forwardingEvent.Correspondence?.Content?.MessageTitle ?? string.Empty,
+                correspondence.Content?.MessageTitle ?? string.Empty,
                 forwardedToUser.Name ?? throw new Exception($"No name found for user {forwardedToUser.PartyUuid}"),
                 forwardingEvent.ForwardingText ?? string.Empty
             };
-
-            await CreateInformationActivity(
-                forwardingEvent.CorrespondenceId,
-                DialogportenActorType.Recipient,
-                DialogportenTextType.CorrespondenceInstanceDelegated,
-                forwardedByUrn,
-                forwardingEvent.DialogActivityId,
-                forwardingEvent.ForwardedOnDate,
-                tokens);
         }
         else if (!string.IsNullOrEmpty(forwardingEvent.ForwardedToEmailAddress))
         {
             // Email forwarding
-            string[] tokens =
+            textType = DialogportenTextType.CorrespondenceForwardedToEmail;
+            tokens = new[]
             {
-                forwardingEvent.Correspondence?.Content?.MessageTitle ?? string.Empty,
+                correspondence.Content?.MessageTitle ?? string.Empty,
                 forwardingEvent.ForwardedToEmailAddress,
                 forwardingEvent.ForwardingText ?? string.Empty
             };
-
-            await CreateInformationActivity(
-                forwardingEvent.CorrespondenceId,
-                DialogportenActorType.Recipient,
-                DialogportenTextType.CorrespondenceForwardedToEmail,
-                forwardedByUrn,
-                forwardingEvent.DialogActivityId,
-                forwardingEvent.ForwardedOnDate,
-                tokens);
         }
         else if (!string.IsNullOrWhiteSpace(forwardingEvent.MailboxSupplier))
         {
@@ -1120,27 +1206,49 @@ public class DialogportenService(HttpClient _httpClient,
                 "urn:altinn:organization:identifier-no:996460320" => "e-Boks",
                 _ => throw new Exception($"Unknown mailbox supplier {forwardingEvent.MailboxSupplier} in forwarding event {forwardingEvent.Id}")
             };
-
-            string[] tokens =
+            textType = DialogportenTextType.CorrespondenceForwardedToMailboxSupplier;
+            tokens = new[]
             {
-                forwardingEvent.Correspondence?.Content?.MessageTitle ?? string.Empty,
+                correspondence.Content?.MessageTitle ?? string.Empty,
                 mailboxSupplierName,
                 forwardingEvent.ForwardingText ?? string.Empty
             };
-
-            await CreateInformationActivity(
-                forwardingEvent.CorrespondenceId,
-                DialogportenActorType.Recipient,
-                DialogportenTextType.CorrespondenceForwardedToMailboxSupplier,
-                forwardedByUrn,
-                forwardingEvent.DialogActivityId,
-                forwardingEvent.ForwardedOnDate,
-                tokens);
         }
         else
         {
             throw new Exception($"Forwarding event {forwardingEvent.Id} has no valid forwarding target (no ForwardedToUserUuid, ForwardedToEmailAddress or MailboxSupplier)");
         }
+
+        // Build and return the Activity object
+        return new Activity
+        {
+            Id = forwardingEvent.DialogActivityId.Value.ToString(),
+            PerformedBy = new PerformedBy
+            {
+                ActorId = forwardedByUrn,
+                ActorType = "PartyRepresentative"
+            },
+            CreatedAt = forwardingEvent.ForwardedOnDate,
+            Type = "Information",
+            Description = new List<Description>
+            {
+                new()
+                {
+                    LanguageCode = "nb",
+                    Value = DialogportenText.GetDialogportenText(textType, DialogportenLanguageCode.NB, tokens)
+                },
+                new()
+                {
+                    LanguageCode = "nn",
+                    Value = DialogportenText.GetDialogportenText(textType, DialogportenLanguageCode.NN, tokens)
+                },
+                new()
+                {
+                    LanguageCode = "en",
+                    Value = DialogportenText.GetDialogportenText(textType, DialogportenLanguageCode.EN, tokens)
+                }
+            }
+        };
     }
 
     private async Task<string?> GetDialogParty(CorrespondenceEntity correspondence)

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -21,7 +21,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
     internal static class CreateDialogRequestMapper
     {
-        internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl, bool includeActivities = false, ILogger? logger = null, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, bool isSoftDeleted = false, DateTimeOffset? currentUtcNow = null, string? dialogParty = null)
+        internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl, bool includeActivities = false, ILogger? logger = null, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, bool isSoftDeleted = false, DateTimeOffset? currentUtcNow = null, string? dialogParty = null, List<Activity>? forwardingActivities = null)
         {
             DateTimeOffset currentDateTimeUtcNow = currentUtcNow ?? DateTimeOffset.UtcNow;
             var dialogId = GetDialogId(correspondence, currentDateTimeUtcNow, logger);
@@ -61,7 +61,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 ApiActions = GetApiActionsForCorrespondence(baseUrl, correspondence),
                 GuiActions = GetGuiActionsForCorrespondence(baseUrl, correspondence),
                 Attachments = GetAttachmentsForCorrespondence(baseUrl, correspondence),
-                Activities = includeActivities ? GetActivitiesForMigratedCorrespondence(correspondence, openedActivityIdempotencyKey, confirmedActivityIdempotencyKey, dialogParty) : new List<Activity>(),
+                Activities = includeActivities ? GetActivitiesForMigratedCorrespondence(correspondence, openedActivityIdempotencyKey, confirmedActivityIdempotencyKey, dialogParty, forwardingActivities) : new List<Activity>(),
                 Transmissions = new List<Transmission>(),
                 SystemLabel = GetSystemLabelForCorrespondence(correspondence, isSoftDeleted),
                 ServiceOwnerContext = GetServiceOwnerContextForCorrespondence(correspondence)
@@ -301,7 +301,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
         }
 
 
-        private static List<Activity> GetActivitiesForMigratedCorrespondence(CorrespondenceEntity correspondence, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, string? dialogParty = null)
+        private static List<Activity> GetActivitiesForMigratedCorrespondence(CorrespondenceEntity correspondence, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, string? dialogParty = null, List<Activity>? forwardingActivities = null)
         {
             List<Activity> activities = new();
             var orderedStatuses = correspondence.Statuses.OrderBy(s => s.StatusChanged);
@@ -319,6 +319,11 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             }
 
             activities.AddRange(GetActivitiesFromNotifications(correspondence));
+
+            if (forwardingActivities != null)
+            {
+                activities.AddRange(forwardingActivities);
+            }
 
             return activities.OrderBy(a => a.CreatedAt).ToList();
         }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceForwardingEventRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceForwardingEventRepository.cs
@@ -37,7 +37,13 @@ public class CorrespondenceForwardingEventRepository(ApplicationDbContext contex
 
     public async Task<CorrespondenceForwardingEventEntity> GetForwardingEvent(Guid forwardingEventId, CancellationToken cancellationToken)
     {
-        var correspondenceForwardingEventQuery = _context.CorrespondenceForwardingEvents.AsSplitQuery().Include(c => c.Correspondence).ThenInclude(c => c.Content).AsQueryable(); 
+        var correspondenceForwardingEventQuery = _context.CorrespondenceForwardingEvents.AsSplitQuery()
+            .Include(c => c.Correspondence)
+            .ThenInclude(c => c.Content)
+            .Include(c => c.Correspondence)
+            .ThenInclude(c => c.ExternalReferences)
+            .AsQueryable();
+
         var forwardingEvent = await correspondenceForwardingEventQuery.SingleOrDefaultAsync(c => c.Id == forwardingEventId, cancellationToken);
         return forwardingEvent ?? throw new KeyNotFoundException($"Could not find correspondence forwarding event with id {forwardingEventId}");
     }


### PR DESCRIPTION
Updated CreateDialog to include activites for ForwardingEvents, so that ForwardingEvents that have occured before Creating the Dialog are updated in Dialogporten.

Before this change, only ForwardingEvents that occurred after MakeAvailable (or processed through the MigrateForwardingEventsBatch) were made visible in Dialogporten.


## Description
- Added new common methods for creating InformationActivites based on ForwardingEvents, and refactored CreateCorrespondenceDialog and AddForwardingEvent to use these.
- Added additional unit tests and tweaked existing to verify logic.

## Related Issue(s)
- #1789

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration now builds and includes forwarding activities (email, mailbox, delegation) upfront, appended and ordered by forward date with multilingual descriptions; existing activity IDs are preserved and dialog-activity IDs are persisted only after validation.
  * Create/post logic tolerates duplicate postings (422 "already exists") to avoid failures.

* **Tests**
  * Added comprehensive tests validating forwarding inclusion, ordering, lookups, dialog-activity persistence, and end-to-end migration processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->