### PR TITLE
Feat/additional notification events

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CheckNotificationDeliveryHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CheckNotificationDeliveryHandlerTests.cs
@@ -274,7 +274,7 @@ public class CheckNotificationDeliveryHandlerTests
     [InlineData(NotificationStatusV2.SMS_Failed)]
     [InlineData(NotificationStatusV2.SMS_Failed_TTL)]
     [InlineData(NotificationStatusV2.SMS_Failed_RecipientNotIdentified)]
-    public async Task Process_WhenNotificationFails_CreateFailedEvent(NotificationStatusV2 recipientStatus)
+    public async Task Process_WhenAllNotificationsFail_CreatesAllFailedEvent(NotificationStatusV2 recipientStatus)
     {
         // Arrange
         var notificationId = Guid.NewGuid();
@@ -306,17 +306,17 @@ public class CheckNotificationDeliveryHandlerTests
             Status = "Order_Completed",
             ShipmentId = shipmentId,
             Recipients = new List<RecipientStatus>
-        {
-            new()
             {
-                Type = recipientStatus >= NotificationStatusV2.SMS_New && recipientStatus < NotificationStatusV2.Unknown
-                    ? NotificationType.SMS
-                    : NotificationType.Email,
-                Destination = "test@example.com",
-                Status = recipientStatus,
-                LastUpdate = DateTimeOffset.UtcNow
+                new()
+                {
+                    Type = recipientStatus >= NotificationStatusV2.SMS_New && recipientStatus < NotificationStatusV2.Unknown
+                        ? NotificationType.SMS
+                        : NotificationType.Email,
+                    Destination = "test@example.com",
+                    Status = recipientStatus,
+                    LastUpdate = DateTimeOffset.UtcNow
+                }
             }
-        }
         };
         _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(notification);
