### PR TITLE
fix: separate manual maskinporten rotation trigger

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingAPI/RecurringJobRegistrationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingAPI/RecurringJobRegistrationTests.cs
@@ -22,8 +22,7 @@ public class RecurringJobRegistrationTests
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                [$"{nameof(MaskinportenJwkRotationSettings)}:Enabled"] = "true",
-                [$"{nameof(MaskinportenJwkRotationSettings)}:CronExpression"] = "0 0 1 * *"
+                [$"{nameof(MaskinportenJwkRotationSettings)}:Enabled"] = "true"
             })
             .Build();
 
@@ -33,7 +32,7 @@ public class RecurringJobRegistrationTests
             invocation.Method.Name == nameof(IRecurringJobManager.AddOrUpdate)
             && invocation.Arguments.Count > 2
             && invocation.Arguments[0] as string == RecurringJobRegistration.MaskinportenJwkRotationJobId
-            && invocation.Arguments[2] as string == "0 0 1 * *");
+            && invocation.Arguments[2] as string == RecurringJobRegistration.MaskinportenJwkRotationCronExpression);
 
         Assert.Contains(recurringJobManager.Invocations, invocation =>
             invocation.Method.Name == nameof(IRecurringJobManager.AddOrUpdate)

--- a/Test/Altinn.Correspondence.Tests/TestingApplication/MaskinportenJwkRotationHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingApplication/MaskinportenJwkRotationHandlerTests.cs
@@ -74,7 +74,8 @@ public class MaskinportenJwkRotationHandlerTests
         await handler.ProcessScheduled(CancellationToken.None);
 
         rotationService.Verify(service => service.RotateAsync(It.IsAny<CancellationToken>()), Times.Once);
-        slackClient.Verify(client => client.PostAsync(It.IsAny<SlackMessage>()), Times.Once);
+        slackClient.Verify(client => client.PostAsync(It.Is<SlackMessage>(message =>
+            message.Text.StartsWith(":white_check_mark: *Maskinporten JWK rotation completed*"))), Times.Once);
     }
 
     private static MaskinportenJwkRotationHandler CreateHandler(

--- a/Test/Altinn.Correspondence.Tests/TestingApplication/MaskinportenJwkRotationHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingApplication/MaskinportenJwkRotationHandlerTests.cs
@@ -5,7 +5,6 @@ using Altinn.Correspondence.Core.Services;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
 using Slack.Webhooks;
 
@@ -81,8 +80,7 @@ public class MaskinportenJwkRotationHandlerTests
     private static MaskinportenJwkRotationHandler CreateHandler(
         IMaskinportenJwkRotationService rotationService,
         ISlackClient slackClient,
-        DateTimeOffset utcNow,
-        bool onlyRunOnFirstWeekdayOfMonth = true)
+        DateTimeOffset utcNow)
     {
         var slackHandler = new SendSlackNotificationHandler(
             slackClient,
@@ -91,10 +89,6 @@ public class MaskinportenJwkRotationHandlerTests
             NullLogger<SendSlackNotificationHandler>.Instance);
 
         return new MaskinportenJwkRotationHandler(
-            Options.Create(new MaskinportenJwkRotationSettings
-            {
-                OnlyRunOnFirstWeekdayOfMonth = onlyRunOnFirstWeekdayOfMonth
-            }),
             rotationService,
             slackHandler,
             new FixedTimeProvider(utcNow),

--- a/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
@@ -16,6 +16,7 @@ using Hangfire;
 using Altinn.Correspondence.Application.MigrateForwardingEventsBatch;
 using Altinn.Correspondence.Application.CleanupBulkFetchStatuses;
 using Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
+using Altinn.Correspondence.Application.MaskinportenJwkRotation;
 
 namespace Altinn.Correspondence.API.Controllers;
 
@@ -330,5 +331,46 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
         );
     }
 
+    [HttpPost]
+    [Route("maskinporten-jwk-rotation")]
+    [Authorize(Policy = AuthorizationConstants.Maintenance)]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public ActionResult TriggerMaskinportenJwkRotation(
+        [FromServices] IBackgroundJobClient backgroundJobClient,
+        [FromBody] TriggerMaskinportenJwkRotationRequest request)
+    {
+        const string expectedConfirmation = "rotate-maskinporten-jwk";
+        if (!string.Equals(request.Confirmation, expectedConfirmation, StringComparison.Ordinal))
+        {
+            return BadRequest(new
+            {
+                message = $"Confirmation must be '{expectedConfirmation}' to trigger Maskinporten JWK rotation."
+            });
+        }
+
+        var jobId = backgroundJobClient.Enqueue<MaskinportenJwkRotationHandler>(
+            handler => handler.Process(CancellationToken.None));
+
+        _logger.LogWarning(
+            "Manual Maskinporten JWK rotation job {JobId} was enqueued by {User}.",
+            jobId,
+            HttpContext.User.Identity?.Name ?? "unknown");
+
+        return Ok(new
+        {
+            jobId,
+            message = "Maskinporten JWK rotation was enqueued."
+        });
+    }
+
     private ActionResult Problem(Error error) => ProblemDetailsHelper.ToProblemResult(error);
+}
+
+public class TriggerMaskinportenJwkRotationRequest
+{
+    public string Confirmation { get; set; } = string.Empty;
 }

