### PR TITLE
Default data attachment location type

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -254,7 +254,7 @@ namespace Altinn.Correspondence.API.Controllers
         {
             LogContextHelpers.EnrichLogsWithInsertCorrespondence(request.Correspondence);
             _logger.LogInformation("Insert correspondences with attachment data");
-            _logger.LogDebug("Request: " + JsonSerializer.Serialize(request);
+            _logger.LogDebug("Request: " + JsonSerializer.Serialize(request));
 
             var result = InitializeCorrespondencesMapper.MapToRequest(request, attachments);
             if (result.IsT1)

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -254,7 +254,7 @@ namespace Altinn.Correspondence.API.Controllers
         {
             LogContextHelpers.EnrichLogsWithInsertCorrespondence(request.Correspondence);
             _logger.LogInformation("Insert correspondences with attachment data");
-            _logger.LogInformation("Request: " + JsonSerializer.Serialize(request));
+            _logger.LogDebug("Request: " + JsonSerializer.Serialize(request));
 
             var result = InitializeCorrespondencesMapper.MapToRequest(request, attachments);
             if (result.IsT1)

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using Altinn.Authorization.ProblemDetails;
+using System.Text.Json;
 
 namespace Altinn.Correspondence.API.Controllers
 {
@@ -253,7 +254,8 @@ namespace Altinn.Correspondence.API.Controllers
         {
             LogContextHelpers.EnrichLogsWithInsertCorrespondence(request.Correspondence);
             _logger.LogInformation("Insert correspondences with attachment data");
-            
+            _logger.LogDebug("Request: " + JsonSerializer.Serialize(request);
+
             var result = InitializeCorrespondencesMapper.MapToRequest(request, attachments);
             if (result.IsT1)
                 return BadRequest(result.AsT1.Message); 

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -254,7 +254,7 @@ namespace Altinn.Correspondence.API.Controllers
         {
             LogContextHelpers.EnrichLogsWithInsertCorrespondence(request.Correspondence);
             _logger.LogInformation("Insert correspondences with attachment data");
-            _logger.LogDebug("Request: " + JsonSerializer.Serialize(request));
+            _logger.LogInformation("Request: " + JsonSerializer.Serialize(request));
 
             var result = InitializeCorrespondencesMapper.MapToRequest(request, attachments);
             if (result.IsT1)

--- a/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceAttachmentMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/InitializeCorrespondenceAttachmentMapper.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.API.Models;
+using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
@@ -7,6 +8,16 @@ namespace Altinn.Correspondence.Mappers;
 
 internal static class InitializeCorrespondenceAttachmentMapper
 {
+    private static AttachmentDataLocationType MapDataLocationType(InitializeAttachmentDataLocationTypeExt dataLocationType) =>
+        dataLocationType switch
+        {
+            // Both "new" and "existing correspondence attachment" are stored in Altinn Correspondence storage.
+            InitializeAttachmentDataLocationTypeExt.NewCorrespondenceAttachment => AttachmentDataLocationType.AltinnCorrespondenceAttachment,
+            InitializeAttachmentDataLocationTypeExt.ExistingCorrespondenceAttachment => AttachmentDataLocationType.AltinnCorrespondenceAttachment,
+            InitializeAttachmentDataLocationTypeExt.ExistingExternalStorage => AttachmentDataLocationType.ExternalStorage,
+            _ => AttachmentDataLocationType.AltinnCorrespondenceAttachment
+        };
+
     internal static CorrespondenceAttachmentEntity MapToEntity(InitializeCorrespondenceAttachmentExt initializeAttachmentExt, string resourceId, string sender)
     {
         return new CorrespondenceAttachmentEntity
@@ -23,7 +34,7 @@ internal static class InitializeCorrespondenceAttachmentMapper
                 SendersReference = initializeAttachmentExt.SendersReference,
                 Checksum = initializeAttachmentExt.Checksum,
                 IsEncrypted = initializeAttachmentExt.IsEncrypted,
-                DataLocationType = (AttachmentDataLocationType)initializeAttachmentExt.DataLocationType,
+                DataLocationType = MapDataLocationType(initializeAttachmentExt.DataLocationType),
                 ExpirationInDays = initializeAttachmentExt.ExpirationInDays,
             }
         };

--- a/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceAttachmentExt.cs
+++ b/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceAttachmentExt.cs
@@ -1,6 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 using Altinn.Correspondence.API.Models.Enums;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace Altinn.Correspondence.API.Models
 {
@@ -19,7 +19,7 @@ namespace Altinn.Correspondence.API.Models
         /// Specifies the location type of the attachment data
         /// </summary>
         [JsonPropertyName("dataLocationType")]
-        [Required]
-        public InitializeAttachmentDataLocationTypeExt DataLocationType { get; set; }
+        [DefaultValue(InitializeAttachmentDataLocationTypeExt.NewCorrespondenceAttachment)]
+        public InitializeAttachmentDataLocationTypeExt DataLocationType { get; set; } = InitializeAttachmentDataLocationTypeExt.NewCorrespondenceAttachment;
     }
 }

--- a/src/Altinn.Correspondence.API/appsettings.json
+++ b/src/Altinn.Correspondence.API/appsettings.json
@@ -17,6 +17,6 @@
   },
   "GeneralSettings": {
     "WorkerCountPerReplica": 35,
-    "MigrationWorkerCountPerReplica": 15
+    "MigrationWorkerCountPerReplica": 3
   }
 }

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -503,8 +503,7 @@ namespace Altinn.Correspondence.Application.Helpers
 
         public static bool IsUploadTarget(AttachmentEntity attachment)
         {
-            return attachment.DataLocationType == AttachmentDataLocationType.AltinnCorrespondenceAttachment
-                && string.IsNullOrWhiteSpace(attachment.DataLocationUrl);
+            return string.IsNullOrWhiteSpace(attachment.DataLocationUrl);
         }
 
         private static Dictionary<string, int> BuildUniqueFileIndexByName(IReadOnlyList<IFormFile> files)

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -381,6 +381,7 @@ namespace Altinn.Correspondence.Application.Helpers
                 var attachment = attachmentMetadata.Attachment;
                 if (attachment is null)
                 {
+                    logger.LogDebug("Attachment metadata with id {AttachmentMetadataId} does not have an attachment. Attachment metadata list count: {AttachmentMetadataListCount}", attachmentMetadata.Id, attachments.Count);
                     return CorrespondenceErrors.UploadedFilesDoesNotMatchAttachments;
                 }
 
@@ -398,6 +399,7 @@ namespace Altinn.Correspondence.Application.Helpers
 
             if (uploadTargetAttachments.Count != files.Count)
             {
+                logger.LogDebug("Number of upload target attachments does not match number of uploaded files. Upload target attachments: {UploadTargetAttachmentCount}, Uploaded files: {UploadedFileCount}", uploadTargetAttachments.Count, files.Count);
                 return CorrespondenceErrors.UploadedFilesDoesNotMatchAttachments;
             }
 
@@ -409,6 +411,7 @@ namespace Altinn.Correspondence.Application.Helpers
                 var attachment = uploadTargetAttachments[i].Attachment!;
                 if (!TryResolveFileIndex(files, uniqueFileIndexByName, usedFileIndices, attachment.FileName, i, out var fileIndex))
                 {
+                    logger.LogDebug("Could not resolve file index for attachment with filename {AttachmentFileName}. Expected file index: {ExpectedFileIndex}", attachment.FileName, i);
                     return CorrespondenceErrors.UploadedFilesDoesNotMatchAttachments;
                 }
 


### PR DESCRIPTION
## Description
The field is not really in use but was expected by re-factored validation code. Set a default value for it.

## Related Issue(s)
- #1868

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment data location handling with explicit mappings and updated upload-target determination to avoid misclassification.
  * Default applied for attachment data location to ensure predictable behavior when omitted.

* **Chores**
  * Added diagnostic debug logging for attachment validation failures and for incoming initialization requests.
  * Reduced configured migration worker concurrency per replica.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->