@@ -338,9 +338,85 @@ public class CheckNotificationDeliveryHandlerTests
             It.IsAny<CancellationToken>()), Times.Never);
         _backgroundJobClientMock.Verify(x => x.Create(
             It.Is<Job>(job =>
-                job.Type == typeof(IDialogportenService) &&
-                job.Method.Name == nameof(IDialogportenService.CreateInformationActivity)),
+                job.Type == typeof(IEventBus) &&
+                job.Method.Name == nameof(IEventBus.Publish) &&
+                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationAllFailed &&
+                (string)job.Args[1] == correspondence.ResourceId &&
+                (string)job.Args[2] == correspondence.Id.ToString() &&
+                (string)job.Args[3] == "correspondence" &&
+                (string)job.Args[4] == correspondence.Sender),
+            It.Is<IState>(state => state is EnqueuedState)), Times.Once);
+        _backgroundJobClientMock.Verify(x => x.Create(
+            It.Is<Job>(job =>
+                job.Type == typeof(IEventBus) &&
+                job.Method.Name == nameof(IEventBus.Publish) &&
+                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationFailed),
             It.IsAny<IState>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenSomeRecipientsFail_CreatesPartialFailedEvent()
+    {
+        // Arrange
+        var notificationId = Guid.NewGuid();
+        var correspondenceId = Guid.NewGuid();
+        var shipmentId = Guid.NewGuid();
+        var notification = new CorrespondenceNotificationEntity
+        {
+            Id = notificationId,
+            CorrespondenceId = correspondenceId,
+            ShipmentId = shipmentId,
+            NotificationChannel = NotificationChannel.Email,
+            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
+            Created = DateTimeOffset.UtcNow,
+            RequestedSendTime = DateTimeOffset.UtcNow
+        };
+        var correspondence = new CorrespondenceEntity
+        {
+            Id = correspondenceId,
+            Recipient = "12345678901",
+            Sender = "test_sender",
+            ResourceId = "test_resource",
+            SendersReference = "test_reference",
+            RequestedPublishTime = DateTimeOffset.UtcNow,
+            Statuses = new List<CorrespondenceStatusEntity>(),
+            Created = DateTimeOffset.UtcNow
+        };
+        var notificationDetailsV2 = new NotificationStatusResponseV2
+        {
+            Status = "Order_Completed",
+            ShipmentId = shipmentId,
+            Recipients = new List<RecipientStatus>
+            {
+                new()
+                {
+                    Type = NotificationType.Email,
+                    Destination = "delivered@example.com",
+                    Status = NotificationStatusV2.Email_Delivered,
+                    LastUpdate = DateTimeOffset.UtcNow
+                },
+                new()
+                {
+                    Type = NotificationType.Email,
+                    Destination = "failed@example.com",
+                    Status = NotificationStatusV2.Email_Failed,
+                    LastUpdate = DateTimeOffset.UtcNow
+                }
+            }
+        };
+        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notification);
+        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(correspondence);
+        _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notificationDetailsV2);
+
+        // Act
+        var result = await _handler.Process(notificationId, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsT0);
+
         _backgroundJobClientMock.Verify(x => x.Create(
             It.Is<Job>(job =>
                 job.Type == typeof(IEventBus) &&
@@ -351,5 +427,161 @@ public class CheckNotificationDeliveryHandlerTests
                 (string)job.Args[3] == "correspondence" &&
                 (string)job.Args[4] == correspondence.Sender),
             It.Is<IState>(state => state is EnqueuedState)), Times.Once);
+        _backgroundJobClientMock.Verify(x => x.Create(
+            It.Is<Job>(job =>
+                job.Type == typeof(IEventBus) &&
+                job.Method.Name == nameof(IEventBus.Publish) &&
+                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationAllFailed),
+            It.IsAny<IState>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenMainNotificationSent_CreatesNotificationSentEvent()
+    {
+        // Arrange
+        var notificationId = Guid.NewGuid();
+        var correspondenceId = Guid.NewGuid();
+        var shipmentId = Guid.NewGuid();
+        var notification = new CorrespondenceNotificationEntity
+        {
+            Id = notificationId,
+            CorrespondenceId = correspondenceId,
+            ShipmentId = shipmentId,
+            IsReminder = false,
+            NotificationChannel = NotificationChannel.Email,
+            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
+            Created = DateTimeOffset.UtcNow,
+            RequestedSendTime = DateTimeOffset.UtcNow
+        };
+        var correspondence = new CorrespondenceEntity
+        {
+            Id = correspondenceId,
+            Recipient = "12345678901",
+            Sender = "test_sender",
+            ResourceId = "test_resource",
+            SendersReference = "test_reference",
+            RequestedPublishTime = DateTimeOffset.UtcNow,
+            Statuses = new List<CorrespondenceStatusEntity>(),
+            Created = DateTimeOffset.UtcNow
+        };
+        var notificationDetailsV2 = new NotificationStatusResponseV2
+        {
+            Status = "Order_Completed",
+            ShipmentId = shipmentId,
+            Recipients = new List<RecipientStatus>
+            {
+                new()
+                {
+                    Type = NotificationType.Email,
+                    Destination = "test@example.com",
+                    Status = NotificationStatusV2.Email_Delivered,
+                    LastUpdate = DateTimeOffset.UtcNow
+                }
+            }
+        };
+        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notification);
+        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(correspondence);
+        _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notificationDetailsV2);
+
+        // Act
+        var result = await _handler.Process(notificationId, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsT0);
+
+        _backgroundJobClientMock.Verify(x => x.Create(
+            It.Is<Job>(job =>
+                job.Type == typeof(IEventBus) &&
+                job.Method.Name == nameof(IEventBus.Publish) &&
+                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationDelivered &&
+                (string)job.Args[1] == correspondence.ResourceId &&
+                (string)job.Args[2] == correspondence.Id.ToString() &&
+                (string)job.Args[3] == "correspondence" &&
+                (string)job.Args[4] == correspondence.Sender),
+            It.Is<IState>(state => state is EnqueuedState)), Times.Once);
+        _backgroundJobClientMock.Verify(x => x.Create(
+            It.Is<Job>(job =>
+                job.Type == typeof(IEventBus) &&
+                job.Method.Name == nameof(IEventBus.Publish) &&
+                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationReminderDelivered),
+            It.IsAny<IState>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenReminderNotificationSent_CreatesReminderSentEvent()
+    {
+        // Arrange
+        var notificationId = Guid.NewGuid();
+        var correspondenceId = Guid.NewGuid();
+        var shipmentId = Guid.NewGuid();
+        var notification = new CorrespondenceNotificationEntity
+        {
+            Id = notificationId,
+            CorrespondenceId = correspondenceId,
+            ShipmentId = shipmentId,
+            IsReminder = true,
+            NotificationChannel = NotificationChannel.Email,
+            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
+            Created = DateTimeOffset.UtcNow,
+            RequestedSendTime = DateTimeOffset.UtcNow
+        };
+        var correspondence = new CorrespondenceEntity
+        {
+            Id = correspondenceId,
+            Recipient = "12345678901",
+            Sender = "test_sender",
+            ResourceId = "test_resource",
+            SendersReference = "test_reference",
+            RequestedPublishTime = DateTimeOffset.UtcNow,
+            Statuses = new List<CorrespondenceStatusEntity>(),
+            Created = DateTimeOffset.UtcNow
+        };
+        var notificationDetailsV2 = new NotificationStatusResponseV2
+        {
+            Status = "Order_Completed",
+            ShipmentId = shipmentId,
+            Recipients = new List<RecipientStatus>
+            {
+                new()
+                {
+                    Type = NotificationType.Email,
+                    Destination = "test@example.com",
+                    Status = NotificationStatusV2.Email_Delivered,
+                    LastUpdate = DateTimeOffset.UtcNow
+                }
+            }
+        };
+        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notification);
+        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(correspondence);
+        _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notificationDetailsV2);
+
+        // Act
+        var result = await _handler.Process(notificationId, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsT0);
+
+        _backgroundJobClientMock.Verify(x => x.Create(
+            It.Is<Job>(job =>
+                job.Type == typeof(IEventBus) &&
+                job.Method.Name == nameof(IEventBus.Publish) &&
+                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationReminderDelivered &&
+                (string)job.Args[1] == correspondence.ResourceId &&
+                (string)job.Args[2] == correspondence.Id.ToString() &&
+                (string)job.Args[3] == "correspondence" &&
+                (string)job.Args[4] == correspondence.Sender),
+            It.Is<IState>(state => state is EnqueuedState)), Times.Once);
+        _backgroundJobClientMock.Verify(x => x.Create(
+            It.Is<Job>(job =>
+                job.Type == typeof(IEventBus) &&
+                job.Method.Name == nameof(IEventBus.Publish) &&
+                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationDelivered),
+            It.IsAny<IState>()), Times.Never);
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CheckNotificationDeliveryHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CheckNotificationDeliveryHandlerTests.cs
@@ -10,6 +10,7 @@ using Hangfire.Common;
 using Hangfire.States;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Text.Json;
 
 namespace Altinn.Correspondence.Tests.TestingHandler;
 
@@ -41,15 +42,12 @@ public class CheckNotificationDeliveryHandlerTests
     [Fact]
     public async Task Process_WhenNotificationNotFound_ReturnsError()
     {
-        // Arrange
         var notificationId = Guid.NewGuid();
         _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((CorrespondenceNotificationEntity?)null);
 
-        // Act
         var result = await _handler.Process(notificationId, CancellationToken.None);
 
-        // Assert
         Assert.True(result.IsT1);
         Assert.Equal(3020, result.AsT1.ErrorCode);
     }
@@ -57,29 +55,11 @@ public class CheckNotificationDeliveryHandlerTests
     [Fact]
     public async Task Process_WhenCorrespondenceNotFound_ReturnsError()
     {
-        // Arrange
-        var notificationId = Guid.NewGuid();
-        var correspondenceId = Guid.NewGuid();
-        var notification = new CorrespondenceNotificationEntity
-        {
-            Id = notificationId,
-            CorrespondenceId = correspondenceId,
-            NotificationOrderId = Guid.NewGuid(),
-            NotificationChannel = NotificationChannel.Email,
-            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
-            Created = DateTimeOffset.UtcNow,
-            RequestedSendTime = DateTimeOffset.UtcNow
-        };
+        var (notification, _, shipmentId) = BuildScenario();
+        SetupMocks(notification, correspondence: null, shipmentId);
 
-        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notification);
-        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
-            .ReturnsAsync((CorrespondenceEntity?)null);
+        var result = await _handler.Process(notification.Id, CancellationToken.None);
 
-        // Act
-        var result = await _handler.Process(notificationId, CancellationToken.None);
-
-        // Assert
         Assert.True(result.IsT1);
         Assert.Equal(1001, result.AsT1.ErrorCode);
     }
@@ -87,42 +67,11 @@ public class CheckNotificationDeliveryHandlerTests
     [Fact]
     public async Task Process_WhenNotificationAlreadyMarkedAsSent_ReturnsTrue()
     {
-        // Arrange
-        var notificationId = Guid.NewGuid();
-        var correspondenceId = Guid.NewGuid();
-        var notification = new CorrespondenceNotificationEntity
-        {
-            Id = notificationId,
-            CorrespondenceId = correspondenceId,
-            NotificationOrderId = Guid.NewGuid(),
-            NotificationChannel = NotificationChannel.Email,
-            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
-            Created = DateTimeOffset.UtcNow,
-            RequestedSendTime = DateTimeOffset.UtcNow,
-            NotificationSent = DateTimeOffset.UtcNow.AddMinutes(-5)
-        };
+        var (notification, correspondence, shipmentId) = BuildScenario(notificationSent: DateTimeOffset.UtcNow.AddMinutes(-5));
+        SetupMocks(notification, correspondence, shipmentId);
 
-        var correspondence = new CorrespondenceEntity
-        {
-            Id = correspondenceId,
-            Recipient = "12345678901",
-            Sender = "test_sender",
-            ResourceId = "test_resource",
-            SendersReference = "test_reference",
-            RequestedPublishTime = DateTimeOffset.UtcNow,
-            Statuses = new List<CorrespondenceStatusEntity>(),
-            Created = DateTimeOffset.UtcNow
-        };
+        var result = await _handler.Process(notification.Id, CancellationToken.None);
 
-        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notification);
-        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
-            .ReturnsAsync(correspondence);
-
-        // Act
-        var result = await _handler.Process(notificationId, CancellationToken.None);
-
-        // Assert
         Assert.True(result.IsT0);
         Assert.True(result.AsT0);
     }
@@ -130,140 +79,32 @@ public class CheckNotificationDeliveryHandlerTests
     [Fact]
     public async Task Process_WhenV2NotificationDelivered_CreatesActivityAndMarksAsSent()
     {
-        // Arrange
-        var notificationId = Guid.NewGuid();
-        var correspondenceId = Guid.NewGuid();
-        var shipmentId = Guid.NewGuid();
-        var notification = new CorrespondenceNotificationEntity
-        {
-            Id = notificationId,
-            CorrespondenceId = correspondenceId,
-            ShipmentId = shipmentId,
-            NotificationChannel = NotificationChannel.Email,
-            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
-            Created = DateTimeOffset.UtcNow,
-            RequestedSendTime = DateTimeOffset.UtcNow
-        };
+        var (notification, correspondence, shipmentId) = BuildScenario();
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId));
 
