### PR TITLE
Setup our own Github runners

### DIFF
--- a/.azure/applications/githubRunner/Dockerfile
+++ b/.azure/applications/githubRunner/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:24.04
+
+ARG RUNNER_VERSION=2.326.0
+ARG TARGETARCH=amd64
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUNNER_ALLOW_RUNASROOT=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        tar \
+        unzip \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -d /home/runner -s /bin/bash runner
+WORKDIR /home/runner
+
+RUN ARCHIVE_NAME="actions-runner-linux-${TARGETARCH}-${RUNNER_VERSION}.tar.gz" \
+    && curl -fsSL -o "${ARCHIVE_NAME}" "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${ARCHIVE_NAME}" \
+    && tar xzf "${ARCHIVE_NAME}" \
+    && rm "${ARCHIVE_NAME}" \
+    && ./bin/installdependencies.sh
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && chown -R runner:runner /home/runner
+
+USER runner
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.azure/applications/githubRunner/Dockerfile
+++ b/.azure/applications/githubRunner/Dockerfile
@@ -8,13 +8,24 @@ ENV RUNNER_ALLOW_RUNASROOT=1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        apt-transport-https \
         ca-certificates \
         curl \
         git \
+        gnupg \
         jq \
+        lsb-release \
+        docker.io \
         tar \
         unzip \
         wget \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null \
+    && SUITE=$(lsb_release -cs) \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $SUITE main" > /etc/apt/sources.list.d/azure-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends azure-cli \
+    && az aks install-cli --install-location /usr/local/bin/kubectl --kubelogin-install-location /usr/local/bin/kubelogin \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -d /home/runner -s /bin/bash runner
@@ -35,5 +46,4 @@ RUN case "${TARGETARCH}" in \
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && chown -R runner:runner /home/runner
 
-USER runner
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.azure/applications/githubRunner/Dockerfile
+++ b/.azure/applications/githubRunner/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && mkdir -p /etc/apt/keyrings \
     && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null \
     && SUITE=$(lsb_release -cs) \
-    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $SUITE main" > /etc/apt/sources.list.d/azure-cli.list \
+    && echo "deb [arch=${TARGETARCH} signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $SUITE main" > /etc/apt/sources.list.d/azure-cli.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends azure-cli \
     && az aks install-cli --install-location /usr/local/bin/kubectl --kubelogin-install-location /usr/local/bin/kubelogin \
@@ -44,6 +44,7 @@ RUN case "${TARGETARCH}" in \
     && ./bin/installdependencies.sh
 
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh && chown -R runner:runner /home/runner
+RUN chmod +x /entrypoint.sh && chown runner:runner /entrypoint.sh && chown -R runner:runner /home/runner
 
+USER runner
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.azure/applications/githubRunner/Dockerfile
+++ b/.azure/applications/githubRunner/Dockerfile
@@ -20,7 +20,13 @@ RUN apt-get update \
 RUN useradd -m -d /home/runner -s /bin/bash runner
 WORKDIR /home/runner
 
-RUN ARCHIVE_NAME="actions-runner-linux-${TARGETARCH}-${RUNNER_VERSION}.tar.gz" \
+RUN case "${TARGETARCH}" in \
+      amd64) RUNNER_ARCH="linux-x64" ;; \
+      arm64) RUNNER_ARCH="linux-arm64" ;; \
+      arm) RUNNER_ARCH="linux-arm" ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac \
+    && ARCHIVE_NAME="actions-runner-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz" \
     && curl -fsSL -o "${ARCHIVE_NAME}" "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${ARCHIVE_NAME}" \
     && tar xzf "${ARCHIVE_NAME}" \
     && rm "${ARCHIVE_NAME}" \

--- a/.azure/applications/githubRunner/README.md
+++ b/.azure/applications/githubRunner/README.md
@@ -18,7 +18,6 @@ At startup, it:
 ## Optional Runtime Environment Variables
 
 - `RUNNER_NAME_PREFIX` (entrypoint default: `aca-runner`; this deployment overrides it to `${namePrefix}-runner`, so runner names will appear as `<namePrefix>-runner-*`)
-- `LABELS` (default: `containerapps`)
 - `RUNNER_WORKDIR` (default: `_work`)
 
 ## Build And Push (example)

--- a/.azure/applications/githubRunner/README.md
+++ b/.azure/applications/githubRunner/README.md
@@ -17,7 +17,7 @@ At startup, it:
 
 ## Optional Runtime Environment Variables
 
-- `RUNNER_NAME_PREFIX` (default: `aca-runner`)
+- `RUNNER_NAME_PREFIX` (entrypoint default: `aca-runner`; this deployment overrides it to `${namePrefix}-runner`, so runner names will appear as `<namePrefix>-runner-*`)
 - `LABELS` (default: `containerapps`)
 - `RUNNER_WORKDIR` (default: `_work`)
 

--- a/.azure/applications/githubRunner/README.md
+++ b/.azure/applications/githubRunner/README.md
@@ -25,3 +25,12 @@ The `manage-github-runners.yml` workflow expects these repository secrets:
 The Azure Key Vault referenced by `AZURE_ENVIRONMENT_KEY_VAULT_NAME` must also contain:
 
 - `github-runner-token` (GitHub PAT/app token with permissions to manage self-hosted runners)
+
+## Required GitHub Repository Variable
+
+Set repository variable `USE_SELF_HOSTED_RUNNERS` to control workflow runner selection:
+
+- `true`: workflows using the conditional `runs-on` expression run on `self-hosted`
+- any other value (or unset): workflows fall back to `ubuntu-latest`
+
+The `manage-github-runners.yml` workflow controls the runner infrastructure itself, while this variable controls whether eligible workflows actually target self-hosted runners.

--- a/.azure/applications/githubRunner/README.md
+++ b/.azure/applications/githubRunner/README.md
@@ -10,21 +10,17 @@ At startup, it:
 3. Executes one job and then exits.
 4. Removes its runner registration on shutdown.
 
