### PR TITLE
Make CreateDialog re-entrant

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -1,6 +1,7 @@
-﻿using Altinn.Correspondence.API.Models;
+using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application.GetCorrespondenceOverview;
+using Altinn.Correspondence.Application.InitializeCorrespondences;
 using Altinn.Correspondence.Application.PublishCorrespondence;
 using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Core.Models.Entities;
@@ -70,6 +71,72 @@ public class DialogportenTests
         // Assert
         initializeCorrespondenceResponse.EnsureSuccessStatusCode();
         Assert.Contains(hangfireBackgroundJobClient.Invocations, invocation => invocation.Arguments[0].ToString() == "InitializeCorrespondencesHandler.CreateDialogportenDialog");
+    }
+
+    [Fact]
+    public async Task CreateDialogportenDialog_WhenJobIsReEntrant_DoesNotCreateDuplicateExternalReference()
+    {
+        // Arrange
+        var dialogId = "existing-dialog-id";
+        var mockDialogportenService = new Mock<IDialogportenService>();
+        mockDialogportenService
+            .Setup(x => x.CreateCorrespondenceDialog(It.IsAny<Guid>()))
+            .ReturnsAsync(dialogId);
+
+        using var testFactory = new UnitWebApplicationFactory((IServiceCollection services) =>
+        {
+            services.AddSingleton(mockDialogportenService.Object);
+        });
+
+        using var scope = testFactory.Services.CreateScope();
+        var correspondenceRepository = scope.ServiceProvider.GetRequiredService<ICorrespondenceRepository>();
+        var correspondenceId = Guid.NewGuid();
+
+        await correspondenceRepository.CreateCorrespondence(new CorrespondenceEntity()
+        {
+            Id = correspondenceId,
+            Created = DateTimeOffset.UtcNow,
+            Recipient = $"{UrnConstants.PersonIdAttribute}:12345678901",
+            RequestedPublishTime = DateTimeOffset.UtcNow,
+            ResourceId = "urn:altinn:resource:test-resource",
+            Sender = "991825827",
+            SendersReference = "reentrant-test-reference",
+            Content = new CorrespondenceContentEntity
+            {
+                Id = Guid.NewGuid(),
+                CorrespondenceId = correspondenceId,
+                Language = "nb",
+                MessageTitle = "title",
+                MessageSummary = "summary",
+                MessageBody = "body",
+                Attachments = new List<CorrespondenceAttachmentEntity>()
+            },
+            Statuses = new List<CorrespondenceStatusEntity>()
+            {
+                new CorrespondenceStatusEntity
+                {
+                    Status = CorrespondenceStatus.Initialized,
+                    StatusChanged = DateTimeOffset.UtcNow
+                }
+            },
+            StatusFetched = new List<CorrespondenceStatusFetchedEntity>(),
+            ExternalReferences = new List<ExternalReferenceEntity>()
+        }, CancellationToken.None);
+
+        var handler = scope.ServiceProvider.GetRequiredService<InitializeCorrespondencesHandler>();
+
+        // Act - simulate the same Hangfire job running twice
+        await handler.CreateDialogportenDialog(correspondenceId);
+        await handler.CreateDialogportenDialog(correspondenceId);
+
+        var updatedCorrespondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, false, false, false, CancellationToken.None);
+        var dialogReferences = updatedCorrespondence!.ExternalReferences
+            .Where(er => er.ReferenceType == ReferenceType.DialogportenDialogId)
+            .ToList();
+
+        // Assert
+        Assert.Single(dialogReferences);
+        Assert.Equal(dialogId, dialogReferences[0].ReferenceValue);
     }
 
     [Fact]

--- a/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
@@ -37,7 +37,7 @@ namespace Altinn.Correspondence.Application.Helpers
             }
             else
             {
-                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(dialogJobId, (helper) => helper.SchedulePublishAtPublishTime(correspondenceId, cancellationToken));
+                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(dialogJobId, (helper) => helper.SchedulePublishAtPublishTime(correspondenceId, cancellationToken), JobContinuationOptions.OnAnyFinishedState);
             }
         }
 

--- a/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/HangfireScheduleHelper.cs
@@ -37,7 +37,7 @@ namespace Altinn.Correspondence.Application.Helpers
             }
             else
             {
-                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(dialogJobId, (helper) => helper.SchedulePublishAtPublishTime(correspondenceId, cancellationToken), JobContinuationOptions.OnAnyFinishedState);
+                backgroundJobClient.ContinueJobWith<HangfireScheduleHelper>(dialogJobId, (helper) => helper.SchedulePublishAtPublishTime(correspondenceId, cancellationToken));
             }
         }
 

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -49,6 +49,20 @@ public class DialogportenService(HttpClient _httpClient,
         var response = await _httpClient.PostAsJsonAsync("dialogporten/api/v1/serviceowner/dialogs", createDialogRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
+            if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync();
+                if (errorContent.Contains("already exists"))
+                {
+                    logger.LogWarning("Dialog already exists for correspondence {correspondenceId}", correspondenceId);
+                    var existingDialogId = correspondence.ExternalReferences.FirstOrDefault(reference => reference.ReferenceType == ReferenceType.DialogportenDialogId)?.ReferenceValue;
+                    if (existingDialogId is null)
+                    {
+                        return createDialogRequest.Id; // Return the dialog ID from the request if it's not yet stored on the correspondence, it will be stored when the dialog is created on Dialogporten
+                    }
+                    return existingDialogId;
+                }
+            }
             var errorMessage = await response.Content.ReadAsStringAsync();
             logger.LogError(errorMessage);
             throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -186,10 +186,14 @@ namespace Altinn.Correspondence.Persistence.Repositories
 
         public async Task AddExternalReference(Guid correspondenceId, ReferenceType referenceType, string referenceValue, CancellationToken cancellationToken = default)
         {
-            var correspondence = await _context.Correspondences.SingleOrDefaultAsync(c => c.Id == correspondenceId, cancellationToken);
+            var correspondence = await _context.Correspondences.Include(c => c.ExternalReferences).SingleOrDefaultAsync(c => c.Id == correspondenceId, cancellationToken);
             if (correspondence is null)
             {
                 throw new ArgumentException("Correspondence not found", nameof(correspondenceId));
+            }
+            if (referenceType == ReferenceType.DialogportenDialogId && correspondence.ExternalReferences.Any(er => er.ReferenceType == ReferenceType.DialogportenDialogId))
+            {
+                return;
             }
             correspondence.ExternalReferences.Add(new ExternalReferenceEntity
             {


### PR DESCRIPTION
## Description
Handle already created in dialogporten and do not store dialog id if already stored.

## Related Issue(s)
- #1878 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling when creating a dialog that already exists, allowing graceful fallback to existing dialog identifiers.
  * Prevented duplicate external references from being added to the system, improving data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->