-        var correspondence = new CorrespondenceEntity
-        {
-            Id = correspondenceId,
-            Recipient = "12345678901",
-            Sender = "test_sender",
-            ResourceId = "test_resource",
-            SendersReference = "test_reference",
-            RequestedPublishTime = DateTimeOffset.UtcNow,
-            Statuses = new List<CorrespondenceStatusEntity>(),
-            Created = DateTimeOffset.UtcNow
-        };
+        var result = await _handler.Process(notification.Id, CancellationToken.None);
 
-        var notificationDetailsV2 = new NotificationStatusResponseV2
-        {
-            Status = "Order_Completed",
-            ShipmentId = shipmentId,
-            Recipients = new List<RecipientStatus>
-            {
-                new()
-                {
-                    Type = NotificationType.Email,
-                    Destination = "test@example.com",
-                    Status = NotificationStatusV2.Email_Delivered,
-                    LastUpdate = DateTimeOffset.UtcNow
-                }
-            }
-        };
-
-        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notification);
-        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
-            .ReturnsAsync(correspondence);
-        _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notificationDetailsV2);
-
-        // Act
-        var result = await _handler.Process(notificationId, CancellationToken.None);
-
-        // Assert
         Assert.True(result.IsT0);
         Assert.True(result.AsT0);
-
         _notificationRepositoryMock.Verify(x => x.UpdateNotificationSent(
-            notificationId,
-            It.IsAny<DateTimeOffset>(),
-            "test@example.com",
-            It.IsAny<CancellationToken>()), Times.Once);
-
+            notification.Id, It.IsAny<DateTimeOffset>(), "test@example.com", It.IsAny<CancellationToken>()), Times.Once);
         _backgroundJobClientMock.Verify(x => x.Create(
-            It.Is<Job>(job =>
-                job.Type == typeof(IDialogportenService) &&
-                job.Method.Name == nameof(IDialogportenService.CreateInformationActivity)),
+            It.Is<Job>(job => job.Type == typeof(IDialogportenService) && job.Method.Name == nameof(IDialogportenService.CreateInformationActivity)),
             It.Is<IState>(state => state is EnqueuedState)), Times.Once);
     }
 
     [Fact]
     public async Task Process_WhenNotificationNotDelivered_ThrowsException()
     {
-        // Arrange
-        var notificationId = Guid.NewGuid();
-        var correspondenceId = Guid.NewGuid();
-        var shipmentId = Guid.NewGuid();
-        var notification = new CorrespondenceNotificationEntity
-        {
-            Id = notificationId,
-            CorrespondenceId = correspondenceId,
-            ShipmentId = shipmentId,
-            NotificationChannel = NotificationChannel.Email,
-            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
-            Created = DateTimeOffset.UtcNow,
-            RequestedSendTime = DateTimeOffset.UtcNow
-        };
-        var correspondence = new CorrespondenceEntity
-        {
-            Id = correspondenceId,
-            Recipient = "12345678901",
-            Sender = "test_sender",
-            ResourceId = "test_resource",
-            SendersReference = "test_reference",
-            RequestedPublishTime = DateTimeOffset.UtcNow,
-            Statuses = new List<CorrespondenceStatusEntity>(),
-            Created = DateTimeOffset.UtcNow
-        };
-        var notificationDetailsV2 = new NotificationStatusResponseV2
-        {
-            Status = "Order_Processing",
-            ShipmentId = shipmentId,
-            Recipients = new List<RecipientStatus>
-        {
-            new()
-            {
-                Type = NotificationType.Email,
-                Destination = "test@example.com",
-                Status = NotificationStatusV2.Email_New,
-                LastUpdate = DateTimeOffset.UtcNow
-            }
-        }
-        };
-        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notification);
-        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
-            .ReturnsAsync(correspondence);
-        _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notificationDetailsV2);
+        var (notification, correspondence, shipmentId) = BuildScenario();
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_New, orderStatus: "Order_Processing"));
 
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _handler.Process(notificationId, CancellationToken.None)
-        );
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Process(notification.Id, CancellationToken.None));
 
         _notificationRepositoryMock.Verify(x => x.UpdateNotificationSent(
-            It.IsAny<Guid>(),
-            It.IsAny<DateTimeOffset>(),
-            It.IsAny<string>(),
-            It.IsAny<CancellationToken>()), Times.Never);
+            It.IsAny<Guid>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         _backgroundJobClientMock.Verify(x => x.Create(
-            It.Is<Job>(job =>
-                job.Type == typeof(IDialogportenService) &&
-                job.Method.Name == nameof(IDialogportenService.CreateInformationActivity)),
+            It.Is<Job>(job => job.Type == typeof(IDialogportenService) && job.Method.Name == nameof(IDialogportenService.CreateInformationActivity)),
             It.IsAny<IState>()), Times.Never);
     }
 
