### PR TITLE
Reschedule instead of polling migration queuing

### DIFF
--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -199,14 +199,20 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
             var currentBatch = 999;
             var migrationQueueLimit = currentBatch * 20;
 
-            long enqueuedJobs;
-            while ((enqueuedJobs = JobStorage.Current.GetMonitoringApi().EnqueuedCount(HangfireQueues.Migration)) > migrationQueueLimit)
+            var enqueuedJobs = JobStorage.Current.GetMonitoringApi().EnqueuedCount(HangfireQueues.Migration);
+            if (enqueuedJobs > migrationQueueLimit)
             {
                 logger.LogInformation(
-                    "Waiting before scheduling next migration batch: {EnqueuedJobs} jobs in Migration queue (limit {Limit})",
+                    "Migration queue has {EnqueuedJobs} jobs (limit {Limit}), rescheduling in 1 minute",
                     enqueuedJobs,
                     migrationQueueLimit);
-                await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+
+                backgroundJobClient.Schedule<MigrateCorrespondenceHandler>(
+                    HangfireQueues.LiveMigration,
+                    handler => handler.MakeCorrespondenceAvailable(request, CancellationToken.None),
+                    TimeSpan.FromMinutes(1));
+
+                return response;
             }
 
             logger.LogInformation("Querying db");

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -200,7 +200,7 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
             var migrationQueueLimit = currentBatch * 20;
 
             var enqueuedJobs = JobStorage.Current.GetMonitoringApi().EnqueuedCount(HangfireQueues.Migration);
-            if (enqueuedJobs > migrationQueueLimit)
+            if (enqueuedJobs >= migrationQueueLimit)
             {
                 logger.LogInformation(
                     "Migration queue has {EnqueuedJobs} jobs (limit {Limit}), rescheduling in 1 minute",


### PR DESCRIPTION
## Description
If the job runs beyond the sliding invisibility timeout it starts running another job, and we get concurrent jobs adding the same jobs to queue. They are idempotent, but they end up slowing down due to noop jobs.

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized correspondence migration processing to improve system responsiveness during high-volume operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1934)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->