### PR TITLE
Show propertyDetails additional properties in swagger 

### DIFF
--- a/src/Altinn.Correspondence.API/Filters/BadRequestOneOfOperationFilter.cs
+++ b/src/Altinn.Correspondence.API/Filters/BadRequestOneOfOperationFilter.cs
@@ -1,0 +1,28 @@
+using Altinn.Authorization.ProblemDetails;
+using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Altinn.Correspondence.API.Filters;
+
+public class BadRequestOneOfOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        if (operation.Responses is null || !operation.Responses.TryGetValue("400", out var response))
+            return;
+
+        if (response.Content is null || !response.Content.TryGetValue("application/json", out var mediaType))
+            return;
+
+        var domainErrorSchema = context.SchemaGenerator.GenerateSchema(
+            typeof(AltinnProblemDetails), context.SchemaRepository);
+
+        var validationErrorSchema = context.SchemaGenerator.GenerateSchema(
+            typeof(AltinnValidationProblemDetails), context.SchemaRepository);
+
+        mediaType.Schema = new OpenApiSchema
+        {
+            OneOf = [domainErrorSchema, validationErrorSchema]
+        };
+    }
+}

--- a/src/Altinn.Correspondence.API/Filters/ProblemDetailsSchemaFilter.cs
+++ b/src/Altinn.Correspondence.API/Filters/ProblemDetailsSchemaFilter.cs
@@ -12,10 +12,12 @@ public class ProblemDetailsSchemaFilter : ISchemaFilter
         if (!typeof(ProblemDetails).IsAssignableFrom(context.Type))
             return;
 
-        if (schema is OpenApiSchema concreteSchema)
-            concreteSchema.AdditionalPropertiesAllowed = false;
+        if (schema is not OpenApiSchema concreteSchema)
+            return;
 
-        var props = schema.Properties ?? new Dictionary<string, IOpenApiSchema>();
+        concreteSchema.AdditionalPropertiesAllowed = false;
+        concreteSchema.Properties ??= new Dictionary<string, IOpenApiSchema>();
+        var props = concreteSchema.Properties;
 
         if (props.ContainsKey("code"))
             props["code"] = StringSchema();

--- a/src/Altinn.Correspondence.API/Filters/ProblemDetailsSchemaFilter.cs
+++ b/src/Altinn.Correspondence.API/Filters/ProblemDetailsSchemaFilter.cs
@@ -1,0 +1,79 @@
+using Altinn.Authorization.ProblemDetails;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Altinn.Correspondence.API.Filters;
+
+public class ProblemDetailsSchemaFilter : ISchemaFilter
+{
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (!typeof(ProblemDetails).IsAssignableFrom(context.Type))
+            return;
+
+        if (schema is OpenApiSchema concreteSchema)
+            concreteSchema.AdditionalPropertiesAllowed = false;
+
+        var props = schema.Properties ?? new Dictionary<string, IOpenApiSchema>();
+
+        if (props.ContainsKey("code"))
+            props["code"] = StringSchema();
+
+        props["traceId"] = StringNullableSchema("OpenTelemetry trace ID for the request.");
+
+        if (typeof(AltinnValidationProblemDetails).IsAssignableFrom(context.Type))
+        {
+            props["code"] = StringNullableSchema("Altinn error code (e.g. STD-00000).");
+
+            props["validationErrors"] = new OpenApiSchema
+            {
+                Type = JsonSchemaType.Array | JsonSchemaType.Null,
+                Items = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Object,
+                    Properties = new Dictionary<string, IOpenApiSchema>
+                    {
+                        ["code"] = StringSchema("Altinn validation error code (e.g. CORR.VLD-00000)."),
+                        ["detail"] = StringSchema("Human-readable description of the validation error."),
+                        ["paths"] = new OpenApiSchema
+                        {
+                            Type = JsonSchemaType.Array,
+                            Items = StringSchema(),
+                            Description = "JSON pointer paths to the fields that failed validation."
+                        }
+                    }
+                },
+                Description = "Structured validation errors per field."
+            };
+
+            props["errors"] = new OpenApiSchema
+            {
+                Type = JsonSchemaType.Object | JsonSchemaType.Null,
+                AdditionalPropertiesAllowed = true,
+                AdditionalProperties = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Array,
+                    Items = StringSchema()
+                },
+                Description = "Field-keyed validation error messages (legacy format)."
+            };
+        }
+        else
+        {
+            props["errorCode"] = StringNullableSchema("Altinn error code (e.g. CORR-00001).");
+        }
+    }
+
+    private static OpenApiSchema StringSchema(string? description = null) => new()
+    {
+        Type = JsonSchemaType.String,
+        Description = description
+    };
+
+    private static OpenApiSchema StringNullableSchema(string? description = null) => new()
+    {
+        Type = JsonSchemaType.String | JsonSchemaType.Null,
+        Description = description
+    };
+}

--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -155,6 +155,8 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
         var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
         var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
         options.IncludeXmlComments(xmlPath);
+        options.SchemaFilter<ProblemDetailsSchemaFilter>();
+        options.OperationFilter<BadRequestOneOfOperationFilter>();
     });
 
     services.AddApplicationHandlers();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the swagger just shows a basic example and schema for the propertyDetails response: 
<img width="949" height="298" alt="image" src="https://github.com/user-attachments/assets/8fa40676-85a8-4858-aed1-166d880b8412" />

Instead of just displaying additionalProperties it should display the additionalProperties the system actually sets, including
TraceId, errorcode, errors. Also badRequest responses can be either AltinnValidationProblemDetails for validation errors or AltinnProblemDetails for business errors. 

This PR adds a filter to replace additionalProperties with the additional properties we set for both AltinnValidationProblemDetails and AltinnProblemDetails. And this PR adds a filter to make badrequest responses one of AltinnValidationProblemDetails and AltinnProblemDetails.

### Result:
example: 
<img width="374" height="250" alt="image" src="https://github.com/user-attachments/assets/8324606f-01a9-4c71-a2b3-002458b309db" />

schema: 
<img width="529" height="681" alt="image" src="https://github.com/user-attachments/assets/7f3bda0d-6b03-47e6-8d7f-2e81c8e1a40f" />



## Related Issue(s)
- #1857 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation for HTTP 400 error responses with improved schema definitions in the OpenAPI specification. Problem details responses now include clearer structure and documentation for error codes, trace IDs, validation errors, and related error information, helping API consumers understand and handle various error scenarios more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->