@@ -276,262 +117,189 @@ public class CheckNotificationDeliveryHandlerTests
     [InlineData(NotificationStatusV2.SMS_Failed_RecipientNotIdentified)]
     public async Task Process_WhenAllNotificationsFail_CreatesAllFailedEvent(NotificationStatusV2 recipientStatus)
     {
-        // Arrange
-        var notificationId = Guid.NewGuid();
-        var correspondenceId = Guid.NewGuid();
-        var shipmentId = Guid.NewGuid();
-        var notification = new CorrespondenceNotificationEntity
-        {
-            Id = notificationId,
-            CorrespondenceId = correspondenceId,
-            ShipmentId = shipmentId,
-            NotificationChannel = NotificationChannel.Email,
-            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
-            Created = DateTimeOffset.UtcNow,
-            RequestedSendTime = DateTimeOffset.UtcNow
-        };
-        var correspondence = new CorrespondenceEntity
-        {
-            Id = correspondenceId,
-            Recipient = "12345678901",
-            Sender = "test_sender",
-            ResourceId = "test_resource",
-            SendersReference = "test_reference",
-            RequestedPublishTime = DateTimeOffset.UtcNow,
-            Statuses = new List<CorrespondenceStatusEntity>(),
-            Created = DateTimeOffset.UtcNow
-        };
-        var notificationDetailsV2 = new NotificationStatusResponseV2
-        {
-            Status = "Order_Completed",
-            ShipmentId = shipmentId,
-            Recipients = new List<RecipientStatus>
-            {
-                new()
-                {
-                    Type = recipientStatus >= NotificationStatusV2.SMS_New && recipientStatus < NotificationStatusV2.Unknown
-                        ? NotificationType.SMS
-                        : NotificationType.Email,
-                    Destination = "test@example.com",
-                    Status = recipientStatus,
-                    LastUpdate = DateTimeOffset.UtcNow
-                }
-            }
-        };
-        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notification);
-        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
-            .ReturnsAsync(correspondence);
-        _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notificationDetailsV2);
+        var (notification, correspondence, shipmentId) = BuildScenario();
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, recipientStatus));
 
-        // Act
-        var result = await _handler.Process(notificationId, CancellationToken.None);
+        var result = await _handler.Process(notification.Id, CancellationToken.None);
 
-        // Assert
         Assert.True(result.IsT0);
-
         _notificationRepositoryMock.Verify(x => x.UpdateNotificationSent(
-            It.IsAny<Guid>(),
-            It.IsAny<DateTimeOffset>(),
-            It.IsAny<string>(),
-            It.IsAny<CancellationToken>()), Times.Never);
-        _backgroundJobClientMock.Verify(x => x.Create(
-            It.Is<Job>(job =>
-                job.Type == typeof(IEventBus) &&
-                job.Method.Name == nameof(IEventBus.Publish) &&
-                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationAllFailed &&
-                (string)job.Args[1] == correspondence.ResourceId &&
-                (string)job.Args[2] == correspondence.Id.ToString() &&
-                (string)job.Args[3] == "correspondence" &&
-                (string)job.Args[4] == correspondence.Sender),
-            It.Is<IState>(state => state is EnqueuedState)), Times.Once);
-        _backgroundJobClientMock.Verify(x => x.Create(
-            It.Is<Job>(job =>
-                job.Type == typeof(IEventBus) &&
-                job.Method.Name == nameof(IEventBus.Publish) &&
-                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationFailed),
-            It.IsAny<IState>()), Times.Never);
+            It.IsAny<Guid>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationAllFailed, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationFailed, Times.Never());
     }
 
     [Fact]
     public async Task Process_WhenSomeRecipientsFail_CreatesPartialFailedEvent()
     {
-        // Arrange
-        var notificationId = Guid.NewGuid();
-        var correspondenceId = Guid.NewGuid();
-        var shipmentId = Guid.NewGuid();
-        var notification = new CorrespondenceNotificationEntity
-        {
-            Id = notificationId,
-            CorrespondenceId = correspondenceId,
-            ShipmentId = shipmentId,
-            NotificationChannel = NotificationChannel.Email,
-            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
-            Created = DateTimeOffset.UtcNow,
-            RequestedSendTime = DateTimeOffset.UtcNow
-        };
-        var correspondence = new CorrespondenceEntity
-        {
-            Id = correspondenceId,
-            Recipient = "12345678901",
-            Sender = "test_sender",
-            ResourceId = "test_resource",
-            SendersReference = "test_reference",
-            RequestedPublishTime = DateTimeOffset.UtcNow,
-            Statuses = new List<CorrespondenceStatusEntity>(),
-            Created = DateTimeOffset.UtcNow
-        };
-        var notificationDetailsV2 = new NotificationStatusResponseV2
-        {
-            Status = "Order_Completed",
-            ShipmentId = shipmentId,
-            Recipients = new List<RecipientStatus>
-            {
-                new()
-                {
-                    Type = NotificationType.Email,
-                    Destination = "delivered@example.com",
-                    Status = NotificationStatusV2.Email_Delivered,
-                    LastUpdate = DateTimeOffset.UtcNow
-                },
-                new()
-                {
-                    Type = NotificationType.Email,
-                    Destination = "failed@example.com",
-                    Status = NotificationStatusV2.Email_Failed,
-                    LastUpdate = DateTimeOffset.UtcNow
-                }
-            }
-        };
-        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notification);
-        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
-            .ReturnsAsync(correspondence);
-        _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notificationDetailsV2);
+        var (notification, correspondence, shipmentId) = BuildScenario();
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, partialFail: true));
 
