### PR TITLE
Added support for searching on Altinn2CorrespondenceId

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Correspondence.API.Models;
+using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Application.GetCorrespondences;
 using Altinn.Correspondence.Common.Constants;
@@ -559,6 +559,93 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var result = await search.Content.ReadFromJsonAsync<GetCorrespondencesResponse>(_responseSerializerOptions);
 
             // Assert
+            Assert.Empty(result.Ids);
+        }
+
+        [Fact]
+        public async Task GetCorrespondences_WithValidAltinn2CorrespondenceId_ReturnsCorrespondence()
+        {
+            // Arrange
+            var resourceId = Guid.NewGuid().ToString();
+            var altinn2CorrespondenceId = new Random().Next(100000, int.MaxValue);
+            var migrationClient = _factory.CreateClientWithAddedClaims(
+                ("scope", AuthorizationConstants.MigrateScope));
+
+            var migratePayload = new MigrateCorrespondenceBuilder()
+                .CreateMigrateCorrespondence()
+                .WithResourceId(resourceId)
+                .WithAltinn2CorrespondenceId(altinn2CorrespondenceId)
+                .WithIsMigrating(false)
+                .Build();
+
+            var migrateResponse = await migrationClient.PostAsJsonAsync("correspondence/api/v1/migration/correspondence", migratePayload);
+            Assert.True(migrateResponse.IsSuccessStatusCode, await migrateResponse.Content.ReadAsStringAsync());
+            var migrateResult = await migrateResponse.Content.ReadFromJsonAsync<CorrespondenceMigrationStatusExt>(_responseSerializerOptions);
+
+            // Act
+            var search = await _senderClient.GetAsync($"/correspondence/api/v1/correspondence?resourceId={resourceId}&altinn2CorrespondenceId={altinn2CorrespondenceId}&role={"recipientandsender"}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, search.StatusCode);
+            var result = await search.Content.ReadFromJsonAsync<GetCorrespondencesResponse>(_responseSerializerOptions);
+            Assert.Single(result.Ids);
+            Assert.Equal(migrateResult.CorrespondenceId, result.Ids.First());
+        }
+
+        [Fact]
+        public async Task GetCorrespondences_WithNonExistentAltinn2CorrespondenceId_ReturnsEmptyList()
+        {
+            // Arrange
+            var resourceId = Guid.NewGuid().ToString();
+            var altinn2CorrespondenceId = new Random().Next(100000, int.MaxValue);
+            var nonExistentId = altinn2CorrespondenceId + 1;
+            var migrationClient = _factory.CreateClientWithAddedClaims(
+                ("scope", AuthorizationConstants.MigrateScope));
+
+            var migratePayload = new MigrateCorrespondenceBuilder()
+                .CreateMigrateCorrespondence()
+                .WithResourceId(resourceId)
+                .WithAltinn2CorrespondenceId(altinn2CorrespondenceId)
+                .WithIsMigrating(false)
+                .Build();
+
+            var migrateResponse = await migrationClient.PostAsJsonAsync("correspondence/api/v1/migration/correspondence", migratePayload);
+            Assert.True(migrateResponse.IsSuccessStatusCode, await migrateResponse.Content.ReadAsStringAsync());
+
+            // Act
+            var search = await _senderClient.GetAsync($"/correspondence/api/v1/correspondence?resourceId={resourceId}&altinn2CorrespondenceId={nonExistentId}&role={"recipientandsender"}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, search.StatusCode);
+            var result = await search.Content.ReadFromJsonAsync<GetCorrespondencesResponse>(_responseSerializerOptions);
+            Assert.Empty(result.Ids);
+        }
+
+        [Fact]
+        public async Task GetCorrespondences_WithAltinn2CorrespondenceId_WhenStillMigrating_ReturnsEmptyList()
+        {
+            // Arrange
+            var resourceId = Guid.NewGuid().ToString();
+            var altinn2CorrespondenceId = new Random().Next(100000, int.MaxValue);
+            var migrationClient = _factory.CreateClientWithAddedClaims(
+                ("scope", AuthorizationConstants.MigrateScope));
+
+            var migratePayload = new MigrateCorrespondenceBuilder()
+                .CreateMigrateCorrespondence()
+                .WithResourceId(resourceId)
+                .WithAltinn2CorrespondenceId(altinn2CorrespondenceId)
+                .WithIsMigrating(true)
+                .Build();
+
+            var migrateResponse = await migrationClient.PostAsJsonAsync("correspondence/api/v1/migration/correspondence", migratePayload);
+            Assert.True(migrateResponse.IsSuccessStatusCode, await migrateResponse.Content.ReadAsStringAsync());
+
+            // Act
+            var search = await _senderClient.GetAsync($"/correspondence/api/v1/correspondence?resourceId={resourceId}&altinn2CorrespondenceId={altinn2CorrespondenceId}&role={"recipientandsender"}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, search.StatusCode);
+            var result = await search.Content.ReadFromJsonAsync<GetCorrespondencesResponse>(_responseSerializerOptions);
             Assert.Empty(result.Ids);
         }
     }

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -415,6 +415,7 @@ namespace Altinn.Correspondence.API.Controllers
             [FromQuery, OnBehalfOf] string? onBehalfOf,
             [FromQuery] string? sendersReference,
             [FromQuery] Guid? idempotentKey,
+            [FromQuery] int? altinn2CorrespondenceId,
             CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Get correspondences for receiver");
@@ -428,7 +429,8 @@ namespace Altinn.Correspondence.API.Controllers
                 Role = role,
                 OnBehalfOf = onBehalfOf,
                 SendersReference = sendersReference,
-                IdempotentKey = idempotentKey
+                IdempotentKey = idempotentKey,
+                Altinn2CorrespondenceId = altinn2CorrespondenceId
             }, HttpContext.User, cancellationToken);
 
             return commandResult.Match(

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
@@ -53,6 +53,18 @@ public class GetCorrespondencesHandler(
             }
                 return new GetCorrespondencesResponse { Ids = new List<Guid> { correspondence.Id } };
         }