-## Required Runtime Environment Variables
+## Required GitHub Repository Secrets
 
-- `GITHUB_URL` (example: `https://github.com/Altinn/altinn-correspondence`)
-- `GITHUB_TOKEN` (PAT/app token with permissions to manage self-hosted runners)
+The `manage-github-runners.yml` workflow expects these repository secrets:
 
-## Optional Runtime Environment Variables
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+- `AZURE_NAME_PREFIX`
+- `AZURE_ENVIRONMENT`
+- `AZURE_ENVIRONMENT_KEY_VAULT_NAME`
 
-- `RUNNER_NAME_PREFIX` (entrypoint default: `aca-runner`; this deployment overrides it to `${namePrefix}-runner`, so runner names will appear as `<namePrefix>-runner-*`)
-- `RUNNER_WORKDIR` (default: `_work`)
+The Azure Key Vault referenced by `AZURE_ENVIRONMENT_KEY_VAULT_NAME` must also contain:
 
-## Build And Push (example)
-
-```bash
-docker build -f .azure/applications/githubRunner/Dockerfile -t ghcr.io/altinn/altinn-correspondence-github-runner:latest .azure/applications/githubRunner
-docker push ghcr.io/altinn/altinn-correspondence-github-runner:latest
-```
-
-Use the pushed image value in `GITHUB_RUNNER_IMAGE` for your Bicep deployment.
+- `github-runner-token` (GitHub PAT/app token with permissions to manage self-hosted runners)

--- a/.azure/applications/githubRunner/README.md
+++ b/.azure/applications/githubRunner/README.md
@@ -1,0 +1,31 @@
+# GitHub Runner Image
+
+This folder contains a container image for self-hosted GitHub Actions runners in Azure Container Apps.
+
+The image is built on Ubuntu and installs the official GitHub Actions runner binaries.  
+At startup, it:
+
+1. Requests a temporary registration token from GitHub using `GITHUB_TOKEN`.
+2. Registers itself as an ephemeral runner for one repository (`GITHUB_URL`).
+3. Executes one job and then exits.
+4. Removes its runner registration on shutdown.
+
+## Required Runtime Environment Variables
+
+- `GITHUB_URL` (example: `https://github.com/Altinn/altinn-correspondence`)
+- `GITHUB_TOKEN` (PAT/app token with permissions to manage self-hosted runners)
+
+## Optional Runtime Environment Variables
+
+- `RUNNER_NAME_PREFIX` (default: `aca-runner`)
+- `LABELS` (default: `containerapps`)
+- `RUNNER_WORKDIR` (default: `_work`)
+
+## Build And Push (example)
+
+```bash
+docker build -f .azure/applications/githubRunner/Dockerfile -t ghcr.io/altinn/altinn-correspondence-github-runner:latest .azure/applications/githubRunner
+docker push ghcr.io/altinn/altinn-correspondence-github-runner:latest
+```
+
+Use the pushed image value in `GITHUB_RUNNER_IMAGE` for your Bicep deployment.

--- a/.azure/applications/githubRunner/README.md
+++ b/.azure/applications/githubRunner/README.md
@@ -2,13 +2,14 @@
 
 This folder contains a container image for self-hosted GitHub Actions runners in Azure Container Apps.
 
-The image is built on Ubuntu and installs the official GitHub Actions runner binaries.  
+The image is built on Ubuntu and installs the official GitHub Actions runner binaries, Docker, Azure CLI, kubectl, and kubelogin.  
 At startup, it:
 
 1. Requests a temporary registration token from GitHub using `GITHUB_TOKEN`.
 2. Registers itself as an ephemeral runner for one repository (`GITHUB_URL`).
 3. Executes one job and then exits.
 4. Removes its runner registration on shutdown.
+5. Starts a Docker daemon so workflows can run `docker build/push` and `az` commands.
 
 ## Required GitHub Repository Secrets
 