-        // Act
-        var result = await _handler.Process(notificationId, CancellationToken.None);
+        var result = await _handler.Process(notification.Id, CancellationToken.None);
 
-        // Assert
         Assert.True(result.IsT0);
-
-        _backgroundJobClientMock.Verify(x => x.Create(
-            It.Is<Job>(job =>
-                job.Type == typeof(IEventBus) &&
-                job.Method.Name == nameof(IEventBus.Publish) &&
-                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationFailed &&
-                (string)job.Args[1] == correspondence.ResourceId &&
-                (string)job.Args[2] == correspondence.Id.ToString() &&
-                (string)job.Args[3] == "correspondence" &&
-                (string)job.Args[4] == correspondence.Sender),
-            It.Is<IState>(state => state is EnqueuedState)), Times.Once);
-        _backgroundJobClientMock.Verify(x => x.Create(
-            It.Is<Job>(job =>
-                job.Type == typeof(IEventBus) &&
-                job.Method.Name == nameof(IEventBus.Publish) &&
-                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationAllFailed),
-            It.IsAny<IState>()), Times.Never);
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationFailed, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationAllFailed, Times.Never());
     }
 
     [Fact]
     public async Task Process_WhenMainNotificationSent_CreatesNotificationSentEvent()
     {
-        // Arrange
-        var notificationId = Guid.NewGuid();
-        var correspondenceId = Guid.NewGuid();
-        var shipmentId = Guid.NewGuid();
-        var notification = new CorrespondenceNotificationEntity
-        {
-            Id = notificationId,
-            CorrespondenceId = correspondenceId,
-            ShipmentId = shipmentId,
-            IsReminder = false,
-            NotificationChannel = NotificationChannel.Email,
-            NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
-            Created = DateTimeOffset.UtcNow,
-            RequestedSendTime = DateTimeOffset.UtcNow
-        };
-        var correspondence = new CorrespondenceEntity
-        {
-            Id = correspondenceId,
-            Recipient = "12345678901",
-            Sender = "test_sender",
-            ResourceId = "test_resource",
-            SendersReference = "test_reference",
-            RequestedPublishTime = DateTimeOffset.UtcNow,
-            Statuses = new List<CorrespondenceStatusEntity>(),
-            Created = DateTimeOffset.UtcNow
-        };
-        var notificationDetailsV2 = new NotificationStatusResponseV2
-        {
-            Status = "Order_Completed",
-            ShipmentId = shipmentId,
-            Recipients = new List<RecipientStatus>
-            {
-                new()
-                {
-                    Type = NotificationType.Email,
-                    Destination = "test@example.com",
-                    Status = NotificationStatusV2.Email_Delivered,
-                    LastUpdate = DateTimeOffset.UtcNow
-                }
-            }
-        };
-        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notification);
-        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
-            .ReturnsAsync(correspondence);
-        _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notificationDetailsV2);
+        var (notification, correspondence, shipmentId) = BuildScenario();
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId));
 
-        // Act
-        var result = await _handler.Process(notificationId, CancellationToken.None);
+        var result = await _handler.Process(notification.Id, CancellationToken.None);
 
-        // Assert
         Assert.True(result.IsT0);
