### PR TITLE
Fix duplicate migration jobs

### DIFF
--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -181,8 +181,8 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
         {
             if (!request.AsyncProcessing)
             {
-                var correspondences = await correspondenceRepository.GetCandidatesForMigrationToDialogporten(request.BatchSize ?? 0, request.CursorCreated, request.CursorId, request.CreatedFrom, request.CreatedTo, cancellationToken);
-                foreach (var correspondence in correspondences)
+                var correspondenceCandidates = await correspondenceRepository.GetCandidatesForMigrationToDialogporten(request.BatchSize ?? 0, request.CursorCreated, request.CursorId, request.CreatedFrom, request.CreatedTo, cancellationToken);
+                foreach (var correspondence in correspondenceCandidates)
                 {
                     try
                     {
@@ -199,7 +199,7 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
             var currentBatch = 999;
             var migrationQueueLimit = currentBatch * 20;
 
-            int enqueuedJobs;
+            long enqueuedJobs;
             while ((enqueuedJobs = JobStorage.Current.GetMonitoringApi().EnqueuedCount(HangfireQueues.Migration)) > migrationQueueLimit)
             {
                 logger.LogInformation(

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -197,47 +197,39 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
                 return response;
             }
             var currentBatch = 999;
+            var migrationQueueLimit = currentBatch * 20;
 
-            var enqueuedJobs = JobStorage.Current.GetMonitoringApi().EnqueuedCount(HangfireQueues.Migration);
-            if (enqueuedJobs > currentBatch * 20)
+            int enqueuedJobs;
+            while ((enqueuedJobs = JobStorage.Current.GetMonitoringApi().EnqueuedCount(HangfireQueues.Migration)) > migrationQueueLimit)
             {
-                var migrateRequest = new MakeCorrespondenceAvailableRequest()
-                {
-                    AsyncProcessing = true,
-                    BatchSize = request.BatchSize,
-                    CreateEvents = request.CreateEvents,
-                    CursorCreated = request.CursorCreated,
-                    CursorId = request.CursorId,
-                    CreatedFrom = request.CreatedFrom,
-                    CreatedTo = request.CreatedTo
-                };
-                logger.LogInformation("Delaying scheduling of migration jobs as there are currently {EnqueuedJobs} jobs in the queue", enqueuedJobs);
-                backgroundJobClient.Schedule<MigrateCorrespondenceHandler>(HangfireQueues.LiveMigration, (handler) => handler.MakeCorrespondenceAvailable(migrateRequest, CancellationToken.None), TimeSpan.FromMinutes(1));
-            } 
-            else
-            {
-                logger.LogInformation("Querying db");
-                var correspondences = await correspondenceRepository.GetCandidatesForMigrationToDialogporten(currentBatch, request.CursorCreated, request.CursorId, request.CreatedFrom, request.CreatedTo, cancellationToken);
-                logger.LogInformation("Found {count} correspondences", correspondences.Count);
-                var last = correspondences.Last();
-                var migrateRequest = new MakeCorrespondenceAvailableRequest()
-                {
-                    AsyncProcessing = true,
-                    BatchSize = request.BatchSize - correspondences.Count,
-                    CreateEvents = request.CreateEvents,
-                    CursorCreated = last.Created,
-                    CursorId = last.Id,
-                    CreatedFrom = request.CreatedFrom,
-                    CreatedTo = request.CreatedTo
-                };
-                logger.LogInformation("Enqueuing next batch for {id}", last.Id);
-                backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.LiveMigration, (handler) => handler.MakeCorrespondenceAvailable(migrateRequest, CancellationToken.None));
-                foreach (var correspondence in correspondences)
-                {
-                    backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.Migration, handler => handler.MakeCorrespondenceAvailableInDialogportenAndApi(correspondence.Id, CancellationToken.None, true, null, request.CreateEvents));
-                }
-                logger.LogInformation("Finished queuing {count} correspondences", correspondences.Count);
+                logger.LogInformation(
+                    "Waiting before scheduling next migration batch: {EnqueuedJobs} jobs in Migration queue (limit {Limit})",
+                    enqueuedJobs,
+                    migrationQueueLimit);
+                await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
             }
+
+            logger.LogInformation("Querying db");
+            var correspondences = await correspondenceRepository.GetCandidatesForMigrationToDialogporten(currentBatch, request.CursorCreated, request.CursorId, request.CreatedFrom, request.CreatedTo, cancellationToken);
+            logger.LogInformation("Found {count} correspondences", correspondences.Count);
+            var last = correspondences.Last();
+            var migrateRequest = new MakeCorrespondenceAvailableRequest()
+            {
+                AsyncProcessing = true,
+                BatchSize = request.BatchSize - correspondences.Count,
+                CreateEvents = request.CreateEvents,
+                CursorCreated = last.Created,
+                CursorId = last.Id,
+                CreatedFrom = request.CreatedFrom,
+                CreatedTo = request.CreatedTo
+            };
+            logger.LogInformation("Enqueuing next batch for {id}", last.Id);
+            backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.LiveMigration, (handler) => handler.MakeCorrespondenceAvailable(migrateRequest, CancellationToken.None));
+            foreach (var correspondence in correspondences)
+            {
+                backgroundJobClient.Enqueue<MigrateCorrespondenceHandler>(HangfireQueues.Migration, handler => handler.MakeCorrespondenceAvailableInDialogportenAndApi(correspondence.Id, CancellationToken.None, true, null, request.CreateEvents));
+            }
+            logger.LogInformation("Finished queuing {count} correspondences", correspondences.Count);
         }
 
         return response;


### PR DESCRIPTION
## Description
The previous re-scheduling approach failed if it ended up having to wait several minutes before a new job could be re-scheduled. Instead we poll inside one job to make re-scheduling single-threaded.

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)