### PR TITLE
Tiebreak for ReadyForPublish/Published

### DIFF
--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -38,7 +38,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
                 return query.Where(c => (c.ServiceOwnerId == orgNo || c.Sender.Contains(orgNo)) &&
                     status.HasValue ?
                     (!blacklistSender.Contains(status)) && c.Statuses.Any(statusEntity => statusEntity.Status == status) :
-                    (!blacklistSender.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status)));
+                    (!blacklistSender.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).ThenBy(cs => cs.Status).Last().Status)));
             }
 
             IQueryable<CorrespondenceEntity> FilterForRecipient()
@@ -46,7 +46,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
                 return query.Where(c => c.Recipient.Contains(orgNo) &&
                     status.HasValue ?
                     (!blacklistRecipient.Contains(status)) && c.Statuses.Any(statusEntity => statusEntity.Status == status) :
-                    (!blacklistRecipient.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).Last().Status)));
+                    (!blacklistRecipient.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).ThenBy(cs => cs.Status).Last().Status)));
             }
             return role switch
             {

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -38,7 +38,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
                 return query.Where(c => (c.ServiceOwnerId == orgNo || c.Sender.Contains(orgNo)) &&
                     status.HasValue ?
                     (!blacklistSender.Contains(status)) && c.Statuses.Any(statusEntity => statusEntity.Status == status) :
-                    (!blacklistSender.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).ThenBy(cs => cs.Status).Last().Status)));
+                    (!blacklistSender.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).ThenBy(cs => cs.Id).Last().Status)));
             }
 
             IQueryable<CorrespondenceEntity> FilterForRecipient()
@@ -46,7 +46,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
                 return query.Where(c => c.Recipient.Contains(orgNo) &&
                     status.HasValue ?
                     (!blacklistRecipient.Contains(status)) && c.Statuses.Any(statusEntity => statusEntity.Status == status) :
-                    (!blacklistRecipient.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).ThenBy(cs => cs.Status).Last().Status)));
+                    (!blacklistRecipient.Contains(c.Statuses.OrderBy(cs => cs.StatusChanged).ThenBy(cs => cs.Id).Last().Status)));
             }
             return role switch
             {


### PR DESCRIPTION
## Description
ReadyForPublish and Published may have the same timestamp now so tiebreak such that highest status is always used

## Related Issue(s)
- #1920 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status computation logic to use more deterministic ordering, ensuring consistent and reliable results when determining the current status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->