--- a/.azure/applications/githubRunner/entrypoint.sh
+++ b/.azure/applications/githubRunner/entrypoint.sh
@@ -17,10 +17,16 @@ if [[ "${GITHUB_URL}" != https://github.com/* ]]; then
 fi
 
 repo_path="${GITHUB_URL#https://github.com/}"
-owner="$(echo "${repo_path}" | cut -d'/' -f1)"
-repo="$(echo "${repo_path}" | cut -d'/' -f2)"
+repo_path="${repo_path%/}"
+IFS='/' read -r -a parts <<< "${repo_path}"
+owner=""
+repo=""
+if [[ ${#parts[@]} -eq 2 ]]; then
+  owner="${parts[0]}"
+  repo="${parts[1]}"
+fi
 
-if [[ -z "${owner}" || -z "${repo}" ]]; then
+if [[ ${#parts[@]} -ne 2 || -z "${owner}" || -z "${repo}" ]]; then
   echo "GITHUB_URL must be in the format https://github.com/<owner>/<repo>."
   exit 1
 fi
@@ -69,4 +75,4 @@ trap remove_runner EXIT INT TERM
   --labels "${runner_labels}"
 
 echo "Runner ${runner_name} configured. Waiting for a single job..."
-exec ./run.sh
+./run.sh

--- a/.azure/applications/githubRunner/entrypoint.sh
+++ b/.azure/applications/githubRunner/entrypoint.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GITHUB_URL:-}" ]]; then
+  echo "GITHUB_URL is required."
+  exit 1
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN is required."
+  exit 1
+fi
+
+if [[ "${GITHUB_URL}" != https://github.com/* ]]; then
+  echo "GITHUB_URL must start with https://github.com/."
+  exit 1
+fi
+
+repo_path="${GITHUB_URL#https://github.com/}"
+owner="$(echo "${repo_path}" | cut -d'/' -f1)"
+repo="$(echo "${repo_path}" | cut -d'/' -f2)"
+
+if [[ -z "${owner}" || -z "${repo}" ]]; then
+  echo "GITHUB_URL must be in the format https://github.com/<owner>/<repo>."
+  exit 1
+fi
+
+runner_prefix="${RUNNER_NAME_PREFIX:-aca-runner}"
+runner_name="${runner_prefix}-$(hostname)-${RANDOM}"
+runner_labels="${LABELS:-containerapps}"
+work_folder="${RUNNER_WORKDIR:-_work}"
+
+api_url="https://api.github.com/repos/${owner}/${repo}/actions/runners"
+common_headers=(
+  -H "Accept: application/vnd.github+json"
+  -H "Authorization: Bearer ${GITHUB_TOKEN}"
+  -H "X-GitHub-Api-Version: 2022-11-28"
+)
+
+echo "Requesting registration token for ${owner}/${repo}..."
+registration_token="$(
+  curl -fsSL -X POST "${common_headers[@]}" "${api_url}/registration-token" | jq -r '.token'
+)"
+
+if [[ -z "${registration_token}" || "${registration_token}" == "null" ]]; then
+  echo "Failed to fetch runner registration token."
+  exit 1
+fi
+
+remove_runner() {
+  set +e
+  echo "Removing runner registration..."
+  remove_token="$(curl -fsSL -X POST "${common_headers[@]}" "${api_url}/remove-token" | jq -r '.token')"
+  if [[ -n "${remove_token}" && "${remove_token}" != "null" ]]; then
+    ./config.sh remove --unattended --token "${remove_token}" >/dev/null 2>&1
+  fi
+}
+
+trap remove_runner EXIT INT TERM
+
+./config.sh \
+  --unattended \
+  --replace \
+  --ephemeral \
+  --name "${runner_name}" \
+  --work "${work_folder}" \
+  --url "${GITHUB_URL}" \
+  --token "${registration_token}" \
+  --labels "${runner_labels}"
+
+echo "Runner ${runner_name} configured. Waiting for a single job..."
+exec ./run.sh

--- a/.azure/applications/githubRunner/entrypoint.sh
+++ b/.azure/applications/githubRunner/entrypoint.sh
@@ -31,9 +31,8 @@ if [[ ${#parts[@]} -ne 2 || -z "${owner}" || -z "${repo}" ]]; then
   exit 1
 fi
 
-runner_prefix="${RUNNER_NAME_PREFIX:-aca-runner}"
-runner_name="${runner_prefix}-$(hostname)-${RANDOM}"
-work_folder="${RUNNER_WORKDIR:-_work}"
+runner_name="runner-$(hostname)-${RANDOM}"
+work_folder="_work"
 
 api_url="https://api.github.com/repos/${owner}/${repo}/actions/runners"
 common_headers=(

--- a/.azure/applications/githubRunner/entrypoint.sh
+++ b/.azure/applications/githubRunner/entrypoint.sh
@@ -33,7 +33,6 @@ fi
 
 runner_prefix="${RUNNER_NAME_PREFIX:-aca-runner}"
 runner_name="${runner_prefix}-$(hostname)-${RANDOM}"
-runner_labels="${LABELS:-containerapps}"
 work_folder="${RUNNER_WORKDIR:-_work}"
 
 api_url="https://api.github.com/repos/${owner}/${repo}/actions/runners"
@@ -71,8 +70,7 @@ trap remove_runner EXIT INT TERM
   --name "${runner_name}" \
   --work "${work_folder}" \
   --url "${GITHUB_URL}" \
-  --token "${registration_token}" \
-  --labels "${runner_labels}"
+  --token "${registration_token}"
 
 echo "Runner ${runner_name} configured. Waiting for a single job..."
 ./run.sh

--- a/.azure/applications/githubRunner/entrypoint.sh
+++ b/.azure/applications/githubRunner/entrypoint.sh
@@ -33,6 +33,7 @@ fi
 
 runner_name="runner-$(hostname)-${RANDOM}"
 work_folder="_work"
+DOCKERD_PID=""
 
 api_url="https://api.github.com/repos/${owner}/${repo}/actions/runners"
 common_headers=(
@@ -58,9 +59,27 @@ remove_runner() {
   if [[ -n "${remove_token}" && "${remove_token}" != "null" ]]; then
     ./config.sh remove --unattended --token "${remove_token}" >/dev/null 2>&1
   fi
+  if [[ -n "${DOCKERD_PID}" ]]; then
+    kill "${DOCKERD_PID}" >/dev/null 2>&1 || true
+  fi
 }
 
 trap remove_runner EXIT INT TERM
+
+echo "Starting Docker daemon..."
+dockerd --host=unix:///var/run/docker.sock >/tmp/dockerd.log 2>&1 &
+DOCKERD_PID=$!
+for i in {1..30}; do
+  if docker info >/dev/null 2>&1; then
+    break
+  fi
+  if [[ ${i} -eq 30 ]]; then
+    echo "Docker daemon failed to start. Last log lines:"
+    tail -n 50 /tmp/dockerd.log || true
+    exit 1
+  fi
+  sleep 1
+done
 
 ./config.sh \
   --unattended \

--- a/.azure/applications/githubRunner/main.bicep
+++ b/.azure/applications/githubRunner/main.bicep
@@ -57,7 +57,7 @@ module githubRunnerContainerApp '../../modules/githubRunnerContainerApp/main.bic
   params: {
     namePrefix: namePrefix
     location: location
-    principalId: runnerIdentity.outputs.id
+    userAssignedIdentityResourceId: runnerIdentity.outputs.id
     keyVaultUrl: keyVaultUrl
     containerAppEnvId: keyvault.getSecret('container-app-env-id')
     runnerImage: runnerImage

--- a/.azure/applications/githubRunner/main.bicep
+++ b/.azure/applications/githubRunner/main.bicep
@@ -1,0 +1,74 @@
+targetScope = 'subscription'
+
+@minLength(3)
+param environment string
+@minLength(3)
+param location string
+@secure()
+@minLength(3)
+param sourceKeyVaultName string
+@secure()
+param keyVaultUrl string
+@secure()
+param namePrefix string
+@description('GitHub registration URL, e.g. https://github.com/Altinn/altinn-correspondence')
+param githubUrl string
+@description('Container image for the self-hosted runner.')
+param runnerImage string = 'ghcr.io/altinn/altinn-correspondence-github-runner:latest'
+
+var resourceGroupName = '${namePrefix}-rg'
+var appName = '${namePrefix}-github-runner'
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-11-01' existing = {
+  name: resourceGroupName
+}
+
+resource keyvault 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+  name: sourceKeyVaultName
+  scope: resourceGroup
+}
+
+module runnerIdentity '../../modules/identity/create.bicep' = {
+  name: 'githubRunnerIdentity'
+  scope: resourceGroup
+  params: {
+    namePrefix: '${namePrefix}-github-runner'
+    location: location
+  }
+}
+
+module keyvaultAddReaderRolesRunnerIdentity '../../modules/keyvault/addReaderRoles.bicep' = {
+  name: 'kvreader-${namePrefix}-github-runner'
+  scope: resourceGroup
+  params: {
+    keyvaultName: sourceKeyVaultName
+    principals: [
+      { objectId: runnerIdentity.outputs.principalId, principalType: 'ServicePrincipal' }
+    ]
+  }
+}
+
+module githubRunnerContainerApp '../../modules/githubRunnerContainerApp/main.bicep' = {
+  name: appName
+  scope: resourceGroup
+  dependsOn: [
+    keyvaultAddReaderRolesRunnerIdentity
+  ]
+  params: {
+    namePrefix: namePrefix
+    location: location
+    principalId: runnerIdentity.outputs.id
+    keyVaultUrl: keyVaultUrl
+    containerAppEnvId: keyvault.getSecret('container-app-env-id')
+    runnerImage: runnerImage
+    githubUrl: githubUrl
+    githubTokenSecretName: 'github-runner-token'
+    runnerLabels: 'containerapps,altinn-correspondence'
+    targetQueueLength: 1
+    cooldownPeriodSeconds: 3600
+    maxReplicas: 4
+  }
+}
+
+output name string = githubRunnerContainerApp.outputs.name
+output revisionName string = githubRunnerContainerApp.outputs.revisionName

--- a/.azure/applications/githubRunner/main.bicep
+++ b/.azure/applications/githubRunner/main.bicep
@@ -62,10 +62,6 @@ module githubRunnerContainerApp '../../modules/githubRunnerContainerApp/main.bic
     containerAppEnvId: keyvault.getSecret('container-app-env-id')
     runnerImage: runnerImage
     githubUrl: githubUrl
-    githubTokenSecretName: 'github-runner-token'
-    targetQueueLength: 1
-    cooldownPeriodSeconds: 3600
-    maxReplicas: 4
   }
 }
 

--- a/.azure/applications/githubRunner/main.bicep
+++ b/.azure/applications/githubRunner/main.bicep
@@ -63,7 +63,6 @@ module githubRunnerContainerApp '../../modules/githubRunnerContainerApp/main.bic
     runnerImage: runnerImage
     githubUrl: githubUrl
     githubTokenSecretName: 'github-runner-token'
-    runnerLabels: 'containerapps,altinn-correspondence'
     targetQueueLength: 1
     cooldownPeriodSeconds: 3600
     maxReplicas: 4

--- a/.azure/applications/githubRunner/params.bicepparam
+++ b/.azure/applications/githubRunner/params.bicepparam
@@ -1,0 +1,13 @@
+using './main.bicep'
+
+param namePrefix = readEnvironmentVariable('NAME_PREFIX')
+param location = 'norwayeast'
+param environment = readEnvironmentVariable('ENVIRONMENT')
+
+// secrets
+param sourceKeyVaultName = readEnvironmentVariable('KEY_VAULT_NAME')
+param keyVaultUrl = readEnvironmentVariable('KEY_VAULT_URL')
+
+// GitHub runner settings
+param githubUrl = readEnvironmentVariable('GITHUB_URL')
+param runnerImage = readEnvironmentVariable('GITHUB_RUNNER_IMAGE', 'ghcr.io/altinn/altinn-correspondence-github-runner:latest')

--- a/.azure/modules/githubRunnerContainerApp/main.bicep
+++ b/.azure/modules/githubRunnerContainerApp/main.bicep
@@ -33,7 +33,6 @@ var secrets = [
 ]
 
 var containerAppEnvVars = [
-  { name: 'RUNNER_NAME_PREFIX', value: '${namePrefix}-runner' }
   { name: 'RUNNER_SCOPE', value: 'repo' }
   { name: 'GITHUB_URL', value: githubUrl }
   { name: 'DISABLE_AUTO_UPDATE', value: 'true' }

--- a/.azure/modules/githubRunnerContainerApp/main.bicep
+++ b/.azure/modules/githubRunnerContainerApp/main.bicep
@@ -2,7 +2,7 @@ param location string
 @secure()
 param namePrefix string
 @secure()
-param principalId string
+param userAssignedIdentityResourceId string
 @secure()
 param keyVaultUrl string
 @secure()
@@ -35,7 +35,7 @@ var githubTokenSecretRefName = 'github-runner-token'
 
 var secrets = [
   {
-    identity: principalId
+    identity: userAssignedIdentityResourceId
     keyVaultUrl: '${keyVaultUrl}/secrets/${githubTokenSecretName}'
     name: githubTokenSecretRefName
   }
@@ -56,7 +56,7 @@ resource githubRunnerContainerApp 'Microsoft.App/containerApps@2023-05-01' = {
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {
-      '${principalId}': {}
+      '${userAssignedIdentityResourceId}': {}
     }
   }
   properties: {
@@ -77,9 +77,10 @@ resource githubRunnerContainerApp 'Microsoft.App/containerApps@2023-05-01' = {
             custom: {
               type: 'github-runner'
               metadata: {
-                githubAPIURL: 'https://api.github.com'
+                githubApiURL: 'https://api.github.com'
                 owner: split(replace(githubUrl, 'https://github.com/', ''), '/')[0]
-                repo: split(replace(githubUrl, 'https://github.com/', ''), '/')[1]
+                repos: split(replace(githubUrl, 'https://github.com/', ''), '/')[1]
+                labels: runnerLabels
                 targetWorkflowQueueLength: string(targetQueueLength)
                 runnerScope: 'repo'
               }

--- a/.azure/modules/githubRunnerContainerApp/main.bicep
+++ b/.azure/modules/githubRunnerContainerApp/main.bicep
@@ -14,8 +14,6 @@ param runnerImage string = 'ghcr.io/altinn/altinn-correspondence-github-runner:l
 param githubUrl string
 @description('Key Vault secret name holding the GitHub PAT/token.')
 param githubTokenSecretName string = 'github-runner-token'
-@description('Additional runner labels added to this runner.')
-param runnerLabels string = 'containerapps,altinn-correspondence'
 @description('How many queued jobs each replica should target before scaling.')
 param targetQueueLength int = 1
 @description('Idle time in seconds before scaling down.')
@@ -44,7 +42,6 @@ var secrets = [
 var containerAppEnvVars = [
   { name: 'RUNNER_NAME_PREFIX', value: '${namePrefix}-runner' }
   { name: 'RUNNER_SCOPE', value: 'repo' }
-  { name: 'LABELS', value: runnerLabels }
   { name: 'GITHUB_URL', value: githubUrl }
   { name: 'DISABLE_AUTO_UPDATE', value: 'true' }
 ]
@@ -80,7 +77,6 @@ resource githubRunnerContainerApp 'Microsoft.App/containerApps@2023-05-01' = {
                 githubApiURL: 'https://api.github.com'
                 owner: split(replace(githubUrl, 'https://github.com/', ''), '/')[0]
                 repos: split(replace(githubUrl, 'https://github.com/', ''), '/')[1]
-                labels: runnerLabels
                 targetWorkflowQueueLength: string(targetQueueLength)
                 runnerScope: 'repo'
               }

--- a/.azure/modules/githubRunnerContainerApp/main.bicep
+++ b/.azure/modules/githubRunnerContainerApp/main.bicep
@@ -20,8 +20,8 @@ var cooldownPeriodSeconds = 3600
 var pollingIntervalSeconds = 30
 var maxReplicas = 4
 var containerAppResources = {
-  cpu: json('1.0')
-  memory: '2.0Gi'
+  cpu: 4
+  memory: '8.0Gi'
 }
 
 var secrets = [

--- a/.azure/modules/githubRunnerContainerApp/main.bicep
+++ b/.azure/modules/githubRunnerContainerApp/main.bicep
@@ -1,0 +1,115 @@
+param location string
+@secure()
+param namePrefix string
+@secure()
+param principalId string
+@secure()
+param keyVaultUrl string
+@secure()
+param containerAppEnvId string
+
+@description('Container image for the self-hosted runner.')
+param runnerImage string = 'ghcr.io/altinn/altinn-correspondence-github-runner:latest'
+@description('GitHub registration URL, e.g. https://github.com/Altinn/altinn-correspondence')
+param githubUrl string
+@description('Key Vault secret name holding the GitHub PAT/token.')
+param githubTokenSecretName string = 'github-runner-token'
+@description('Additional runner labels added to this runner.')
+param runnerLabels string = 'containerapps,altinn-correspondence'
+@description('How many queued jobs each replica should target before scaling.')
+param targetQueueLength int = 1
+@description('Idle time in seconds before scaling down.')
+param cooldownPeriodSeconds int = 3600
+@description('Polling interval in seconds for scaler.')
+param pollingIntervalSeconds int = 30
+@description('Maximum replica count during high load.')
+param maxReplicas int = 4
+@description('Runner resources.')
+param containerAppResources object = {
+  cpu: json('1.0')
+  memory: '2.0Gi'
+}
+
+var containerAppName = '${namePrefix}-github-runner'
+var githubTokenSecretRefName = 'github-runner-token'
+
+var secrets = [
+  {
+    identity: principalId
+    keyVaultUrl: '${keyVaultUrl}/secrets/${githubTokenSecretName}'
+    name: githubTokenSecretRefName
+  }
+]
+
+var containerAppEnvVars = [
+  { name: 'RUNNER_NAME_PREFIX', value: '${namePrefix}-runner' }
+  { name: 'RUNNER_SCOPE', value: 'repo' }
+  { name: 'LABELS', value: runnerLabels }
+  { name: 'GITHUB_URL', value: githubUrl }
+  { name: 'DISABLE_AUTO_UPDATE', value: 'true' }
+]
+
+resource githubRunnerContainerApp 'Microsoft.App/containerApps@2023-05-01' = {
+  name: containerAppName
+  location: location
+  tags: resourceGroup().tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${principalId}': {}
+    }
+  }
+  properties: {
+    environmentId: containerAppEnvId
+    configuration: {
+      activeRevisionsMode: 'Single'
+      secrets: secrets
+    }
+    template: {
+      scale: {
+        minReplicas: 0
+        maxReplicas: maxReplicas
+        cooldownPeriod: cooldownPeriodSeconds
+        pollingInterval: pollingIntervalSeconds
+        rules: [
+          {
+            name: 'github-runner-queue'
+            custom: {
+              type: 'github-runner'
+              metadata: {
+                githubAPIURL: 'https://api.github.com'
+                owner: split(replace(githubUrl, 'https://github.com/', ''), '/')[0]
+                repo: split(replace(githubUrl, 'https://github.com/', ''), '/')[1]
+                targetWorkflowQueueLength: string(targetQueueLength)
+                runnerScope: 'repo'
+              }
+              auth: [
+                {
+                  secretRef: githubTokenSecretRefName
+                  triggerParameter: 'personalAccessToken'
+                }
+              ]
+            }
+          }
+        ]
+      }
+      containers: [
+        {
+          name: 'github-runner'
+          image: runnerImage
+          env: concat(containerAppEnvVars, [
+            {
+              name: 'GITHUB_TOKEN'
+              secretRef: githubTokenSecretRefName
+            }
+          ])
+          resources: containerAppResources
+        }
+      ]
+    }
+  }
+}
+
+output name string = githubRunnerContainerApp.name
+output revisionName string = githubRunnerContainerApp.properties.latestRevisionName
+output app object = githubRunnerContainerApp

--- a/.azure/modules/githubRunnerContainerApp/main.bicep
+++ b/.azure/modules/githubRunnerContainerApp/main.bicep
@@ -7,29 +7,22 @@ param userAssignedIdentityResourceId string
 param keyVaultUrl string
 @secure()
 param containerAppEnvId string
-
 @description('Container image for the self-hosted runner.')
-param runnerImage string = 'ghcr.io/altinn/altinn-correspondence-github-runner:latest'
+param runnerImage string
 @description('GitHub registration URL, e.g. https://github.com/Altinn/altinn-correspondence')
 param githubUrl string
-@description('Key Vault secret name holding the GitHub PAT/token.')
-param githubTokenSecretName string = 'github-runner-token'
-@description('How many queued jobs each replica should target before scaling.')
-param targetQueueLength int = 1
-@description('Idle time in seconds before scaling down.')
-param cooldownPeriodSeconds int = 3600
-@description('Polling interval in seconds for scaler.')
-param pollingIntervalSeconds int = 30
-@description('Maximum replica count during high load.')
-param maxReplicas int = 4
-@description('Runner resources.')
-param containerAppResources object = {
-  cpu: json('1.0')
-  memory: '2.0Gi'
-}
 
 var containerAppName = '${namePrefix}-github-runner'
 var githubTokenSecretRefName = 'github-runner-token'
+var githubTokenSecretName = 'github-runner-token'
+var targetQueueLength = 1
+var cooldownPeriodSeconds = 3600
+var pollingIntervalSeconds = 30
+var maxReplicas = 4
+var containerAppResources = {
+  cpu: json('1.0')
+  memory: '2.0Gi'
+}
 
 var secrets = [
   {

--- a/.azure/modules/githubRunnerContainerApp/main.bicep
+++ b/.azure/modules/githubRunnerContainerApp/main.bicep
@@ -20,8 +20,8 @@ var cooldownPeriodSeconds = 3600
 var pollingIntervalSeconds = 30
 var maxReplicas = 4
 var containerAppResources = {
-  cpu: 4
-  memory: '8.0Gi'
+  cpu: 2
+  memory: '4.0Gi'
 }
 
 var secrets = [

--- a/.github/workflows/check-label-for-pr.yml
+++ b/.github/workflows/check-label-for-pr.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, reopened, ready_for_review, labeled, unlabeled]
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -13,7 +13,7 @@ jobs:
 
   get-version: 
     name: Get version
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     outputs:
       imageTag: ${{ steps.get-version.outputs.imageTag }}
       version: ${{ steps.get-version.outputs.version }}
@@ -27,7 +27,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [get-version]
     permissions: 
       packages: write
@@ -51,7 +51,7 @@ jobs:
 
   deploy-test:
     name: Internal test
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     environment: test
     if: always() && !failure() && !cancelled() 
     needs: [get-version, publish, test]
@@ -82,7 +82,7 @@ jobs:
           GRAFANA_MONITORING_PRINCIPAL_ID: ${{ secrets.GRAFANA_MONITORING_PRINCIPAL_ID }}
   deploy-at22:
     name: deploy at22
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     environment: test
     if: always() && !failure() && !cancelled() 
     needs: [get-version, publish, test, deploy-test]
@@ -112,7 +112,7 @@ jobs:
           GRAFANA_MONITORING_PRINCIPAL_ID: ${{ secrets.GRAFANA_MONITORING_PRINCIPAL_ID }}
   deploy-staging:
     name: Internal staging
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     environment: staging
     if: always() && !failure() && !cancelled() 
     needs: [ 
@@ -145,7 +145,7 @@ jobs:
           GRAFANA_MONITORING_PRINCIPAL_ID: ${{ secrets.GRAFANA_MONITORING_PRINCIPAL_ID }}
   deploy-production:
     name: Production
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     environment: production
     if: (!failure() && !cancelled())
     needs: [
@@ -178,7 +178,7 @@ jobs:
           GRAFANA_MONITORING_PRINCIPAL_ID: ${{ secrets.GRAFANA_MONITORING_PRINCIPAL_ID }}
   check-version-bump:
     name: Check if version was bumped
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [get-version, deploy-production]
     if: ${{ !failure() && !cancelled()}}
     outputs:
@@ -208,7 +208,7 @@ jobs:
 
   release-to-git:  
     name: Release to git
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [check-version-bump]
     if: ${{ needs.check-version-bump.outputs.should-release == 'true' }}
     permissions: 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.language == 'swift' && 'macos-latest' || (vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest') }}
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -24,7 +24,7 @@ run-name: Deploy to ${{ inputs.environment }}
 jobs:
   get-version: 
     name: Get version
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     outputs:
       imageTag: ${{ steps.get-version.outputs.imageTag }}
     permissions: 
@@ -36,7 +36,7 @@ jobs:
         id: get-version
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [get-version]
     permissions: 
       packages: write
@@ -59,7 +59,7 @@ jobs:
           context: .azure/applications/backup
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [get-version, publish]
     environment: ${{ inputs.environment }}
     permissions: 

--- a/.github/workflows/manage-github-runners.yml
+++ b/.github/workflows/manage-github-runners.yml
@@ -1,0 +1,110 @@
+name: Manage GitHub Runners
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        type: choice
+        description: Choose runner mode
+        options:
+          - self-hosted
+          - github-hosted
+      imageTag:
+        type: string
+        required: false
+        description: Runner image tag (default: latest)
+
+run-name: Runner mode ${{ inputs.mode }}
+
+jobs:
+  enable-self-hosted:
+    name: Enable self-hosted runners
+    if: ${{ inputs.mode == 'self-hosted' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    env:
+      RUNNER_IMAGE_TAG: ${{ inputs.imageTag != '' && inputs.imageTag || 'latest' }}
+      RUNNER_IMAGE_NAME: ghcr.io/altinn/altinn-correspondence-github-runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push runner image
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE="${RUNNER_IMAGE_NAME}:${RUNNER_IMAGE_TAG}"
+          docker build \
+            -f .azure/applications/githubRunner/Dockerfile \
+            -t "$IMAGE" \
+            .azure/applications/githubRunner
+          docker push "$IMAGE"
+          echo "PUBLISHED_RUNNER_IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: OIDC login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy GitHub runner Container App
+        uses: azure/arm-deploy@v2
+        env:
+          NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+          ENVIRONMENT: ${{ secrets.AZURE_ENVIRONMENT }}
+          KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+          KEY_VAULT_URL: ${{ format('https://{0}.vault.azure.net', secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME) }}
+          GITHUB_URL: ${{ github.server_url }}/${{ github.repository }}
+          GITHUB_RUNNER_IMAGE: ${{ env.PUBLISHED_RUNNER_IMAGE }}
+        with:
+          scope: subscription
+          template: ./.azure/applications/githubRunner/main.bicep
+          parameters: ./.azure/applications/githubRunner/params.bicepparam
+          region: norwayeast
+          subscriptionId: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          deploymentName: ${{ format('{0}-github-runner-{1}', secrets.AZURE_NAME_PREFIX, github.run_number) }}
+          failOnStdErr: false
+
+  enable-github-hosted:
+    name: Enable GitHub-hosted runners
+    if: ${{ inputs.mode == 'github-hosted' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: OIDC login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Scale self-hosted runner app to zero
+        shell: bash
+        run: |
+          set -euo pipefail
+          RG="${{ secrets.AZURE_NAME_PREFIX }}-rg"
+          APP="${{ secrets.AZURE_NAME_PREFIX }}-github-runner"
+          az extension add --name containerapp --upgrade --yes
+          if az containerapp show --resource-group "$RG" --name "$APP" >/dev/null 2>&1; then
+            az containerapp update \
+              --resource-group "$RG" \
+              --name "$APP" \
+              --min-replicas 0 \
+              --max-replicas 0
+            echo "Self-hosted runner app scaled to zero."
+          else
+            echo "Runner app not found ($APP). Nothing to disable."
+          fi

--- a/.github/workflows/manage-github-runners.yml
+++ b/.github/workflows/manage-github-runners.yml
@@ -12,7 +12,8 @@ on:
       imageTag:
         type: string
         required: false
-        description: Runner image tag (default: latest)
+        default: "latest"
+        description: "Runner image tag (default: latest)"
 
 run-name: Runner mode ${{ inputs.mode }}
 
@@ -97,12 +98,10 @@ jobs:
           set -euo pipefail
           RG="${{ secrets.AZURE_NAME_PREFIX }}-rg"
           APP="${{ secrets.AZURE_NAME_PREFIX }}-github-runner"
-          az extension add --name containerapp --upgrade --yes
           if az containerapp show --resource-group "$RG" --name "$APP" >/dev/null 2>&1; then
             az containerapp update \
               --resource-group "$RG" \
               --name "$APP" \
-              --min-replicas 0 \
               --max-replicas 0
             echo "Self-hosted runner app scaled to zero."
           else

--- a/.github/workflows/manage-github-runners.yml
+++ b/.github/workflows/manage-github-runners.yml
@@ -9,12 +9,6 @@ on:
         options:
           - self-hosted
           - github-hosted
-      imageTag:
-        type: string
-        required: false
-        default: "latest"
-        description: "Runner image tag (default: latest)"
-
 run-name: Runner mode ${{ inputs.mode }}
 
 jobs:
@@ -22,13 +16,11 @@ jobs:
     name: Enable self-hosted runners
     if: ${{ inputs.mode == 'self-hosted' }}
     runs-on: ubuntu-latest
+    environment: test
     permissions:
       id-token: write
       contents: read
       packages: write
-    env:
-      RUNNER_IMAGE_TAG: ${{ inputs.imageTag != '' && inputs.imageTag || 'latest' }}
-      RUNNER_IMAGE_NAME: ghcr.io/altinn/altinn-correspondence-github-runner
     steps:
       - name: Validate required configuration
         shell: bash
@@ -68,7 +60,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          IMAGE="${RUNNER_IMAGE_NAME}:${RUNNER_IMAGE_TAG}"
+          IMAGE="ghcr.io/altinn/altinn-correspondence-github-runner:latest"
           docker build \
             -f .azure/applications/githubRunner/Dockerfile \
             -t "$IMAGE" \
@@ -105,6 +97,7 @@ jobs:
     name: Enable GitHub-hosted runners
     if: ${{ inputs.mode == 'github-hosted' }}
     runs-on: ubuntu-latest
+    environment: test
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/manage-github-runners.yml
+++ b/.github/workflows/manage-github-runners.yml
@@ -30,6 +30,30 @@ jobs:
       RUNNER_IMAGE_TAG: ${{ inputs.imageTag != '' && inputs.imageTag || 'latest' }}
       RUNNER_IMAGE_NAME: ghcr.io/altinn/altinn-correspondence-github-runner
     steps:
+      - name: Validate required configuration
+        shell: bash
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+          AZURE_ENVIRONMENT: ${{ secrets.AZURE_ENVIRONMENT }}
+          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for var in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_NAME_PREFIX AZURE_ENVIRONMENT AZURE_ENVIRONMENT_KEY_VAULT_NAME; do
+            if [[ -z "${!var:-}" ]]; then
+              missing+=("$var")
+            fi
+          done
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Missing required repository secrets/environment variables: ${missing[*]}"
+            echo "::error::See setup instructions: https://github.com/Altinn/altinn-correspondence/blob/main/.azure/applications/githubRunner/README.md"
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -85,6 +109,28 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Validate required configuration
+        shell: bash
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for var in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_NAME_PREFIX; do
+            if [[ -z "${!var:-}" ]]; then
+              missing+=("$var")
+            fi
+          done
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Missing required repository secrets/environment variables: ${missing[*]}"
+            echo "::error::See setup instructions: https://github.com/Altinn/altinn-correspondence/blob/main/.azure/applications/githubRunner/README.md"
+            exit 1
+          fi
+
       - name: OIDC login to Azure
         uses: azure/login@v2
         with:

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     environment: test
     permissions: 
       id-token: write

--- a/.github/workflows/publish-correspondence-sync.yml
+++ b/.github/workflows/publish-correspondence-sync.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
     name: Build latest
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     environment: test
     steps:
       - name: Checkout
@@ -61,7 +61,7 @@ jobs:
           docker push $IMAGE
   deploy_test:
     name: Deploy to test
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [ build ]
     environment: test
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   deploy_staging:
     name: Deploy to staging
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [ deploy_test ]
     environment: staging
     steps:
@@ -107,7 +107,7 @@ jobs:
 
   deploy_production:
     name: Deploy to production
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [ deploy_staging ]
     environment: production
     steps:
@@ -130,7 +130,7 @@ jobs:
 
   deploy_other_environments:
     name: Deploy to other environments (${{ matrix.environment }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [ deploy_test ]
     strategy:
       max-parallel: 1

--- a/.github/workflows/publish-syncroot.yml
+++ b/.github/workflows/publish-syncroot.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   build:
     name: Build latest from main
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     environment: test
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
   deploy_test:
     name: Deploy to test
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [ build ]
     environment: test
     steps:
@@ -67,7 +67,7 @@ jobs:
 
   deploy_staging:
     name: Deploy to staging
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [ deploy_test ]
     environment: staging
     steps:
@@ -90,7 +90,7 @@ jobs:
 
   deploy_production:
     name: Deploy to production
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [ deploy_staging ]
     environment: production
     steps:
@@ -113,7 +113,7 @@ jobs:
 
   deploy_other_environments:
     name: Deploy to other environments (${{ matrix.environment }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: [ deploy_test ]
     strategy:
       max-parallel: 1

--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-application:
     name: Test application
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -113,7 +113,7 @@ permissions:
 run-name: ${{ inputs.tag }} ${{ inputs.vus }}/${{ inputs.duration }}/${{ inputs.parallelism }}
 jobs:
   k6-performance:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     environment: ${{ inputs.environment }}
     steps:
     - name: Checkout code

--- a/.github/workflows/validate-formatting.yml
+++ b/.github/workflows/validate-formatting.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-formatting:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
         - uses: actions/checkout@v6
 

--- a/.github/workflows/verify-db-migration.yml
+++ b/.github/workflows/verify-db-migration.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   determine-commits:
     name: Determine commits to test
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     outputs:
       old_commit: ${{ steps.set-commits.outputs.old_commit }}
       new_commit: ${{ steps.set-commits.outputs.new_commit }}
@@ -53,7 +53,7 @@ jobs:
   test-migration-compatibility:
     environment: use-case-test
     name: Test old code with new database
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: determine-commits
     outputs:
       compatible: ${{ steps.test-result.outputs.compatible }}
@@ -277,7 +277,7 @@ jobs:
 
   report-results:
     name: Report test results
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: test-migration-compatibility
     if: always()
     steps:

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -181,6 +181,16 @@ public class DialogportenService(HttpClient _httpClient,
 
     public async Task CreateDownloadStartedActivity(Guid correspondenceId, DialogportenActorType actorType, DateTimeOffset activityTimestamp, string? partyUrn, params string[] tokens)
     {
+        if (partyUrn.WithUrnPrefix().StartsWith(UrnConstants.PartyUuid))
+        {
+            var correspondence = await _correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, false, CancellationToken.None);
+            if (correspondence == null)
+            {
+                logger.LogError("Correspondence with id {correspondenceId} not found", correspondenceId);
+                throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
+            }
+            partyUrn = await GetDialogParty(correspondence);
+        }
         if (tokens.Length < 2 || !Guid.TryParse(tokens[1], out var attachmentId))
         {
             logger.LogError("Invalid attachment ID token for download activity on correspondence {correspondenceId}", correspondenceId);


### PR DESCRIPTION
## Description
The Github-hosted runner queues on the free tier are killing me. More than an hour when lots of activity. Instead, we should try using Azure Container Apps to host it. AI suggested container app jobs as we get perfect scaling, but that also gives us a startup time of up to three minutes. Instead, we can scale-to-zero on Azure Container Apps so it will probably have a trivial cost, and the only startup time cost is the first run of the day (when it will be a minute or two). After an hour of inactivity it will downscale.

Scale out to up to four replicas to run buiilds concurrently. Maybe we can experiment with lowering that if we want to limit costs further.

We'll keep running the use-case tests on Github hosted runners to limit risk. Plus, they run 24/7 anyway so no point in scaling-to-zero.

https://github.com/Altinn/altinn-correspondence/pull/1887/changes#diff-6a047083e3ec491cea77b93ce72fed1924dfed088e12abafe071356e52867ae6R1

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deploy ephemeral self-hosted GitHub Actions runners on Azure (container image, entrypoint script, and infrastructure templates).
  * Workflow to build/publish runner image and deploy/manage runner container apps.

* **Documentation**
  * Added README describing usage, required secrets/variables, and runtime behavior.

* **Chores**
  * CI workflows updated to optionally use self-hosted runners via a repository variable.

* **Bug Fixes**
  * Improved party resolution logic to fail fast when correspondence lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->