### PR TITLE
AT22 can be deployed when needed, not on every CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -72,36 +72,6 @@ jobs:
           MAINTENANCE_AD_GROUP_NAME: ${{ secrets.MAINTENANCE_AD_GROUP_NAME }}
           STATISTICS_API_KEY: ${{ secrets.STATISTICS_API_KEY }}
           GRAFANA_MONITORING_PRINCIPAL_ID: ${{ secrets.GRAFANA_MONITORING_PRINCIPAL_ID }}
-  deploy-at22:
-    name: deploy at22
-    runs-on: ubuntu-latest
-    environment: test
-    if: always() && !failure() && !cancelled() 
-    needs: [get-version, publish, test, deploy-test]
-    permissions: 
-      id-token: write
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Deploy to environment
-        uses: ./.github/actions/deploy-to-environment
-        with:
-          environment: at22
-          imageTag: ${{ needs.get-version.outputs.imageTag }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
-          AZURE_NAME_PREFIX: ${{ secrets.AZURE_NAME_PREFIX }}
-          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_TEST_ACCESS_CLIENT_ID: ${{ secrets.AZURE_TEST_ACCESS_CLIENT_ID }}
-          APIM_IP: ${{ secrets.APIM_IP }}
-          MAINTENANCE_AD_GROUP_ID: ${{ secrets.MAINTENANCE_AD_GROUP_ID }}
-          MAINTENANCE_AD_GROUP_NAME: ${{ secrets.MAINTENANCE_AD_GROUP_NAME }}
-          GRAFANA_MONITORING_PRINCIPAL_ID: ${{ secrets.GRAFANA_MONITORING_PRINCIPAL_ID }}
   deploy-staging:
     name: Internal staging
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
AT22 can be deployed when needed, not on every CI/CD

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the continuous integration and deployment pipeline infrastructure by removing an unused deployment environment from the automated release workflow. This change reduces pipeline configuration complexity and improves maintainability while preserving all critical deployment stages including publish and test pathways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->