### PR TITLE
add maintenance endpoint for manual retry of non-published correspondences

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
@@ -15,6 +15,7 @@ using Altinn.Correspondence.Core.Services;
 using Hangfire;
 using Altinn.Correspondence.Application.MigrateForwardingEventsBatch;
 using Altinn.Correspondence.Application.CleanupBulkFetchStatuses;
+using Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
 
 namespace Altinn.Correspondence.API.Controllers;
 
@@ -301,6 +302,27 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
     )
     {
         _logger.LogInformation("Request to cleanup bulk fetch statuses received");
+        var result = await handler.Process(request, HttpContext.User, cancellationToken);
+        return result.Match(
+            Ok,
+            Problem
+        );
+    }
+
+
+    [HttpPost]
+    [Route("manual-retry-not-published-correspondences")]
+    [Authorize(Policy = AuthorizationConstants.Maintenance)]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult> ManualRetryNotPublishedCorrespondences(
+        [FromServices] ManualRetryNotPublishedCorrespondencesHandler handler,
+        [FromBody] ManualRetryNotPublishedCorrespondencesRequest request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Request to manually retry not published correspondences received");
         var result = await handler.Process(request, HttpContext.User, cancellationToken);
         return result.Match(
             Ok,

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -35,6 +35,7 @@ using Altinn.Correspondence.Application.SendSlackNotification;
 using Altinn.Correspondence.Application.RepairNotificationDelivery;
 using Altinn.Correspondence.Application.GetUnreadConfidentialCorrespondences;
 using Altinn.Correspondence.Application.UnreadConfidentialCorrespondence;
+using Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
 
 namespace Altinn.Correspondence.Application;
 
@@ -81,6 +82,7 @@ public static class DependencyInjection
         services.AddScoped<CleanupConfirmedMigratedCorrespondences.CleanupConfirmedMigratedCorrespondencesHandler>();
         services.AddScoped<EnqueueMissingNotificationSentChecksHandler>();
         services.AddScoped<CleanupBulkFetchStatuses.CleanupBulkFetchStatusesHandler>();
+        services.AddScoped<ManualRetryNotPublishedCorrespondencesHandler>();
 
         // Statistics & Reporting
         services.AddScoped<GenerateDailySummaryReportHandler>();

--- a/src/Altinn.Correspondence.Application/ManualRetryNotPublishedCorrespondences/ManualRetryNotPublishedCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/ManualRetryNotPublishedCorrespondences/ManualRetryNotPublishedCorrespondencesHandler.cs
@@ -1,0 +1,25 @@
+using OneOf;
+using System.Security.Claims;
+using Altinn.Correspondence.Application.PublishCorrespondence;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
+
+public class ManualRetryNotPublishedCorrespondencesHandler(
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<ManualRetryNotPublishedCorrespondencesHandler> logger) : IHandler<ManualRetryNotPublishedCorrespondencesRequest, ManualRetryNotPublishedCorrespondencesResponse>
+
+{
+    public async Task<OneOf<ManualRetryNotPublishedCorrespondencesResponse, Error>> Process(ManualRetryNotPublishedCorrespondencesRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
+    {
+        var response = new ManualRetryNotPublishedCorrespondencesResponse();
+        foreach (var correspondenceId in request.CorrespondenceIds)
+        {
+            logger.LogInformation("Retrying publish for correspondence {CorrespondenceId}", correspondenceId);
+            var jobId = backgroundJobClient.Enqueue<PublishCorrespondenceHandler>(handler => handler.Process(correspondenceId, null, CancellationToken.None));
+            response.RetriedCorrespondenceIds[correspondenceId] = $"Enqueued (jobId: {jobId})";
+        }
+        return response;
+    }
+}

--- a/src/Altinn.Correspondence.Application/ManualRetryNotPublishedCorrespondences/ManualRetryNotPublishedCorrespondencesRequest.cs
+++ b/src/Altinn.Correspondence.Application/ManualRetryNotPublishedCorrespondences/ManualRetryNotPublishedCorrespondencesRequest.cs
@@ -1,0 +1,5 @@
+namespace Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
+public class ManualRetryNotPublishedCorrespondencesRequest
+{
+    public List<Guid> CorrespondenceIds { get; set; } = new List<Guid>();
+}

--- a/src/Altinn.Correspondence.Application/ManualRetryNotPublishedCorrespondences/ManualRetryNotPublishedCorrespondencesResponse.cs
+++ b/src/Altinn.Correspondence.Application/ManualRetryNotPublishedCorrespondences/ManualRetryNotPublishedCorrespondencesResponse.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
+
+public class ManualRetryNotPublishedCorrespondencesResponse
+{
+    public Dictionary<Guid, string> RetriedCorrespondenceIds { get; set; } = new Dictionary<Guid, string>();
+
+}


### PR DESCRIPTION
## Description
Some correspondences have created a dialog but something has failed between this and the correspondence being published. Therefore the continuing calls to CreateDialog will fail and therefore the publishing will fail.
This new endpoint lets us manually retry correspondences which should have been published.

## Related Issue(s)
- #1879

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual retry mechanism for not-published correspondences. Administrators can now use a new maintenance API endpoint to manually trigger retries for previously failed correspondence publications. When invoked, the system enqueues background jobs to reprocess each selected correspondence, ensuring those failed deliveries are automatically retried and recovered in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->