-
-        _backgroundJobClientMock.Verify(x => x.Create(
-            It.Is<Job>(job =>
-                job.Type == typeof(IEventBus) &&
-                job.Method.Name == nameof(IEventBus.Publish) &&
-                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationDelivered &&
-                (string)job.Args[1] == correspondence.ResourceId &&
-                (string)job.Args[2] == correspondence.Id.ToString() &&
-                (string)job.Args[3] == "correspondence" &&
-                (string)job.Args[4] == correspondence.Sender),
-            It.Is<IState>(state => state is EnqueuedState)), Times.Once);
-        _backgroundJobClientMock.Verify(x => x.Create(
-            It.Is<Job>(job =>
-                job.Type == typeof(IEventBus) &&
-                job.Method.Name == nameof(IEventBus.Publish) &&
-                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationReminderDelivered),
-            It.IsAny<IState>()), Times.Never);
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationDelivered, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationReminderDelivered, Times.Never());
     }
 
     [Fact]
     public async Task Process_WhenReminderNotificationSent_CreatesReminderSentEvent()
     {
-        // Arrange
-        var notificationId = Guid.NewGuid();
+        var (notification, correspondence, shipmentId) = BuildScenario(isReminder: true);
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId));
+
+        var result = await _handler.Process(notification.Id, CancellationToken.None);
+
+        Assert.True(result.IsT0);
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationReminderDelivered, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationDelivered, Times.Never());
+    }
+
+    [Fact]
+    public async Task Process_WhenMainOrgOrderAllFail_CreatesAllFailedEvent()
+    {
+        var (notification, correspondence, shipmentId) = BuildScenario(
+            correspondenceRecipient: "urn:altinn:organization:identifier-no:123456789",
+            orderRecipient: new RecipientV2
+            {
+                RecipientOrganization = new RecipientOrganization { OrgNumber = "123456789", ResourceId = "r", ChannelSchema = NotificationChannel.Email }
+            });
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_Failed));
+
+        await _handler.Process(notification.Id, CancellationToken.None);
+
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationAllFailed, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationFailed, Times.Never());
+    }
+
+    [Fact]
+    public async Task Process_WhenMainPersonOrderAllFail_CreatesAllFailedEvent()
+    {
+        var (notification, correspondence, shipmentId) = BuildScenario(
+            correspondenceRecipient: "urn:altinn:person:identifier-no:12345678901",
+            orderRecipient: new RecipientV2
+            {
+                RecipientPerson = new RecipientPerson { NationalIdentityNumber = "12345678901", ResourceId = "r", ChannelSchema = NotificationChannel.Email }
+            });
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_Failed));
+
+        await _handler.Process(notification.Id, CancellationToken.None);
+
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationAllFailed, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationFailed, Times.Never());
+    }
+
+    [Theory]
+    [InlineData("urn:altinn:person:idporten-email:test@example.com")]
+    [InlineData("urn:altinn:person:legacy-selfidentified:testuser")]
+    public async Task Process_WhenMainExternalIdentityOrderAllFail_CreatesAllFailedEvent(string correspondenceRecipient)
+    {
+        var (notification, correspondence, shipmentId) = BuildScenario(
+            correspondenceRecipient: correspondenceRecipient,
+            orderRecipient: new RecipientV2
+            {
+                RecipientExternalIdentity = new RecipientExternalIdentity { ExternalIdentity = correspondenceRecipient, ResourceId = "r", ChannelSchema = NotificationChannel.Email }
+            });
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_Failed));
+
+        await _handler.Process(notification.Id, CancellationToken.None);
+
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationAllFailed, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationFailed, Times.Never());
+    }
+
+    [Fact]
+    public async Task Process_WhenCustomOrgRecipientOrderAllFail_CreatesFailedNotAllFailedEvent()
+    {
+        var (notification, correspondence, shipmentId) = BuildScenario(
+            correspondenceRecipient: "urn:altinn:organization:identifier-no:123456789",
+            orderRecipient: new RecipientV2
+            {
+                RecipientOrganization = new RecipientOrganization { OrgNumber = "987654321", ResourceId = "r", ChannelSchema = NotificationChannel.Email }
+            });
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_Failed));
+
+        await _handler.Process(notification.Id, CancellationToken.None);
+
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationFailed, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationAllFailed, Times.Never());
+    }
+
+    [Fact]
+    public async Task Process_WhenCustomEmailRecipientOrderAllFail_CreatesFailedNotAllFailedEvent()
+    {
+        var (notification, correspondence, shipmentId) = BuildScenario(
+            correspondenceRecipient: "urn:altinn:organization:identifier-no:123456789",
+            orderRecipient: new RecipientV2
+            {
+                RecipientEmail = new RecipientEmail { EmailAddress = "custom@example.com" }
+            });
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_Failed));
+
+        await _handler.Process(notification.Id, CancellationToken.None);
+
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationFailed, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationAllFailed, Times.Never());
+    }
+
+    [Fact]
+    public async Task Process_WhenNullOrderRequestAllFail_CreatesAllFailedEvent()
+    {
+        var (notification, correspondence, shipmentId) = BuildScenario(
+            correspondenceRecipient: "urn:altinn:organization:identifier-no:123456789",
+            orderRecipient: null);
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_Failed));
+
+        await _handler.Process(notification.Id, CancellationToken.None);
+
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationAllFailed, Times.Once());
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationFailed, Times.Never());
+    }
+
+    private static (CorrespondenceNotificationEntity notification, CorrespondenceEntity correspondence, Guid shipmentId) BuildScenario(
+        string correspondenceRecipient = "urn:altinn:person:identifier-no:12345678901",
+        RecipientV2? orderRecipient = null,
+        bool isReminder = false,
+        DateTimeOffset? notificationSent = null)
+    {
         var correspondenceId = Guid.NewGuid();
         var shipmentId = Guid.NewGuid();
         var notification = new CorrespondenceNotificationEntity
         {
-            Id = notificationId,
+            Id = Guid.NewGuid(),
             CorrespondenceId = correspondenceId,
             ShipmentId = shipmentId,
-            IsReminder = true,
+            IsReminder = isReminder,
             NotificationChannel = NotificationChannel.Email,
             NotificationTemplate = NotificationTemplate.GenericAltinnMessage,
             Created = DateTimeOffset.UtcNow,
-            RequestedSendTime = DateTimeOffset.UtcNow
+            RequestedSendTime = DateTimeOffset.UtcNow,
+            NotificationSent = notificationSent,
+            OrderRequest = orderRecipient == null ? null : JsonSerializer.Serialize(new NotificationOrderRequestV2
+            {
+                IdempotencyId = Guid.NewGuid(),
+                SendersReference = "test",
+                RequestedSendTime = DateTime.UtcNow,
+                Recipient = orderRecipient
+            })
         };
         var correspondence = new CorrespondenceEntity
         {
             Id = correspondenceId,
-            Recipient = "12345678901",
+            Recipient = correspondenceRecipient,
             Sender = "test_sender",
             ResourceId = "test_resource",
             SendersReference = "test_reference",
@@ -539,49 +307,55 @@ public class CheckNotificationDeliveryHandlerTests
             Statuses = new List<CorrespondenceStatusEntity>(),
             Created = DateTimeOffset.UtcNow
         };
-        var notificationDetailsV2 = new NotificationStatusResponseV2
-        {
-            Status = "Order_Completed",
-            ShipmentId = shipmentId,
-            Recipients = new List<RecipientStatus>
-            {
-                new()
-                {
-                    Type = NotificationType.Email,
-                    Destination = "test@example.com",
-                    Status = NotificationStatusV2.Email_Delivered,
-                    LastUpdate = DateTimeOffset.UtcNow
-                }
-            }
-        };
-        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notificationId, It.IsAny<CancellationToken>()))
+        return (notification, correspondence, shipmentId);
+    }
+
+    private void SetupMocks(
+        CorrespondenceNotificationEntity notification,
+        CorrespondenceEntity? correspondence,
+        Guid shipmentId,
+        NotificationStatusResponseV2? notificationStatus = null)
+    {
+        _notificationRepositoryMock.Setup(x => x.GetNotificationById(notification.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(notification);
-        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(notification.CorrespondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
             .ReturnsAsync(correspondence);
-        _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(notificationDetailsV2);
+        if (notificationStatus != null)
+        {
+            _notificationServiceMock.Setup(x => x.GetNotificationDetailsV2(shipmentId.ToString(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(notificationStatus);
+        }
+    }
 
-        // Act
-        var result = await _handler.Process(notificationId, CancellationToken.None);
+    private static NotificationStatusResponseV2 BuildStatus(
+        Guid shipmentId,
+        NotificationStatusV2 recipientStatus = NotificationStatusV2.Email_Delivered,
+        string orderStatus = "Order_Completed",
+        bool partialFail = false)
+    {
+        var type = recipientStatus >= NotificationStatusV2.SMS_New && recipientStatus < NotificationStatusV2.Unknown
+            ? NotificationType.SMS
+            : NotificationType.Email;
+        var recipients = partialFail
+            ? (List<RecipientStatus>)
+            [
+                new() { Type = NotificationType.Email, Destination = "delivered@example.com", Status = NotificationStatusV2.Email_Delivered, LastUpdate = DateTimeOffset.UtcNow },
+                new() { Type = NotificationType.Email, Destination = "failed@example.com", Status = NotificationStatusV2.Email_Failed, LastUpdate = DateTimeOffset.UtcNow }
+            ]
+            :
+            [
+                new() { Type = type, Destination = "test@example.com", Status = recipientStatus, LastUpdate = DateTimeOffset.UtcNow }
+            ];
+        return new NotificationStatusResponseV2 { Status = orderStatus, ShipmentId = shipmentId, Recipients = recipients };
+    }
 
-        // Assert
-        Assert.True(result.IsT0);
-
+    private void VerifyEventPublished(AltinnEventType eventType, Times times)
+    {
         _backgroundJobClientMock.Verify(x => x.Create(
             It.Is<Job>(job =>
                 job.Type == typeof(IEventBus) &&
                 job.Method.Name == nameof(IEventBus.Publish) &&
-                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationReminderDelivered &&
-                (string)job.Args[1] == correspondence.ResourceId &&
-                (string)job.Args[2] == correspondence.Id.ToString() &&
-                (string)job.Args[3] == "correspondence" &&
-                (string)job.Args[4] == correspondence.Sender),
-            It.Is<IState>(state => state is EnqueuedState)), Times.Once);
-        _backgroundJobClientMock.Verify(x => x.Create(
-            It.Is<Job>(job =>
-                job.Type == typeof(IEventBus) &&
-                job.Method.Name == nameof(IEventBus.Publish) &&
-                (AltinnEventType)job.Args[0] == AltinnEventType.CorrespondenceNotificationDelivered),
-            It.IsAny<IState>()), Times.Never);
+                (AltinnEventType)job.Args[0] == eventType),
+            It.Is<IState>(state => state is EnqueuedState)), times);
     }
 }

--- a/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
+++ b/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
@@ -1,10 +1,14 @@
 using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Common.Helpers;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Notifications;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
 using Hangfire;
 using Microsoft.Extensions.Logging;
 using OneOf;
+using System.Text.Json;
 
 namespace Altinn.Correspondence.Application.CheckNotificationDelivery;
 
@@ -88,12 +92,13 @@ public class CheckNotificationDeliveryHandler(
                 
                 var hasFailedStatus = notificationDetailsV2.Recipients.Any(r => r.Status.IsFailed());
                 var allFailed = hasFailedStatus && notificationDetailsV2.Recipients.All(r => r.Status.IsFailed());
+                var isMainOrder = IsMainOrder(notification, correspondence.Recipient);
                 if (hasFailedStatus)
-                {
-                    logger.LogError("Notification {NotificationId} has failed status (allFailed: {AllFailed})", notificationId, allFailed);
+                { 
+                    logger.LogError("Notification {NotificationId} has failed status (allFailed: {AllFailed}, isMainOrder: {IsMainOrder})", notificationId, allFailed, isMainOrder);
                     if (publishFailedEvent)
                     {
-                        if (allFailed)
+                        if (allFailed && isMainOrder)
                         {
                             SendAllFailedEvent(correspondence.ResourceId, correspondence.Id.ToString(), correspondence.Sender);
                         }
@@ -187,6 +192,19 @@ public class CheckNotificationDeliveryHandler(
                 logger.LogError(ex, "Error checking delivery status for notification {NotificationId}", notificationId);
                 throw;
         }
+    }
+
+    private static bool IsMainOrder(CorrespondenceNotificationEntity notification, string correspondenceRecipient)
+    {
+        if (notification.OrderRequest == null) return true;
+        var order = JsonSerializer.Deserialize<NotificationOrderRequestV2>(notification.OrderRequest);
+        if (order == null) return true;
+        var recipientWithoutPrefix = correspondenceRecipient.WithoutPrefix();
+        var r = order.Recipient;
+        if (r.RecipientOrganization != null) return r.RecipientOrganization.OrgNumber == recipientWithoutPrefix;
+        if (r.RecipientPerson != null) return r.RecipientPerson.NationalIdentityNumber == recipientWithoutPrefix;
+        if (r.RecipientExternalIdentity != null) return r.RecipientExternalIdentity.ExternalIdentity == correspondenceRecipient;
+        return false;
     }
 
     private void SendFailedEvent(string resourceId, string correspondenceId, string sender)

--- a/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
+++ b/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
@@ -87,20 +87,29 @@ public class CheckNotificationDeliveryHandler(
             {
                 
                 var hasFailedStatus = notificationDetailsV2.Recipients.Any(r => r.Status.IsFailed());
+                var allFailed = hasFailedStatus && notificationDetailsV2.Recipients.All(r => r.Status.IsFailed());
                 if (hasFailedStatus)
                 {
-                    logger.LogError("Notification {NotificationId} has failed status", notificationId);
+                    logger.LogError("Notification {NotificationId} has failed status (allFailed: {AllFailed})", notificationId, allFailed);
                     if (publishFailedEvent)
                     {
-                        SendFailedEvent(correspondence.ResourceId, correspondence.Id.ToString(), correspondence.Sender);
+                        if (allFailed)
+                        {
+                            SendAllFailedEvent(correspondence.ResourceId, correspondence.Id.ToString(), correspondence.Sender);
+                        }
+                        else
+                        {
+                            SendFailedEvent(correspondence.ResourceId, correspondence.Id.ToString(), correspondence.Sender);
+                        }
                     }
                     else
                     {
-                        logger.LogInformation("Skipping CorrespondenceNotificationFailed event publishing for notification {NotificationId}", notificationId);
+                        logger.LogInformation("Skipping notification failed event publishing for notification {NotificationId}", notificationId);
                     }
-                } else
+                }
+                else
                 {
-                    logger.LogInformation("Notification {NotificationId} has status {Status}", notificationId, notificationDetailsV2.Status);   
+                    logger.LogInformation("Notification {NotificationId} has status {Status}", notificationId, notificationDetailsV2.Status);
                 }
             
 
@@ -141,8 +150,8 @@ public class CheckNotificationDeliveryHandler(
                             }
 
                             var sentEventType = notification.IsReminder
-                                ? AltinnEventType.CorrespondenceNotificationReminderSent
-                                : AltinnEventType.CorrespondenceNotificationSent;
+                                ? AltinnEventType.CorrespondenceNotificationReminderDelivered
+                                : AltinnEventType.CorrespondenceNotificationDelivered;
                             backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(
                                 sentEventType, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, CancellationToken.None));
 
@@ -180,9 +189,15 @@ public class CheckNotificationDeliveryHandler(
         }
     }
 
-    private void SendFailedEvent(string resourceId, string correspondenceId, string sender) 
+    private void SendFailedEvent(string resourceId, string correspondenceId, string sender)
     {
         logger.LogInformation("Enqueuing CorrespondenceNotificationFailed event for correspondence {CorrespondenceId}", correspondenceId);
         backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.CorrespondenceNotificationFailed, resourceId, correspondenceId, "correspondence", sender, CancellationToken.None));
+    }
+
+    private void SendAllFailedEvent(string resourceId, string correspondenceId, string sender)
+    {
+        logger.LogInformation("Enqueuing CorrespondenceNotificationAllFailed event for correspondence {CorrespondenceId}", correspondenceId);
+        backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.CorrespondenceNotificationAllFailed, resourceId, correspondenceId, "correspondence", sender, CancellationToken.None));
     }
 }

