### PR TITLE
Fix mapping of resourceId in AttachmentDetails

### DIFF
--- a/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/AttachmentDetailsMapper.cs
@@ -10,7 +10,7 @@ internal static class AttachmentDetailsMapper
     {
         var attachment = new AttachmentDetailsExt
         {
-            ResourceId = "1",
+            ResourceId = AttachmentDetails.ResourceId,
             AttachmentId = AttachmentDetails.AttachmentId,
             Status = (AttachmentStatusExt)AttachmentDetails.Status,
             FileName = AttachmentDetails.FileName,


### PR DESCRIPTION
## Description
Very old mocking code persisted. Endpoint hasn't been hit a single time in the last 30 days though.

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed attachment resource ID mapping to accurately reflect source data instead of using a placeholder value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->