--- a/src/Altinn.Correspondence.API/Helpers/RecurringJobRegistration.cs
+++ b/src/Altinn.Correspondence.API/Helpers/RecurringJobRegistration.cs
@@ -10,6 +10,8 @@ namespace Altinn.Correspondence.API.Helpers;
 public static class RecurringJobRegistration
 {
     public const string MaskinportenJwkRotationJobId = "Rotate Maskinporten JWK and update Key Vault";
+    // The first weekday of a month can only fall on day 1, 2 or 3. The handler validates the exact date.
+    public const string MaskinportenJwkRotationCronExpression = "0 8 1-3 * *";
 
     public static void Register(IServiceProvider services, IConfiguration configuration, ILogger logger)
     {
@@ -43,8 +45,8 @@ public static class RecurringJobRegistration
         recurringJobManager.AddOrUpdate<MaskinportenJwkRotationHandler>(
             MaskinportenJwkRotationJobId,
             handler => handler.ProcessScheduled(CancellationToken.None),
-            settings.CronExpression);
+            MaskinportenJwkRotationCronExpression);
 
-        logger.LogInformation("Maskinporten JWK rotation job registered with cron {CronExpression}.", settings.CronExpression);
+        logger.LogInformation("Maskinporten JWK rotation job registered with cron {CronExpression}.", MaskinportenJwkRotationCronExpression);
     }
 }

--- a/src/Altinn.Correspondence.Application/MaskinportenJwkRotation/MaskinportenJwkRotationHandler.cs
+++ b/src/Altinn.Correspondence.Application/MaskinportenJwkRotation/MaskinportenJwkRotationHandler.cs
@@ -1,14 +1,11 @@
 using Altinn.Correspondence.Application.SendSlackNotification;
-using Altinn.Correspondence.Core.Options;
 using Altinn.Correspondence.Core.Services;
 using Hangfire;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Altinn.Correspondence.Application.MaskinportenJwkRotation;
 
 public class MaskinportenJwkRotationHandler(
-    IOptions<MaskinportenJwkRotationSettings> rotationOptions,
     IMaskinportenJwkRotationService rotationService,
     SendSlackNotificationHandler slackNotificationHandler,
     TimeProvider timeProvider,
@@ -18,10 +15,9 @@ public class MaskinportenJwkRotationHandler(
     [DisableConcurrentExecution(timeoutInSeconds: 1800)]
     public async Task ProcessScheduled(CancellationToken cancellationToken)
     {
-        var settings = rotationOptions.Value;
         var todayUtc = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime.Date);
 
-        if (settings.OnlyRunOnFirstWeekdayOfMonth && !IsFirstWeekdayOfMonth(todayUtc))
+        if (!IsFirstWeekdayOfMonth(todayUtc))
         {
             logger.LogInformation(
                 "Skipping scheduled Maskinporten JWK rotation on {Date} because it is not the first weekday of the month.",
@@ -32,6 +28,8 @@ public class MaskinportenJwkRotationHandler(
         await Process(cancellationToken);
     }
 
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(timeoutInSeconds: 1800)]
     public async Task Process(CancellationToken cancellationToken)
     {
         try

--- a/src/Altinn.Correspondence.Application/MaskinportenJwkRotation/MaskinportenJwkRotationHandler.cs
+++ b/src/Altinn.Correspondence.Application/MaskinportenJwkRotation/MaskinportenJwkRotationHandler.cs
@@ -41,7 +41,8 @@ public class MaskinportenJwkRotationHandler(
                     $"Client {client.ClientName} ({client.ClientId}) rotated to kid {client.NewKid}. Keys before: {client.PreviousKeyCount}, keys after: {client.CurrentKeyCount}. Secret updated: {client.KeyVaultSecretName}. Verification scope: {client.VerificationScope}."));
             await slackNotificationHandler.Process(
                 "Maskinporten JWK rotation completed",
-                summary);
+                summary,
+                ":white_check_mark:");
         }
         catch (Exception ex)
         {

--- a/src/Altinn.Correspondence.Application/SendSlackNotification/SendSlackNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Application/SendSlackNotification/SendSlackNotificationHandler.cs
@@ -14,10 +14,10 @@ public class SendSlackNotificationHandler(
     IHostEnvironment hostEnvironment,
     ILogger<SendSlackNotificationHandler> logger)
 {
-    public async Task Process(string title, string message)
+    public async Task Process(string title, string message, string emoji = ":warning:")
     {
         var text =
-            $":warning: *{title}*\n" +
+            $"{emoji} *{title}*\n" +
             $"*Environment:* {hostEnvironment.EnvironmentName}\n" +
             $"*System:* Correspondence\n" +
             $"*Message:* {message}\n" +

--- a/src/Altinn.Correspondence.Core/Options/MaskinportenJwkRotationSettings.cs
+++ b/src/Altinn.Correspondence.Core/Options/MaskinportenJwkRotationSettings.cs
@@ -4,10 +4,6 @@ public class MaskinportenJwkRotationSettings
 {
     public bool Enabled { get; set; }
 
-    public string CronExpression { get; set; } = "0 8 * * 1-5";
-
-    public bool OnlyRunOnFirstWeekdayOfMonth { get; set; } = true;
-
     public int VerificationMaxAttempts { get; set; } = 12;
 
     public int VerificationDelaySeconds { get; set; } = 15;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an endpoint for manual testing and redused code in settings.

## Related Issue(s)
- #1656 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maintenance endpoint to manually trigger Maskinporten JWK rotation with confirmation verification.

* **Improvements**
  * Fixed Maskinporten JWK rotation scheduling to consistently run on the first weekday of each month.
  * Enhanced Slack notification formatting for rotation completion messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->