### PR TITLE
Updated SyncNotificationEvents to update Dialog

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
@@ -1525,6 +1525,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 n.Altinn2NotificationId == 2 && n.SyncedFromAltinn2 != null && n.CorrespondenceId == correspondenceId), It.IsAny<CancellationToken>()), Times.Once);
             _correspondenceNotificationRepositoryMock.VerifyNoOtherCalls();
 
+            VerifyDialogportenServiceAddNotificationEvent(correspondenceId, DialogportenTextType.NotificationReminderSent, new DateTimeOffset(new DateTime(2024, 1, 14)), "testemail@altinn.no", "Email");
+
             VerifyDialogportenServiceSetArchivedSystemLabelOnDialogEnqueued(correspondenceId, _defaultUserPartyIdentifier);
 
             _correspondenceRepositoryMock.Verify(x => x.ClearChangeTracker(), Times.Once);
@@ -1836,6 +1838,21 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.AddForwardingEvent) && (Guid)job.Args[0] == forwardingEventId),
+                It.IsAny<EnqueuedState>()));
+        }
+
+        private void VerifyDialogportenServiceAddNotificationEvent(Guid correspondenceId, DialogportenTextType dialogportenTextType, DateTimeOffset sentTime, string notificationAddress, string notificationChannel)
+        {
+            _backgroundJobClientMock.Verify(x => x.Create(
+                It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.CreateInformationActivity) 
+                    && (Guid)job.Args[0] == correspondenceId 
+                    && (DialogportenActorType)job.Args[1] == DialogportenActorType.ServiceOwner 
+                    && (DialogportenTextType)job.Args[2] == dialogportenTextType
+                    && (DateTimeOffset)job.Args[3] == sentTime
+                    && ((string[])job.Args[4]).Length == 2 
+                    && ((string[])job.Args[4])[0] == notificationAddress 
+                    && ((string[])job.Args[4])[1] == notificationChannel
+                    ),
                 It.IsAny<EnqueuedState>()));
         }
     }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
@@ -1797,21 +1797,21 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IEventBus.Publish) && (AltinnEventType)job.Args[0] == eventType && (string)job.Args[4] == recipient),
-                It.IsAny<EnqueuedState>()));
+                It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifyDialogportenServiceCreateConfirmedActivityEnqueued(Guid correspondenceId, DialogportenActorType actorType, string partyUrn)
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.CreateConfirmedActivity) && (Guid)job.Args[0] == correspondenceId && (DialogportenActorType)job.Args[1] == actorType && (string)job.Args[3] == partyUrn),
-                It.IsAny<IState>()));
+                It.IsAny<IState>()), Times.Once);
         }
 
         private void VerifyDialogportenServicePatchCorrespondenceDialogToConfirmedEnqueued(Guid correspondenceId)
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.PatchCorrespondenceDialogToConfirmed) && (Guid)job.Args[0] == correspondenceId),
-                It.IsAny<EnqueuedState>()));
+                It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifyDialogportenServiceSetArchivedSystemLabelOnDialogEnqueued(Guid correspondenceId, string partyIdentifier)
@@ -1824,21 +1824,21 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                         && job.Args[3] != null
                         && ((List<DialogPortenSystemLabel>)job.Args[3]).Contains(DialogPortenSystemLabel.Archive)
                         && job.Args[4] == null),
-                    It.IsAny<EnqueuedState>()));
+                    It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifyDialogportenServiceCreateOpenedActivityEnqueued(Guid correspondenceId, string partyUrn)
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.CreateOpenedActivity) && (Guid)job.Args[0] == correspondenceId && (string)job.Args[3] == partyUrn),
-                It.IsAny<EnqueuedState>()));
+                It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifyDialogportenServiceAddForwardingEvent(Guid forwardingEventId)
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.AddForwardingEvent) && (Guid)job.Args[0] == forwardingEventId),
-                It.IsAny<EnqueuedState>()));
+                It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifyDialogportenServiceAddNotificationEvent(Guid correspondenceId, DialogportenTextType dialogportenTextType, DateTimeOffset sentTime, string notificationAddress, string notificationChannel)
@@ -1853,7 +1853,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     && ((string[])job.Args[4])[0] == notificationAddress 
                     && ((string[])job.Args[4])[1] == notificationChannel
                     ),