--- a/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
+++ b/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
@@ -130,16 +130,22 @@ public class CheckNotificationDeliveryHandler(
 
                             foreach (var recipient in sentRecipients)
                             {
-                                
-                            backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) => 
-                            dialogportenService.CreateInformationActivity(
-                                correspondence.Id,
-                                DialogportenActorType.ServiceOwner, 
-                                textType,
-                                recipient.LastUpdate,
-                                recipient.Destination,
-                                recipient.Type.ToString()));
+                                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) =>
+                                dialogportenService.CreateInformationActivity(
+                                    correspondence.Id,
+                                    DialogportenActorType.ServiceOwner,
+                                    textType,
+                                    recipient.LastUpdate,
+                                    recipient.Destination,
+                                    recipient.Type.ToString()));
                             }
+
+                            var sentEventType = notification.IsReminder
+                                ? AltinnEventType.CorrespondenceNotificationReminderSent
+                                : AltinnEventType.CorrespondenceNotificationSent;
+                            backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(
+                                sentEventType, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, CancellationToken.None));
+
                             logger.LogInformation("Successfully processed sent notification {NotificationId} and created activities", notificationId);
                             return true;
                         }, cancellationToken);

--- a/src/Altinn.Correspondence.Core/Services/Enums/AltinnEventType.cs
+++ b/src/Altinn.Correspondence.Core/Services/Enums/AltinnEventType.cs
@@ -25,6 +25,7 @@ public enum AltinnEventType
     NotificationCreated,
     CorrespondenceNotificationCreationFailed,
     CorrespondenceNotificationFailed,
