### PR TITLE
update confidentialReminder to use resourceTitle rather than identifier

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
@@ -15,6 +15,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
     private readonly Mock<ICorrespondenceRepository> _correspondenceRepositoryMock;
     private readonly Mock<IAltinnAuthorizationService> _altinnAuthorizationServiceMock;
     private readonly Mock<IAltinnRegisterService> _altinnRegisterServiceMock;
+    private readonly Mock<IResourceRegistryService> _resourceRegistryServiceMock;
     private readonly Mock<IHostEnvironment> _hostEnvironmentMock;
     private readonly GetUnreadConfidentialCorrespondencesHandler _handler;
 
@@ -23,6 +24,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
         _correspondenceRepositoryMock = new Mock<ICorrespondenceRepository>();
         _altinnAuthorizationServiceMock = new Mock<IAltinnAuthorizationService>();
         _altinnRegisterServiceMock = new Mock<IAltinnRegisterService>();
+        _resourceRegistryServiceMock = new Mock<IResourceRegistryService>();
         _hostEnvironmentMock = new Mock<IHostEnvironment>();
         _hostEnvironmentMock.Setup(x => x.EnvironmentName).Returns("Development");
 
@@ -30,6 +32,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
             _correspondenceRepositoryMock.Object,
             _altinnAuthorizationServiceMock.Object,
             _altinnRegisterServiceMock.Object,
+            _resourceRegistryServiceMock.Object,
             _hostEnvironmentMock.Object);
     }
 
@@ -114,7 +117,6 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
         Assert.True(result.IsT0);
         var text = result.AsT0.Text;
         Assert.Contains("310300942", text);
-        Assert.Contains("some-resource-id", text);
         Assert.Contains("15.01.2026", text);
         Assert.Contains("1.", text);
     }
@@ -141,8 +143,8 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
         // Assert
         Assert.True(result.IsT0);
         var text = result.AsT0.Text;
-        var olderIndex = text.IndexOf("older-resource", StringComparison.Ordinal);
-        var newerIndex = text.IndexOf("newer-resource", StringComparison.Ordinal);
+        var olderIndex = text.IndexOf("111111111", StringComparison.Ordinal);
+        var newerIndex = text.IndexOf("222222222", StringComparison.Ordinal);
         Assert.True(olderIndex < newerIndex, "Older correspondence should appear before newer in the formatted text");
     }
 

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
@@ -93,7 +93,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
     }
 
     [Fact]