-                It.IsAny<EnqueuedState>()));
+                It.IsAny<EnqueuedState>()), Times.Once);
         }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceNotificationEventHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceNotificationEventHandlerTests.cs
@@ -5,8 +5,11 @@ using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
+using Altinn.Correspondence.Core.Services.Enums;
 using Altinn.Correspondence.Tests.Factories;
 using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -131,6 +134,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceNotificationRepositoryMock.Verify(x => x.AddNotificationForSync(It.Is<CorrespondenceNotificationEntity>(n => 
                 n.Altinn2NotificationId == 2 && n.SyncedFromAltinn2 != null && n.CorrespondenceId == correspondenceId), It.IsAny<CancellationToken>()), Times.Once);
             _correspondenceNotificationRepositoryMock.VerifyNoOtherCalls();
+
+            _backgroundJobClientMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -190,6 +195,19 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceNotificationRepositoryMock.Verify(x => x.AddNotificationForSync(It.Is<CorrespondenceNotificationEntity>(n =>
                 n.Altinn2NotificationId == 2 && n.SyncedFromAltinn2 != null && n.CorrespondenceId == correspondenceId), It.IsAny<CancellationToken>()), Times.Once);
             _correspondenceNotificationRepositoryMock.VerifyNoOtherCalls();
+
+            _backgroundJobClientMock.Verify(x => x.Create(
+                It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.CreateInformationActivity)
+                    && (Guid)job.Args[0] == correspondenceId
+                    && (DialogportenActorType)job.Args[1] == DialogportenActorType.ServiceOwner
+                    && (DialogportenTextType)job.Args[2] == DialogportenTextType.NotificationReminderSent
+                    && (DateTimeOffset)job.Args[3] == new DateTimeOffset(new DateTime(2024, 1, 14))
+                    && ((string[])job.Args[4]).Length == 2
+                    && ((string[])job.Args[4])[0] == "testemail@altinn.no"
+                    && ((string[])job.Args[4])[1] == "Email"
+                    ),
+                It.IsAny<EnqueuedState>()));
+            _backgroundJobClientMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -260,6 +278,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceNotificationRepositoryMock.Verify(x => x.AddNotificationForSync(It.Is<CorrespondenceNotificationEntity>(n =>
                 n.Altinn2NotificationId == 3 && n.SyncedFromAltinn2 != null && n.CorrespondenceId == correspondenceId), It.IsAny<CancellationToken>()), Times.Once);
             _correspondenceNotificationRepositoryMock.VerifyNoOtherCalls();
+            _backgroundJobClientMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -316,6 +335,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceRepositoryMock.VerifyNoOtherCalls();
             // Verify that no new notification was added
             _correspondenceNotificationRepositoryMock.VerifyNoOtherCalls();
+            _backgroundJobClientMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -372,6 +392,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _correspondenceRepositoryMock.VerifyNoOtherCalls();
             // Verify that no new notification was added
             _correspondenceNotificationRepositoryMock.VerifyNoOtherCalls();
+            _backgroundJobClientMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -411,9 +432,11 @@ namespace Altinn.Correspondence.Tests.TestingHandler
 
             // Verify correct calls to Correspondence repository
             _correspondenceRepositoryMock.Verify(x => x.GetCorrespondenceByIdForSync(correspondenceId, CorrespondenceSyncType.NotificationEvents, It.IsAny<CancellationToken>()), Times.Once);
-            _correspondenceRepositoryMock.VerifyNoOtherCalls();
+            _correspondenceRepositoryMock.VerifyNoOtherCalls();            
+
             // Verify that no new notification was added
             _correspondenceNotificationRepositoryMock.VerifyNoOtherCalls();