-    CorrespondenceNotificationSent,
-    CorrespondenceNotificationReminderSent
+    CorrespondenceNotificationAllFailed,
+    CorrespondenceNotificationDelivered,
+    CorrespondenceNotificationReminderDelivered
 }

--- a/src/Altinn.Correspondence.Core/Services/Enums/AltinnEventType.cs
+++ b/src/Altinn.Correspondence.Core/Services/Enums/AltinnEventType.cs
@@ -24,5 +24,7 @@ public enum AltinnEventType
     CorrespondenceReceiverNeverRead,
     NotificationCreated,
     CorrespondenceNotificationCreationFailed,
-    CorrespondenceNotificationFailed
+    CorrespondenceNotificationFailed,
+    CorrespondenceNotificationSent,
+    CorrespondenceNotificationReminderSent
 }

--- a/src/Altinn.Correspondence.Integrations/Altinn/Events/AltinnEventBus.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Events/AltinnEventBus.cs
@@ -43,7 +43,7 @@ public class AltinnEventBus : IEventBus
 
     private CloudEvent CreateCloudEvent(AltinnEventType type, string resourceId, string itemId, string party, string eventSource)
     {
-        var alternativeSubjectFormated = handleAlternativeSubject(party);
+        var alternativeSubjectFormated = handleAlternativeSubject(party.WithoutPrefix());
         CloudEvent cloudEvent = new CloudEvent()
         {
             Id = Guid.NewGuid(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds 3 new correspondence notification events `CorrespondenceNotificationAllFailed`, `CorrespondenceNotificationDelivered` and `CorrespondenceNotificationReminderDelivered`.  `CorrespondenceNotificationAllFailed` is sent when all notifications in the main correspondence notfication order failed. 
If the main notification all fail but custom recipients succeed, the 'CorrespondenceNotificationAllFailed' is still sendt. The reasoning for this is that custom-recipient is an opt in extra and a service owner wants to be notified if the correspondence recipient did not receive any notification regardless of the extra custom notifications.

This PR also use without prefix when creating alternative subject in events to ensure alternative subject is included even if the party has a prefix.

## Related Issue(s)
- #1870 
- #1906 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failure handling now distinguishes complete vs partial notification delivery failures.
  * New event types added for "all failed", "delivered", and "reminder delivered" notifications.

* **Bug Fixes**
  * Notification processing now more reliably classifies and publishes the correct failure event for all-vs-partial recipient failures.

* **Tests**
  * Tests updated and added to verify all-failed vs partial-failed event publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->