### PR TITLE
Make hangfire enqueue delayed jobs transactionally

### DIFF
--- a/src/Altinn.Correspondence.Application/ConfirmCorrespondence/ConfirmCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/ConfirmCorrespondence/ConfirmCorrespondenceHandler.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Security.Claims;
 using Altinn.Correspondence.Application.VerifyCorrespondenceConfirmation;
+using Altinn.Correspondence.Integrations.Hangfire;
 
 namespace Altinn.Correspondence.Application.ConfirmCorrespondence;
 
@@ -74,7 +75,7 @@ public class ConfirmCorrespondenceHandler(
             return AuthorizationErrors.CouldNotFindPartyUuid;
         }
 
-        var verifyJobId = backgroundJobClient.Schedule<VerifyCorrespondenceConfirmationHandler>(
+        var verifyJobId = backgroundJobClient.Schedule<VerifyCorrespondenceConfirmationHandler>(HangfireQueues.Default, 
             handler => handler.VerifyPatchAndCommitConfirmation(correspondence.Id, partyUuid, party.PartyId, operationTimestamp, caller, CancellationToken.None),
             TimeSpan.FromSeconds(4));
         

--- a/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
@@ -67,7 +67,7 @@ namespace Altinn.Correspondence.Application.Helpers
 
         public void SchedulePublishAtPublishTime(CorrespondenceEntity correspondence, CancellationToken cancellationToken)
         {
-            backgroundJobClient.Schedule<PublishCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, null, cancellationToken), GetActualPublishTime(correspondence.RequestedPublishTime));
+            backgroundJobClient.Schedule<PublishCorrespondenceHandler>(HangfireQueues.Default, (handler) => handler.Process(correspondence.Id, null, cancellationToken), GetActualPublishTime(correspondence.RequestedPublishTime));
         }
 
         private static DateTimeOffset GetActualPublishTime(DateTimeOffset publishTime) => publishTime < DateTimeOffset.UtcNow ? DateTimeOffset.UtcNow : publishTime; // If in past, do now

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -10,6 +10,7 @@ using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
+using Altinn.Correspondence.Integrations.Hangfire;
 using Altinn.Correspondence.Persistence.Helpers;
 using Hangfire;
 using Microsoft.EntityFrameworkCore;
@@ -136,7 +137,7 @@ public class InitializeCorrespondencesHandler(
             {
                 if (correspondence.DueDateTime is not null)
                 {
-                    backgroundJobClient.Schedule<CorrespondenceDueDateHandler>((handler) => handler.Process(correspondence.Id, cancellationToken), correspondence.DueDateTime.Value);
+                    backgroundJobClient.Schedule<CorrespondenceDueDateHandler>(HangfireQueues.Default, (handler) => handler.Process(correspondence.Id, cancellationToken), correspondence.DueDateTime.Value);
                 }
                 backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.CorrespondenceInitialized, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, CancellationToken.None));
             
@@ -164,7 +165,7 @@ public class InitializeCorrespondencesHandler(
                 }
 
                 backgroundJobClient.Schedule<ExpireAttachmentHandler>(
-                    (handler) => handler.Process(correspondenceAttachment.AttachmentId, null, CancellationToken.None),
+                    HangfireQueues.Default, (handler) => handler.Process(correspondenceAttachment.AttachmentId, null, CancellationToken.None),
                     scheduleAt);
             }
 