+            _backgroundJobClientMock.VerifyNoOtherCalls();
         }
     }
 } 

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceNotificationEventHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceNotificationEventHandlerTests.cs
@@ -206,7 +206,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     && ((string[])job.Args[4])[0] == "testemail@altinn.no"
                     && ((string[])job.Args[4])[1] == "Email"
                     ),
-                It.IsAny<EnqueuedState>()));
+                It.IsAny<EnqueuedState>()), Times.Once);
             _backgroundJobClientMock.VerifyNoOtherCalls();
         }
 

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
@@ -2343,34 +2343,34 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IEventBus.Publish) && (AltinnEventType)job.Args[0] == eventType && (string)job.Args[4] == recipient),
-                It.IsAny<EnqueuedState>()));
+                It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifyStorageDeletionScheduled()
         {
             _backgroundJobClientMock.Verify(x => x.Create(
-                It.Is<Job>(job => job.Method.Name == nameof(IStorageRepository.PurgeAttachment)), It.IsAny<EnqueuedState>()));
+                It.Is<Job>(job => job.Method.Name == nameof(IStorageRepository.PurgeAttachment)), It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifyDialogportenServiceCreateConfirmedActivityEnqueued(Guid correspondenceId, DialogportenActorType actorType, string partyUrn)
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.CreateConfirmedActivity) && (Guid)job.Args[0] == correspondenceId && (DialogportenActorType)job.Args[1] == actorType && (string)job.Args[3] == partyUrn),
-                It.IsAny<IState>()));
+                It.IsAny<IState>()), Times.Once);
         }
 
         private void VerifyDialogportenServiceCreatePurgedActivityEnqueued(Guid correspondenceId, DialogportenActorType actorType, string actorname, DateTimeOffset operationTimestamp)
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.CreateCorrespondencePurgedActivity) && (Guid)job.Args[0] == correspondenceId && (DialogportenActorType)job.Args[1] == actorType && (string)job.Args[2] == actorname && (DateTimeOffset)job.Args[3] == operationTimestamp),
-                It.IsAny<IState>()));
+                It.IsAny<IState>()), Times.Once);
         }
 
         private void VerifyDialogportenServicePatchCorrespondenceDialogToConfirmedEnqueued(Guid correspondenceId)
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.PatchCorrespondenceDialogToConfirmed) && (Guid)job.Args[0] == correspondenceId),
-                It.IsAny<EnqueuedState>()));
+                It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifyDialogportenServiceSetArchivedSystemLabelOnDialogEnqueued(Guid correspondenceId, string partyIdentifier)
@@ -2383,7 +2383,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                         && job.Args[3] != null
                         && ((List<DialogPortenSystemLabel>)job.Args[3]).Contains(DialogPortenSystemLabel.Archive)
                         && job.Args[4] == null),
-                    It.IsAny<EnqueuedState>()));
+                    It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifySoftDeleteUpdateForDialogportenEnqueued(Guid correspondenceId, string partyIdentifier, CorrespondenceDeleteEventType eventType)
@@ -2398,7 +2398,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                         && job.Args[3] != null
                         && ((List<DialogPortenSystemLabel>)job.Args[3]).Contains(DialogPortenSystemLabel.Bin)
                         && job.Args[4] == null),
-                    It.IsAny<EnqueuedState>()));
+                    It.IsAny<EnqueuedState>()), Times.Once);
             }
             else if (eventType == CorrespondenceDeleteEventType.RestoredByRecipient)
             {
@@ -2410,7 +2410,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                         && job.Args[3] == null
                         && job.Args[4] != null
                         && ((List<DialogPortenSystemLabel>)job.Args[4]).Contains(DialogPortenSystemLabel.Bin)),
-                    It.IsAny<EnqueuedState>()));
+                    It.IsAny<EnqueuedState>()), Times.Once);
             }
         }
 