+        if (request.Altinn2CorrespondenceId.HasValue)
+        {
+            logger.LogInformation("Retrieving correspondence for resource {ResourceId} with altinn2CorrespondenceId {Altinn2CorrespondenceId}",
+                request.ResourceId.SanitizeForLogging(),
+                request.Altinn2CorrespondenceId);
+            var correspondence = await correspondenceRepository.GetCorrespondenceByAltinn2CorrespondenceId(request.Altinn2CorrespondenceId.Value, cancellationToken);
+            if (correspondence == null)
+            {
+                return new GetCorrespondencesResponse { Ids = new List<Guid>() };
+            }
+            return new GetCorrespondencesResponse { Ids = new List<Guid> { correspondence.Id } };
+        }
 
         logger.LogInformation("Retrieving correspondences for resource {ResourceId} with filters: from={From}, to={To}, limit={Limit} status={Status}, onBehalfOf={onBehalfOf}, role={Role}",
                 request.ResourceId.SanitizeForLogging(),

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesHandler.cs
@@ -58,7 +58,7 @@ public class GetCorrespondencesHandler(
             logger.LogInformation("Retrieving correspondence for resource {ResourceId} with altinn2CorrespondenceId {Altinn2CorrespondenceId}",
                 request.ResourceId.SanitizeForLogging(),
                 request.Altinn2CorrespondenceId);
-            var correspondence = await correspondenceRepository.GetCorrespondenceByAltinn2CorrespondenceId(request.Altinn2CorrespondenceId.Value, cancellationToken);
+            var correspondence = await correspondenceRepository.GetCorrespondenceByAltinn2CorrespondenceId(request.Altinn2CorrespondenceId.Value, request.ResourceId, onBehalfOf, request.Role, cancellationToken);
             if (correspondence == null)
             {
                 return new GetCorrespondencesResponse { Ids = new List<Guid>() };

--- a/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesRequest.cs
+++ b/src/Altinn.Correspondence.Application/GetCorespondences/GetCorrespondencesRequest.cs
@@ -19,4 +19,6 @@ public class GetCorrespondencesRequest
     public string? SendersReference { get; set; }
 
     public Guid? IdempotentKey { get; set; }
+
+    public int? Altinn2CorrespondenceId { get; set; }
 }

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -101,7 +101,7 @@ namespace Altinn.Correspondence.Core.Repositories
 
         Task<CorrespondenceEntity?> GetCorrespondenceByIdempotentKey(Guid idempotentKey, CancellationToken cancellationToken);
 
-        Task<CorrespondenceEntity?> GetCorrespondenceByAltinn2CorrespondenceId(int altinn2CorrespondenceId, CancellationToken cancellationToken);
+        Task<CorrespondenceEntity?> GetCorrespondenceByAltinn2CorrespondenceId(int altinn2CorrespondenceId, string resourceId, string orgNo, CorrespondencesRoleType role, CancellationToken cancellationToken);
 
         Task<List<CorrespondenceEntity?>> GetCorrespondencesByNoAltinn2IdAndExistingDialog(List<Guid> windowIds, ReferenceType referenceType, CancellationToken cancellationToken);
         Task<List<CorrespondenceEntity>> GetCorrespondencesWithAltinn2IdNotMigratingAndConfirmedStatus(List<Guid> windowIds, CancellationToken cancellationToken);

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -101,6 +101,8 @@ namespace Altinn.Correspondence.Core.Repositories
 
         Task<CorrespondenceEntity?> GetCorrespondenceByIdempotentKey(Guid idempotentKey, CancellationToken cancellationToken);
 
+        Task<CorrespondenceEntity?> GetCorrespondenceByAltinn2CorrespondenceId(int altinn2CorrespondenceId, CancellationToken cancellationToken);
+
         Task<List<CorrespondenceEntity?>> GetCorrespondencesByNoAltinn2IdAndExistingDialog(List<Guid> windowIds, ReferenceType referenceType, CancellationToken cancellationToken);
         Task<List<CorrespondenceEntity>> GetCorrespondencesWithAltinn2IdNotMigratingAndConfirmedStatus(List<Guid> windowIds, CancellationToken cancellationToken);
         Task<List<CorrespondenceEntity>> GetCorrespondencesWithAltinn2IdNotMigratingAndConfirmedStatusUsingCursor(

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -621,11 +621,13 @@ namespace Altinn.Correspondence.Persistence.Repositories
             return correspondence;
         }
 
-        public async Task<CorrespondenceEntity?> GetCorrespondenceByAltinn2CorrespondenceId(int altinn2CorrespondenceId, CancellationToken cancellationToken)
+        public async Task<CorrespondenceEntity?> GetCorrespondenceByAltinn2CorrespondenceId(int altinn2CorrespondenceId, string resourceId, string orgNo, CorrespondencesRoleType role, CancellationToken cancellationToken)
         {
             return await _context.Correspondences
                 .Where(c => c.Altinn2CorrespondenceId == altinn2CorrespondenceId)
+                .Where(c => c.ResourceId == resourceId)
                 .Where(c => c.IsMigrating == false)
+                .FilterBySenderOrRecipient(orgNo, role)
                 .SingleOrDefaultAsync(cancellationToken);
         }
 

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -621,6 +621,14 @@ namespace Altinn.Correspondence.Persistence.Repositories
             return correspondence;
         }
 
+        public async Task<CorrespondenceEntity?> GetCorrespondenceByAltinn2CorrespondenceId(int altinn2CorrespondenceId, CancellationToken cancellationToken)
+        {
+            return await _context.Correspondences
+                .Where(c => c.Altinn2CorrespondenceId == altinn2CorrespondenceId)
+                .Where(c => c.IsMigrating == false)
+                .SingleOrDefaultAsync(cancellationToken);
+        }
+
         public async Task<List<CorrespondenceEntity>> GetCorrespondencesByNoAltinn2IdAndExistingDialog(
             List<Guid> correspondenceIds,
             ReferenceType referenceType,


### PR DESCRIPTION
## Description
For legacy systems that needs to look up based on their old references.

## Related Issue(s)
- #1927 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Correspondence search now supports filtering by Altinn2 correspondence ID, enabling users to locate and retrieve correspondence records using their Altinn2 identifier.

* **Tests**
  * Added test coverage for the new Altinn2 correspondence ID search functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1936)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->