@@ -180,7 +181,7 @@ public class InitializeCorrespondencesHandler(
                 var unreadCheckDelay = hostEnvironment.IsProduction()
                     ? correspondence.RequestedPublishTime.AddDays(7)
                     : correspondence.RequestedPublishTime.AddMinutes(1);
-                backgroundJobClient.Schedule<UnreadConfidentialCorrespondenceHandler>((handler) => handler.Process(correspondence.Id, cancellationToken), unreadCheckDelay);
+                backgroundJobClient.Schedule<UnreadConfidentialCorrespondenceHandler>(HangfireQueues.Default, (handler) => handler.Process(correspondence.Id, cancellationToken), unreadCheckDelay);
             }
 
             initializedCorrespondences.Add(new InitializedCorrespondences()

--- a/src/Altinn.Correspondence.Application/SendNotificationOrder/SendNotificationOrderHandler.cs
+++ b/src/Altinn.Correspondence.Application/SendNotificationOrder/SendNotificationOrderHandler.cs
@@ -6,6 +6,7 @@ using Altinn.Correspondence.Core.Models.Notifications;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
+using Altinn.Correspondence.Integrations.Hangfire;
 using Altinn.Correspondence.Persistence.Helpers;
 using Hangfire;
 using Microsoft.EntityFrameworkCore;
@@ -146,7 +147,7 @@ public class SendNotificationOrderHandler(
 
     private void ScheduleNotificationDeliveryCheck(CorrespondenceNotificationEntity notificationOrder)
     {
-        backgroundJobClient.Schedule<CheckNotificationDeliveryHandler>(
+        backgroundJobClient.Schedule<CheckNotificationDeliveryHandler>(HangfireQueues.Default,
             handler => handler.Process(notificationOrder.Id, CancellationToken.None),
             notificationOrder.RequestedSendTime.AddMinutes(NotificationDeliveryCheckDelayMinutes));
     }

--- a/src/Altinn.Correspondence.Core/Options/GeneralSettings.cs
+++ b/src/Altinn.Correspondence.Core/Options/GeneralSettings.cs
@@ -14,6 +14,5 @@ public class GeneralSettings
     public string MalwareScanBypassWhiteList { get; set; } = string.Empty;
     public int MigrationWorkerCountPerReplica { get; set; } = 2;
     public int WorkerCountPerReplica { get; set; } = 50;
-    public int MaxDegreeOfParallelismForSchedulers { get; set; } = 2;
     public string ArbeidsflateBaseUrl { get; set; } = string.Empty;
 }

--- a/src/Altinn.Correspondence.Integrations/Hangfire/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Integrations/Hangfire/DependencyInjection.cs
@@ -39,7 +39,6 @@ public static class DependencyInjection
             options.SchedulePollingInterval = TimeSpan.FromSeconds(5);
             options.Queues = [ HangfireQueues.Default ];
             options.WorkerCount = generalSettings.WorkerCountPerReplica;
-            options.MaxDegreeOfParallelismForSchedulers = generalSettings.MaxDegreeOfParallelismForSchedulers;
         });
 
         if (generalSettings.MigrationWorkerCountPerReplica > 0)
@@ -49,7 +48,6 @@ public static class DependencyInjection
                 options.SchedulePollingInterval = TimeSpan.FromSeconds(5);
                 options.WorkerCount = generalSettings.MigrationWorkerCountPerReplica;
                 options.Queues = [HangfireQueues.LiveMigration, HangfireQueues.Migration];
-                options.MaxDegreeOfParallelismForSchedulers = generalSettings.MaxDegreeOfParallelismForSchedulers;
             });
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes all the background job schedules use the queue overload parameter so that the value for the shceduled job gets a queue prefix in the set table, as shown here:
<img width="1028" height="431" alt="image" src="https://github.com/user-attachments/assets/9239a00b-20dd-446f-91a9-7568383dbb63" />

#### Why?
After having inspected the source code for the hangfire delayedJobScheduler i found that it enqueues delayed jobs in two ways: For jobs without colon in its value it enqueues sequentially. Meaning it enqueues jobs one after one (O(N)). Whereas for jobs with colon in its value it schedules transactionally, meaning it sets all the delayed jobs to enqueued in one transaction (O(1)). Having the scheduler enque delayed jobs transactionally should be way faster and possibly with less cpu cost. This is the source code in hangfire where this happens for reference: https://github.com/HangfireIO/Hangfire/blob/333bd8eb228402abcee3f261cf32412e844f32c0/src/Hangfire.Core/Server/DelayedJobScheduler.cs#L190.

Using the queue overload parameter when scheduling jobs will give the jobs a queue + colon prefix which should make them enqueued transactionally instead of sequentially by the hangfire delayedjob scheduler. 

This should hopefully remove the bottle neck of the scheduler not being able to enqueue jobs fast enough. Which has limited the system to only publish about 20 correspondences per second at max.

This PR also removes the MaxDegreeOfParallelism from hangfire server options so it uses default value instead, because it was not effective.

## Related Issue(s)
- #1873 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)