### PR TITLE
Fix/initialize transaction and attachment publish race condition

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -730,7 +730,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Assert
             Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
             hangfireBackgroundJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Method.Name == "SchedulePublishAtPublishTime"),
+                It.Is<Job>(job => job.Method.Name == "SchedulePublishAfterDialogCreated"),
                 It.IsAny<IState>()), Times.Once);
         }
 
@@ -771,7 +771,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             // Assert
             Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
             hangfireBackgroundJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Method.Name == "SchedulePublishAtPublishTime"),
+                It.Is<Job>(job => job.Method.Name == "SchedulePublishAfterDialogCreated"),
                 It.IsAny<IState>()), Times.Once);
         }
 
@@ -841,7 +841,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             Assert.NotNull(uploadCorrespondenceResponse);
             Assert.True(uploadCorrespondenceResponse.StatusCode == HttpStatusCode.OK, await uploadCorrespondenceResponse.Content.ReadAsStringAsync());
             hangfireBackgroundJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Method.Name == "SchedulePublishAtPublishTime"),
+                It.Is<Job>(job => job.Method.Name == "SchedulePublishAfterDialogCreated"),
                 It.IsAny<IState>()), Times.Once);
             hangfireBackgroundJobClient.Verify(x => x.Create(
                 It.Is<Job>(job => job.Method.Name == "CreateDialogportenDialog"),

--- a/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
@@ -24,6 +24,11 @@ namespace Altinn.Correspondence.Application.Helpers
 
         public async Task SchedulePublishAfterDialogCreated(Guid correspondenceId, CancellationToken cancellationToken)
         {
+            if (!await correspondenceRepository.AreAllAttachmentsPublished(correspondenceId, cancellationToken))
+            {
+                logger.LogInformation("Not all attachments published for correspondence {correspondenceId}, skipping publish scheduling", correspondenceId);
+                return;
+            }
             var dialogJobId = await hybridCacheWrapper.GetAsync<string?>($"dialogJobId_{correspondenceId}", cancellationToken: cancellationToken);
             if (dialogJobId is null)
             {

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -579,7 +579,7 @@ public class InitializeCorrespondencesHandler(
             }
             else
             {
-                await ScheduleTransmissionAndPublishJobs(correspondence.Id, request.Correspondence.Content!.Attachments.Count, correspondence.RequestedPublishTime, cancellationToken);
+                backgroundJobClient.Enqueue<InitializeCorrespondencesHandler>((handler) => handler.ScheduleTransmissionAndPublishJobs(correspondence.Id, request.Correspondence.Content!.Attachments.Count, correspondence.RequestedPublishTime, cancellationToken));
             }
         }
         else
@@ -590,16 +590,13 @@ public class InitializeCorrespondencesHandler(
             {
                 Expiration = TimeSpan.FromHours(24)
             });
-            if (await correspondenceRepository.AreAllAttachmentsPublished(correspondence.Id, cancellationToken))
+            if (!string.IsNullOrEmpty(notificationJobId))
             {
-                if (!string.IsNullOrEmpty(notificationJobId))
-                {
-                    backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(notificationJobId, (helper) => helper.SchedulePublishAfterDialogCreated(correspondence.Id, cancellationToken));
-                }
-                else
-                {
-                    await hangfireScheduleHelper.SchedulePublishAfterDialogCreated(correspondence.Id, cancellationToken);
-                }
+                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(notificationJobId, (helper) => helper.SchedulePublishAfterDialogCreated(correspondence.Id, cancellationToken));
+            }
+            else
+            {
+                backgroundJobClient.Enqueue<HangfireScheduleHelper>((helper) => helper.SchedulePublishAfterDialogCreated(correspondence.Id, cancellationToken));
             }
         }
 

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -30,7 +30,7 @@ public class PublishCorrespondenceHandler(
     public async Task<OneOf<Task, Error>> Process(Guid correspondenceId, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         logger.LogInformation("Starting publish process with lock for correspondence {CorrespondenceId}", correspondenceId);
-        var operationTimestamp = DateTimeOffset.UtcNow;        
+        var operationTimestamp = DateTimeOffset.UtcNow;
         var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, false, cancellationToken);
         var expectedPublishTime = correspondence?.RequestedPublishTime > correspondence?.Created ? correspondence.RequestedPublishTime : correspondence?.Created;
         logger.LogInformation("Publishing correspondence {CorrespondenceId}. It was expected {expectedPublishTime} and actually executed at {actualPublishTime}.", correspondenceId, expectedPublishTime, operationTimestamp);
@@ -65,10 +65,6 @@ public class PublishCorrespondenceHandler(
         else if (recipientPartyUuid is not Guid)
         {
             errorMessage = $"Party for recipient {correspondence.Recipient} not found in Altinn Register when publishing";
-        }
-        else if (!await IsCorrespondenceReadyForPublish(correspondence, senderPartyUuid.Value, operationTimestamp, cancellationToken))
-        {
-            errorMessage = $"Correspondence {correspondenceId} not ready for publish";
         }
         else if (!hasDialogportenDialog)
         {
@@ -132,6 +128,17 @@ public class PublishCorrespondenceHandler(
             }
             else
             {
+                if (correspondence!.GetHighestStatus()?.Status != CorrespondenceStatus.ReadyForPublish)
+                {
+                    await correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
+                    {
+                        CorrespondenceId = correspondenceId,
+                        Status = CorrespondenceStatus.ReadyForPublish,
+                        StatusChanged = operationTimestamp,
+                        StatusText = CorrespondenceStatus.ReadyForPublish.ToString(),
+                        PartyUuid = senderPartyUuid ?? Guid.Empty
+                    }, cancellationToken);
+                }
                 status = new CorrespondenceStatusEntity
                 {
                     CorrespondenceId = correspondenceId,
@@ -154,32 +161,6 @@ public class PublishCorrespondenceHandler(
             logger.LogInformation("Successfully completed publish process for correspondence {CorrespondenceId} with status {Status}", correspondenceId, status.Status);
             return Task.CompletedTask;
         }, logger, cancellationToken);
-    }
-
-    private async Task<bool> IsCorrespondenceReadyForPublish(CorrespondenceEntity correspondence, Guid partyUuid, DateTimeOffset operationTimestamp, CancellationToken cancellationToken)
-    {
-        if (correspondence.GetHighestStatus()?.Status != CorrespondenceStatus.ReadyForPublish)
-        {
-            if (await correspondenceRepository.AreAllAttachmentsPublished(correspondence.Id, cancellationToken))
-            {
-                await correspondenceStatusRepository.AddCorrespondenceStatus(
-                    new CorrespondenceStatusEntity
-                    {
-                        CorrespondenceId = correspondence.Id,
-                        Status = CorrespondenceStatus.ReadyForPublish,
-                        StatusChanged = operationTimestamp.AddMilliseconds(-1),
-                        StatusText = CorrespondenceStatus.ReadyForPublish.ToString(),
-                        PartyUuid = partyUuid
-                    },
-                    cancellationToken
-                );
-            }
-            else 
-            {
-                return false;
-            }
-        }
-        return true;
     }
 
     private async Task<bool> HasRecipientBeenSetToReservedInKRR(CorrespondenceEntity correspondence, CancellationToken cancellationToken)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes a race condition with attachment malware scan result and correspondence initialize neither creating a publish job. Did this by moving the are all attachment published check to the schedulePublishJob so that check is performed after the create correspondence transaction has commited instead of before.

Also fixed a race condition with concurrent publishjobs where it could create duplicate readyForPublish statuses. Did this by adding the readyforpublish status inside the idempotent atomic publish transaction instead of before. The readyforpublish check was unnesary since it effectively only checked that all attachments are published which is already done earlier.

## Related Issue(s)
- #1853 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous scheduling of follow-up correspondence jobs to improve background processing.

* **Bug Fixes**
  * Scheduling now respects attachment publication: if attachments aren’t published, follow-up jobs are not scheduled.
  * Publication no longer blocks when not all attachments are present; a "Ready for publish" status is recorded to reflect progress.

* **Tests**
  * Updated tests to align with revised scheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->