### PR TITLE
Fix DownloadStarted activity for SI users

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -195,6 +195,16 @@ public class DialogportenService(HttpClient _httpClient,
 
     public async Task CreateDownloadStartedActivity(Guid correspondenceId, DialogportenActorType actorType, DateTimeOffset activityTimestamp, string? partyUrn, params string[] tokens)
     {
+        if (partyUrn?.WithUrnPrefix().StartsWith(UrnConstants.PartyUuid) == true)
+        {
+            var correspondence = await _correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, false, CancellationToken.None);
+            if (correspondence == null)
+            {
+                logger.LogError("Correspondence with id {correspondenceId} not found", correspondenceId);
+                throw new ArgumentException($"Correspondence with id {correspondenceId} not found", nameof(correspondenceId));
+            }
+            partyUrn = await GetDialogParty(correspondence);
+        }
         if (tokens.Length < 2 || !Guid.TryParse(tokens[1], out var attachmentId))
         {
             logger.LogError("Invalid attachment ID token for download activity on correspondence {correspondenceId}", correspondenceId);


### PR DESCRIPTION
## Description
We need to map party uuid to urn:altinn:person:legacy-selfidentified.

## Related Issue(s)
- #1855 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved party data handling** – Enhanced the reliability of party information retrieval in correspondence download operations to ensure consistent data normalization across different party reference formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->