@@ -2418,7 +2418,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
         {
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == nameof(IDialogportenService.CreateOpenedActivity) && (Guid)job.Args[0] == correspondenceId && (string)job.Args[3] == partyUrn),
-                It.IsAny<EnqueuedState>()));
+                It.IsAny<EnqueuedState>()), Times.Once);
         }
 
         private void VerifyPurgeUpdatesAgainstDialogportenEnqueued(Guid correspondenceId, DateTimeOffset purgeOccurred, String dialogId, String userUrn, bool bySender = false)
@@ -2434,12 +2434,12 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     && (Guid)j.Args[1] == correspondenceId
                     && (DateTimeOffset)j.Args[2] == purgeOccurred
                     && (string)j.Args[3] == userUrn
-                ), It.IsAny<AwaitingState>()));
+                ), It.IsAny<AwaitingState>()), Times.Once);
             _backgroundJobClientMock.Verify(x => x.Create(
                 It.Is<Job>(j => j.Method.Name == nameof(PurgeCorrespondenceHelper.ReportNotificationCancelledToDialogporten)
                     && (Guid)j.Args[0] == correspondenceId
                     && (DateTimeOffset)j.Args[1] == purgeOccurred
-                ), It.IsAny<AwaitingState>()));
+                ), It.IsAny<AwaitingState>()), Times.Once);
         }
     }
 } 

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceMigrationEventHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceMigrationEventHelper.cs
@@ -684,13 +684,14 @@ public class CorrespondenceMigrationEventHelper(
         return forwardingEventsToProcess;
     }
 
