### PR TITLE
Setup OpsGenie alert on use case test failure

### DIFF
--- a/.github/workflows/test-use-cases.yml
+++ b/.github/workflows/test-use-cases.yml
@@ -82,20 +82,49 @@ jobs:
       env:
         OPSGENIE_API_URL: https://api.eu.opsgenie.com
       run: |
+        ENV="${{ inputs.environment || github.event.inputs.environment || 'use-case-test' }}"
+        NOW="$(date -u +%Y-%m-%dT%H:%M:%S.%7NZ)"
+        ALERT_ID="$(cat /proc/sys/kernel/random/uuid)"
+
         payload=$(cat <<EOF
         {
-          "message": "Correspondence use case test failed (${{ inputs.environment || github.event.inputs.environment || 'use-case-test' }})",
-          "description": "${{ env.stepreport }}",
-          "alias": "correspondence-usecase-${{ github.run_id }}-${{ inputs.environment || github.event.inputs.environment || 'use-case-test' }}",
-          "priority": "P1",
-          "source": "github-actions",
-          "tags": ["correspondence", "use-case-test", "github-actions"],
-          "details": {
-            "repository": "${{ github.repository }}",
-            "workflow": "${{ github.workflow }}",
-            "run_id": "${{ github.run_id }}",
-            "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-            "environment": "${{ inputs.environment || github.event.inputs.environment || 'use-case-test' }}"
+          "schemaId": "azureMonitorCommonAlertSchema",
+          "data": {
+            "essentials": {
+              "alertId": "${ALERT_ID}",
+              "alertRule": "Correspondence Use Case Test",
+              "severity": "Sev1",
+              "signalType": "Metric",
+              "monitorCondition": "Fired",
+              "monitoringService": "Platform",
+              "alertTargetIDs": ["/correspondence/${ENV}"],
+              "firedDateTime": "${NOW}",
+              "description": "Correspondence use case test failed (${ENV}) - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "essentialsVersion": "1.0",
+              "alertContextVersion": "1.0"
+            },
+            "alertContext": {
+              "properties": {
+                "repository": "${{ github.repository }}",
+                "workflow": "${{ github.workflow }}",
+                "run_id": "${{ github.run_id }}",
+                "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                "environment": "${ENV}"
+              },
+              "conditionType": "SingleResourceMultipleMetricCriteria",
+              "condition": {
+                "windowSize": "PT5M",
+                "allOf": [
+                  {
+                    "metricName": "UseCaseTestFailure",
+                    "operator": "GreaterThan",
+                    "threshold": "0",
+                    "timeAggregation": "Count",
+                    "metricValue": 1
+                  }
+                ]
+              }
+            }
           }
         }
         EOF
@@ -103,7 +132,6 @@ jobs:
 
         curl --fail-with-body --show-error --silent \
           --request POST \
-          --url "${OPSGENIE_API_URL}/v2/alerts" \
-          --header "Authorization: GenieKey ${OPSGENIE_API_KEY}" \
+          --url "${OPSGENIE_API_URL}/v1/json/azure?apiKey=${OPSGENIE_API_KEY}" \
           --header "Content-Type: application/json" \
           --data "${payload}"

--- a/.github/workflows/test-use-cases.yml
+++ b/.github/workflows/test-use-cases.yml
@@ -74,3 +74,35 @@ jobs:
           {
             "text": "${{ env.stepreport }}"
           }
+
+    - name: Report failure to Opsgenie
+      if: failure() && steps.check-enable.outputs.enabled == 'true' && steps.usecase-test.outcome == 'failure' && secrets.OPSGENIE_API_KEY != ''
+      env:
+        OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
+        OPSGENIE_API_URL: https://api.eu.opsgenie.com
+      run: |
+        payload=$(cat <<EOF
+        {
+          "message": "Correspondence use case test failed (${{ inputs.environment || github.event.inputs.environment || 'use-case-test' }})",
+          "description": "${{ env.stepreport }}",
+          "alias": "correspondence-usecase-${{ github.run_id }}-${{ inputs.environment || github.event.inputs.environment || 'use-case-test' }}",
+          "priority": "P1",
+          "source": "github-actions",
+          "tags": ["correspondence", "use-case-test", "github-actions"],
+          "details": {
+            "repository": "${{ github.repository }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "environment": "${{ inputs.environment || github.event.inputs.environment || 'use-case-test' }}"
+          }
+        }
+        EOF
+        )
+
+        curl --fail-with-body --show-error --silent \
+          --request POST \
+          --url "${OPSGENIE_API_URL}/v2/alerts" \
+          --header "Authorization: GenieKey ${OPSGENIE_API_KEY}" \
+          --header "Content-Type: application/json" \
+          --data "${payload}"

--- a/.github/workflows/test-use-cases.yml
+++ b/.github/workflows/test-use-cases.yml
@@ -25,6 +25,8 @@ jobs:
   usecase-test:
     environment: ${{ inputs.environment || github.event.inputs.environment || 'use-case-test' }}
     runs-on: ubuntu-latest
+    env:
+      OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
     outputs:
       tests-enabled: ${{ steps.check-enable.outputs.enabled }}
     steps:
@@ -76,9 +78,8 @@ jobs:
           }
 
     - name: Report failure to Opsgenie
-      if: failure() && steps.check-enable.outputs.enabled == 'true' && steps.usecase-test.outcome == 'failure' && secrets.OPSGENIE_API_KEY != ''
+      if: failure() && steps.check-enable.outputs.enabled == 'true' && steps.usecase-test.outcome == 'failure' && env.OPSGENIE_API_KEY != ''
       env:
-        OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
         OPSGENIE_API_URL: https://api.eu.opsgenie.com
       run: |
         payload=$(cat <<EOF


### PR DESCRIPTION
## Description
Setup OpsGenie alert on use case test failure.

To be tested manually after 16:00 as alerts do not lead to calls during working hours.

## Related Issue(s)
- #1891 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD test-failure notifications: added Opsgenie alerts alongside existing Slack messages, with enriched alert payloads (run URL, environment, timestamps, generated alert ID) and a conditional step that reports failures to Opsgenie only when use-case tests run.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1932)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->