### PR TITLE
remove incorrect validation

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Attachment/AttachmentInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Attachment/AttachmentInitializationTests.cs
@@ -168,21 +168,5 @@ namespace Altinn.Correspondence.Tests.TestingController.Attachment
             var initializeAttachmentResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);
             Assert.Equal(HttpStatusCode.OK, initializeAttachmentResponse.StatusCode);
         }
-
-        [Theory]
-        [InlineData("trailingSpace ")]
-        [InlineData("trailingDot.")]
-        public async Task InitializeAttachment_WithIllegalFilenames_ReturnsBadRequest(string fileName)
-        {
-            var attachment = new AttachmentBuilder()
-                .CreateAttachment()
-                .WithFileName(fileName + ".txt")
-                .Build();
-            
-            var initializeAttachmentResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);
-            var responseContent = await initializeAttachmentResponse.Content.ReadAsStringAsync();
-            Assert.Equal(HttpStatusCode.BadRequest, initializeAttachmentResponse.StatusCode);
-            Assert.Contains(AttachmentErrors.FilenameInvalid.Message, responseContent);
-        }
     }
 }

--- a/src/Altinn.Correspondence.Application/Helpers/AttachmentHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/AttachmentHelper.cs
@@ -198,11 +198,6 @@ namespace Altinn.Correspondence.Application.Helpers
             {
                 return AttachmentErrors.FiletypeNotAllowed;
             }
-            var nameWithoutExtension = Path.GetFileNameWithoutExtension(filename);
-            if (nameWithoutExtension.EndsWith(" ") || nameWithoutExtension.EndsWith("."))
-            {
-                return AttachmentErrors.FilenameInvalid;
-            }
             if (InvalidCharactersRegex.IsMatch(filename))
             {
                 return AttachmentErrors.FilenameInvalid;


### PR DESCRIPTION
## Description
Remove incorrect validation on trailing space or dots at the end of the filename without the extension. This validation declined filenames such as txt..txt when it was intended to disallow txt.txt.
The latter validation is already done from the AllowedFileTypes validation before, so therefore we can just remove this.

## Related Issue(s)
- #1881 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated attachment filename validation to accept filenames with trailing spaces or periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->