-    public async Task Process_WithCorrespondences_ReturnsFormattedTextContainingSenderAndResourceId()
+    public async Task Process_WithCorrespondences_ReturnsFormattedTextContainingSenderAndResourceTitle()
     {
         // Arrange
         var user = CreateOrgUser();
@@ -109,6 +109,9 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
         _correspondenceRepositoryMock
             .Setup(x => x.GetUnopenedConfidentialCorrespondencesForParty(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<CorrespondenceEntity> { correspondence });
+        _resourceRegistryServiceMock
+            .Setup(x => x.GetResourceTitle("some-resource-id", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("My Resolved Service Title");
 
         // Act
         var result = await _handler.Process(user, "nb", CancellationToken.None);
@@ -119,10 +122,12 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
         Assert.Contains("310300942", text);
         Assert.Contains("15.01.2026", text);
         Assert.Contains("1.", text);
+        Assert.Contains("My Resolved Service Title", text);
+        Assert.DoesNotContain("some-resource-id", text);
     }
 
     [Fact]
-    public async Task Process_WithMultipleCorrespondences_OrdersResultsByPublishDate()
+    public async Task Process_WithMultipleCorrespondences_OrdersResultsByPublishDate_NoResourceTitleFallsBackToResourceId()
     {
         // Arrange
         var user = CreateOrgUser();
@@ -132,10 +137,12 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
         _altinnAuthorizationServiceMock
             .Setup(x => x.CheckAccessAsAny(It.IsAny<ClaimsPrincipal>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-
         _correspondenceRepositoryMock
             .Setup(x => x.GetUnopenedConfidentialCorrespondencesForParty(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<CorrespondenceEntity> { newer, older });
+        _resourceRegistryServiceMock
+            .Setup(x => x.GetResourceTitle(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
 
         // Act
         var result = await _handler.Process(user, "nb", CancellationToken.None);
@@ -146,6 +153,9 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
         var olderIndex = text.IndexOf("111111111", StringComparison.Ordinal);
         var newerIndex = text.IndexOf("222222222", StringComparison.Ordinal);
         Assert.True(olderIndex < newerIndex, "Older correspondence should appear before newer in the formatted text");
+        // null title → fallback to raw resource id
+        Assert.Contains("older-resource", text);
+        Assert.Contains("newer-resource", text);
     }
 
     [Fact]

--- a/src/Altinn.Correspondence.Application/CreateNotificationOrder/CreateNotificationOrderHandler.cs
+++ b/src/Altinn.Correspondence.Application/CreateNotificationOrder/CreateNotificationOrderHandler.cs
@@ -438,8 +438,7 @@ public class CreateNotificationOrderHandler(
             Recipient = reminder.Recipient,
             ResourceId = reminder.ResourceId,
             SendersReference = reminder.SendersReference,
-            MessageSender = reminder.MessageSender,
-            SenderUrn = null,
+            SenderUrn = reminder.Sender,
             MessageTitle = reminder.Title,
             RequestedPublishTime = DateTimeOffset.UtcNow,
             IgnoreReservation = null

--- a/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
@@ -12,6 +12,7 @@ public class GetUnreadConfidentialCorrespondencesHandler(
     ICorrespondenceRepository correspondenceRepository,
     IAltinnAuthorizationService altinnAuthorizationService,
     IAltinnRegisterService altinnRegisterService,
+    IResourceRegistryService resourceRegistryService,
     IHostEnvironment hostEnvironment
     )
 {
@@ -70,9 +71,16 @@ public class GetUnreadConfidentialCorrespondencesHandler(
         })
     );
 
+    var uniqueResourceIds = sortedCorrespondences.Select(c => c.ResourceId).Distinct().ToList();
+    var resourceTitles = new Dictionary<string, string?>();
+    foreach (var resourceId in uniqueResourceIds)
+    {
+        resourceTitles[resourceId] = await resourceRegistryService.GetResourceTitle(resourceId, "nb", cancellationToken);
+    }
+
     var lines = sortedCorrespondences
-        .Select((c, i) => $"{i + 1}. Melding fra avsender {senderNames[i] ?? c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krever tilgang til {c.ResourceId}")
-        .ToList();
+        .Select((c, i) => $"{i + 1}. Melding fra avsender {senderNames[i] ?? c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krever tilgang til tjenesten: {resourceTitles[c.ResourceId]}")
+        .ToArray();
 
     var ending = "NB! Dette varselet forsvinner når alle uleste taushetsbelagte meldinger er åpnet.";
 

--- a/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
@@ -25,7 +25,7 @@ public class GetUnreadConfidentialCorrespondencesHandler(
     }
     var hasAccess = await altinnAuthorizationService.CheckAccessAsAny(
             user,
-            "ttd-reminder-unopened-confidential-correspondences",
+            "digdir-reminder-unopened-confidential-correspondences",
             recipientOrg,
             cancellationToken);
 

--- a/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
@@ -92,15 +92,15 @@ public class GetUnreadConfidentialCorrespondencesHandler(
     }
 
     var linesNb = sortedCorrespondences
-        .Select((c, i) => $"{i + 1}. Melding fra avsender {senderNames[i] ?? c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krever tilgang til tjenesten: {resourceTitles[c.ResourceId]}")
+        .Select((c, i) => $"{i + 1}. Melding fra avsender {senderNames[i] ?? c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krever tilgang til tjenesten: {resourceTitles[c.ResourceId] ?? c.ResourceId}")
         .ToList();
 
     var linesNn = sortedCorrespondences
-        .Select((c, i) => $"{i + 1}. Melding frå avsendar {senderNames[i] ?? c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krev tilgang til tenesta: {resourceTitles[c.ResourceId]}")
+        .Select((c, i) => $"{i + 1}. Melding frå avsendar {senderNames[i] ?? c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krev tilgang til tenesta: {resourceTitles[c.ResourceId] ?? c.ResourceId}")
         .ToList();
 
     var linesEn = sortedCorrespondences
-        .Select((c, i) => $"{i + 1}. Correspondence from sender {senderNames[i] ?? c.Sender.WithoutPrefix()} dated {c.Published:dd.MM.yyyy}, this requires access to the service: {resourceTitles[c.ResourceId]}")
+        .Select((c, i) => $"{i + 1}. Correspondence from sender {senderNames[i] ?? c.Sender.WithoutPrefix()} dated {c.Published:dd.MM.yyyy}, this requires access to the service: {resourceTitles[c.ResourceId] ?? c.ResourceId}")
         .ToList();
 
     var lines = languageCode switch

--- a/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
+++ b/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
@@ -43,9 +43,9 @@ public class UnreadConfidentialCorrespondenceHandler(
             Title = "Din virksomhet har en uåpnet taushetsbelagt post",
             Summary = "Din virksomhet har mottatt ett eller flere brev som er taushetsbelagte og som ikke er åpnet. Dette varselet inneholder informasjon om hvordan du kan lese disse",
             Recipient = correspondence.Recipient.WithUrnPrefix(),
-            ResourceId = "ttd-reminder-unopened-confidential-correspondences",
-            SendersReference = "Digdir",
-            MessageSender = "Digitaliseringsdirektoratet",
+            ResourceId = "digdir-reminder-unopened-confidential-correspondences",
+            SendersReference = "corr-confidential-reminder",
+            Sender = "991825827",
             Created = DateTimeOffset.UtcNow,
             Status = "RequiresAttention",
             PropertyList = new Dictionary<string, string>{}

--- a/src/Altinn.Correspondence.Common/Helpers/Models/ConfidentialReminderDialogDto.cs
+++ b/src/Altinn.Correspondence.Common/Helpers/Models/ConfidentialReminderDialogDto.cs
@@ -23,6 +23,9 @@ namespace Altinn.Correspondence.Common.Helpers.Models
         [MaxLength(10, ErrorMessage = "propertyList can contain at most 10 properties")]
         public Dictionary<string, string> PropertyList { get; set; } = new Dictionary<string, string>();
 
+        [Required]
+        public required string Sender { get; set; }
+
         [StringLength(256, MinimumLength = 0)]
         public string? MessageSender { get; set; }
         


### PR DESCRIPTION
## Description
Users do not have a relation to the resource identifier. It is the title that is visible in AF, and thus should be what the users get information about.

## Related Issue(s)
- #1935 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confidential correspondence notifications now show human-readable service titles; when a title is unavailable, the technical identifier is shown as a fallback.

* **Bug Fixes**
  * Notification sender information is now populated from the correct source.

* **Tests**
  * Test assertions updated to reflect title display and ordering behavior for single and multiple correspondences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->