-    public async Task<int> ProcessNotificationEvents(Guid correspondenceId, CorrespondenceEntity correspondence, List<CorrespondenceNotificationEntity> notificationEvents, MigrationOperationType operationName, CancellationToken cancellationToken)
+    public async Task<int> ProcessNotificationEvents(CorrespondenceEntity correspondence, List<CorrespondenceNotificationEntity> notificationEvents, MigrationOperationType operationName, CancellationToken cancellationToken)
     {
         if (notificationEvents.Count == 0)
         {
             return 0;
         }
 
+        Guid correspondenceId = correspondence.Id;
         int savedCount = 0;
 
         foreach (var notification in notificationEvents)
@@ -937,7 +938,7 @@ public class CorrespondenceMigrationEventHelper(
             var filteredNotificationEvents = FilterNotificationEvents(correspondenceId, notificationEvents, correspondence);
             if (filteredNotificationEvents.Count > 0)
             {
-                var savedNotificationEventsCount = await ProcessNotificationEvents(correspondenceId, correspondence, filteredNotificationEvents, operationName, cancellationToken);
+                var savedNotificationEventsCount = await ProcessNotificationEvents(correspondence, filteredNotificationEvents, operationName, cancellationToken);
                 totalEventsProcessed += savedNotificationEventsCount;
             }
         }

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceMigrationEventHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceMigrationEventHelper.cs
@@ -684,7 +684,7 @@ public class CorrespondenceMigrationEventHelper(
         return forwardingEventsToProcess;
     }
 
-    public async Task<int> ProcessNotificationEvents(Guid correspondenceId, List<CorrespondenceNotificationEntity> notificationEvents, MigrationOperationType operationName, CancellationToken cancellationToken)
+    public async Task<int> ProcessNotificationEvents(Guid correspondenceId, CorrespondenceEntity correspondence, List<CorrespondenceNotificationEntity> notificationEvents, MigrationOperationType operationName, CancellationToken cancellationToken)
     {
         if (notificationEvents.Count == 0)
         {
@@ -704,20 +704,42 @@ public class CorrespondenceMigrationEventHelper(
                 IsolationLevel = IsolationLevel.ReadCommitted,
                 Timeout = TimeSpan.FromSeconds(30)
             }, TransactionScopeAsyncFlowOption.Enabled);
-            
+
             try
             {
                 notification.CorrespondenceId = correspondenceId;
                 notification.Correspondence = null; // Clear navigation property to prevent EF Core from tracking the correspondence entity
                 notification.SyncedFromAltinn2 = DateTimeOffset.UtcNow;
-                
+
                 var savedId = await correspondenceNotificationRepository.AddNotificationForSync(notification, cancellationToken);
-                
+
                 // Check if notification was actually saved (not a duplicate)
                 if (savedId != Guid.Empty)
                 {
                     savedCount++;
                     logger.LogDebug("Added new notification {NotificationId} for correspondence {CorrespondenceId}", savedId, correspondenceId);
+
+                    if (correspondence.IsMigrating == false && notification.NotificationSent.HasValue)
+                    {  
+                        var textType = notification.IsReminder 
+                            ? DialogportenTextType.NotificationReminderSent 
+                            : DialogportenTextType.NotificationSent;
+                        string channelType = notification.NotificationChannel == NotificationChannel.Email ? "Email" : "SMS";
+
+                        // Create activity with the same parameters used during initial migration
+                        backgroundJobClient.Enqueue<IDialogportenService>(HangfireQueues.LiveMigration, 
+                            (dialogportenService) => dialogportenService.CreateInformationActivity(
+                                correspondenceId,
+                                DialogportenActorType.ServiceOwner,
+                                textType,
+                                notification.NotificationSent.Value,
+                                notification.NotificationAddress ?? string.Empty,
+                                channelType));
+
+                        logger.LogInformation("Enqueued Dialogporten activity for {OperationName} notification {NotificationId} at {NotificationSent}", 
+                            operationName, savedId, notification.NotificationSent.Value);
+                    }
+
                     transaction.Complete();
                 }
                 else
@@ -915,7 +937,7 @@ public class CorrespondenceMigrationEventHelper(
             var filteredNotificationEvents = FilterNotificationEvents(correspondenceId, notificationEvents, correspondence);
             if (filteredNotificationEvents.Count > 0)
             {
-                var savedNotificationEventsCount = await ProcessNotificationEvents(correspondenceId, filteredNotificationEvents, operationName, cancellationToken);
+                var savedNotificationEventsCount = await ProcessNotificationEvents(correspondenceId, correspondence, filteredNotificationEvents, operationName, cancellationToken);
                 totalEventsProcessed += savedNotificationEventsCount;
             }
         }

--- a/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceNotificationEventHandler.cs
+++ b/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceNotificationEventHandler.cs
@@ -43,7 +43,6 @@ public class SyncCorrespondenceNotificationEventHandler(
         // within a TransactionScope causes "operation in progress" errors with PostgreSQL.
         // EF Core's SaveChangesAsync() already provides transactional guarantees.
         await correspondenceMigrationEventHelper.ProcessNotificationEvents(
-                request.CorrespondenceId,
                 correspondence,
                 notificationsToExecute,
                 MigrationOperationType.Sync,

--- a/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceNotificationEventHandler.cs
+++ b/src/Altinn.Correspondence.Application/SyncCorrespondenceEvent/SyncCorrespondenceNotificationEventHandler.cs
@@ -44,6 +44,7 @@ public class SyncCorrespondenceNotificationEventHandler(
         // EF Core's SaveChangesAsync() already provides transactional guarantees.
         await correspondenceMigrationEventHelper.ProcessNotificationEvents(
                 request.CorrespondenceId,
+                correspondence,
                 notificationsToExecute,
                 MigrationOperationType.Sync,
                 cancellationToken);


### PR DESCRIPTION
Updated SyncNotificationEvents to properly update Dialog with InformationActivites, so that this matches behavior in Altinn 3 and as done when creating the dialog for the Migrated Correspondence.

Also minor improvements to test validation.

## Related Issue(s)
- #1794 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification reminders now enqueue background tasks to create Dialogporten information activities, with activity type and channel selected from the notification.

* **Tests**
  * Tests strengthened to assert background-job behavior precisely across scenarios (new reminders, duplicates, unavailable, and not-found), ensuring reminders trigger a single activity creation when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->