### PR TITLE
add messageSender to reminder

### DIFF
--- a/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
+++ b/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
@@ -45,6 +45,7 @@ public class UnreadConfidentialCorrespondenceHandler(
             Recipient = correspondence.Recipient.WithUrnPrefix(),
             ResourceId = "ttd-reminder-unopened-confidential-correspondences",
             SendersReference = "Digdir",
+            MessageSender = "Digitaliseringsdirektoratet",
             Created = DateTimeOffset.UtcNow,
             Status = "RequiresAttention",
             PropertyList = new Dictionary<string, string>{}


### PR DESCRIPTION
## Description
Det er kommet feil i critical hvor varslinger på ConfidentialReminder ikke blir opprettet. Den returnerer NullreferenceException fra register. Dette skyldtes at MessageSender og SenderUrn var null, og at denne kombinasjonen ikke lenger fungerte. Dette er rettet og rullet ut.

## Related Issue(s)
- #1909

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the message sender attribution for unread confidential correspondence reminders to ensure correct sender identification in notification messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->