### PR TITLE
confidential reminder multiple languages

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
@@ -59,7 +59,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
         var user = new ClaimsPrincipal();
 
         // Act
-        var result = await _handler.Process(user, CancellationToken.None);
+        var result = await _handler.Process(user, "nb", CancellationToken.None);
 
         // Assert
         Assert.True(result.IsT1);
@@ -79,7 +79,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
             .ReturnsAsync(false);
 
         // Act
-        var result = await _handler.Process(user, CancellationToken.None);
+        var result = await _handler.Process(user, "nb", CancellationToken.None);
 
         // Assert
         Assert.True(result.IsT1);
@@ -108,7 +108,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
             .ReturnsAsync(new List<CorrespondenceEntity> { correspondence });
 
         // Act
-        var result = await _handler.Process(user, CancellationToken.None);
+        var result = await _handler.Process(user, "nb", CancellationToken.None);
 
         // Assert
         Assert.True(result.IsT0);
@@ -136,7 +136,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
             .ReturnsAsync(new List<CorrespondenceEntity> { newer, older });
 
         // Act
-        var result = await _handler.Process(user, CancellationToken.None);
+        var result = await _handler.Process(user, "nb", CancellationToken.None);
 
         // Assert
         Assert.True(result.IsT0);
@@ -161,7 +161,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
             .ReturnsAsync(new List<CorrespondenceEntity>());
 
         // Act
-        await _handler.Process(user, CancellationToken.None);
+        await _handler.Process(user, "nb", CancellationToken.None);
 
         // Assert
         Assert.Equal(TimeSpan.FromMinutes(1), capturedMinAge);
@@ -180,7 +180,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
             .ReturnsAsync(new List<CorrespondenceEntity>());
 
         // Act
-        var result = await _handler.Process(user, CancellationToken.None);
+        var result = await _handler.Process(user, "nb", CancellationToken.None);
 
         // Assert
         Assert.True(result.IsT1);

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
@@ -188,7 +188,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
     }
 
     [Fact]
-    public async Task Process_WithCorrespondences_NorwegianBokmål_ReturnsBokmålText()
+    public async Task Process_UserLanguageNorwegianBokmål_ReturnsBokmålText()
     {
         // Arrange
         var user = CreateOrgUser();
@@ -218,7 +218,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
     }
 
     [Fact]
-    public async Task Process_WithCorrespondences_NorwegianNynorsk_ReturnsNynorskText()
+    public async Task Process_UserLanguageNorwegianNynorsk_ReturnsNynorskText()
     {
         // Arrange
         var user = CreateOrgUser();
@@ -248,7 +248,7 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
     }
 
     [Fact]
-    public async Task Process_WithCorrespondences_English_ReturnsEnglishText()
+    public async Task Process_UserLanguageEnglish_ReturnsEnglishText()
     {
         // Arrange
         var user = CreateOrgUser();

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetUnreadConfidentialCorrespondencesHandlerTests.cs
@@ -186,4 +186,94 @@ public class GetUnreadConfidentialCorrespondencesHandlerTests
         Assert.True(result.IsT1);
         Assert.Equal(CorrespondenceErrors.UnreadConfidentialCorrespondencesNotFound.ErrorCode, result.AsT1.ErrorCode);
     }
+
+    [Fact]
+    public async Task Process_WithCorrespondences_NorwegianBokmål_ReturnsBokmålText()
+    {
+        // Arrange
+        var user = CreateOrgUser();
+        var published = new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero);
+        var correspondence = CreateCorrespondenceForListing(
+            "urn:altinn:organization:identifier-no:310300942",
+            published,
+            "some-resource-id");
+
+        _altinnAuthorizationServiceMock
+            .Setup(x => x.CheckAccessAsAny(It.IsAny<ClaimsPrincipal>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _correspondenceRepositoryMock
+            .Setup(x => x.GetUnopenedConfidentialCorrespondencesForParty(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CorrespondenceEntity> { correspondence });
+
+        // Act
+        var result = await _handler.Process(user, "nb", CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsT0);
+        var text = result.AsT0.Text;
+
+        Assert.Contains("Under ligger en oversikt over hvilke meldinger som er uåpnet og viser til avsender, dato meldingen ble publisert og hvilken tjeneste som kreves.", text);
+        Assert.DoesNotContain("Under ligg ein oversikt over kva meldingar som er uopna og viser til avsendar, dato meldinga blei publisert og kva teneste som krevst.", text);
+        Assert.DoesNotContain("Below is an overview of which correspondences are unopened and shows the sender, the date the correspondence was published and which service is required.", text);
+    }
+
+    [Fact]
+    public async Task Process_WithCorrespondences_NorwegianNynorsk_ReturnsNynorskText()
+    {
+        // Arrange
+        var user = CreateOrgUser();
+        var published = new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero);
+        var correspondence = CreateCorrespondenceForListing(
+            "urn:altinn:organization:identifier-no:310300942",
+            published,
+            "some-resource-id");
+
+        _altinnAuthorizationServiceMock
+            .Setup(x => x.CheckAccessAsAny(It.IsAny<ClaimsPrincipal>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _correspondenceRepositoryMock
+            .Setup(x => x.GetUnopenedConfidentialCorrespondencesForParty(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CorrespondenceEntity> { correspondence });
+
+        // Act
+        var result = await _handler.Process(user, "nn", CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsT0);
+        var text = result.AsT0.Text;
+
+        Assert.Contains("Under ligg ein oversikt over kva meldingar som er uopna og viser til avsendar, dato meldinga blei publisert og kva teneste som krevst.", text);
+        Assert.DoesNotContain("Below is an overview of which correspondences are unopened and shows the sender, the date the correspondence was published and which service is required.", text);
+        Assert.DoesNotContain("Under ligger en oversikt over hvilke meldinger som er uåpnet og viser til avsender, dato meldingen ble publisert og hvilken tjeneste som kreves.", text);
+    }
+
+    [Fact]
+    public async Task Process_WithCorrespondences_English_ReturnsEnglishText()
+    {
+        // Arrange
+        var user = CreateOrgUser();
+        var published = new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero);
+        var correspondence = CreateCorrespondenceForListing(
+            "urn:altinn:organization:identifier-no:310300942",
+            published,
+            "some-resource-id");
+
+        _altinnAuthorizationServiceMock
+            .Setup(x => x.CheckAccessAsAny(It.IsAny<ClaimsPrincipal>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _correspondenceRepositoryMock
+            .Setup(x => x.GetUnopenedConfidentialCorrespondencesForParty(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CorrespondenceEntity> { correspondence });
+
+        // Act
+        var result = await _handler.Process(user, "en", CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsT0);
+        var text = result.AsT0.Text;
+
+        Assert.Contains("Below is an overview of which correspondences are unopened and shows the sender, the date the correspondence was published and which service is required.", text);
+        Assert.DoesNotContain("Under ligg ein oversikt over kva meldingar som er uopna og viser til avsendar, dato meldinga blei publisert og kva teneste som krevst.", text);
+        Assert.DoesNotContain("Under ligger en oversikt over hvilke meldinger som er uåpnet og viser til avsender, dato meldingen ble publisert og hvilken tjeneste som kreves.", text);
+    }
 }

--- a/src/Altinn.Correspondence.API/Controllers/ConfidentialReminderController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/ConfidentialReminderController.cs
@@ -30,10 +30,11 @@ public class ConfidentialReminderController(ILogger<ConfidentialReminderControll
     [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
     public async Task<ActionResult> GetUnreadConfidentialCorrespondences(
         [FromServices] GetUnreadConfidentialCorrespondencesHandler handler,
+        [FromQuery] string languageCode,
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Getting unread confidential correspondences");
-        var commandResult = await handler.Process(HttpContext.User, cancellationToken);
+        var commandResult = await handler.Process(HttpContext.User, languageCode, cancellationToken);
         return commandResult.Match(
             data => Content(MessageBodyHelpers.ConvertMixedToMarkdown(data.Text, false)),
             Problem

--- a/src/Altinn.Correspondence.API/Controllers/ConfidentialReminderController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/ConfidentialReminderController.cs
@@ -30,8 +30,8 @@ public class ConfidentialReminderController(ILogger<ConfidentialReminderControll
     [EnableCors(AuthorizationConstants.ArbeidsflateCors)]
     public async Task<ActionResult> GetUnreadConfidentialCorrespondences(
         [FromServices] GetUnreadConfidentialCorrespondencesHandler handler,
-        [FromQuery] string languageCode,
-        CancellationToken cancellationToken)
+        [FromQuery] string languageCode = "nb",
+        CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Getting unread confidential correspondences");
         var commandResult = await handler.Process(HttpContext.User, languageCode, cancellationToken);

--- a/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
@@ -91,7 +91,7 @@ public class GetUnreadConfidentialCorrespondencesHandler(
         .ToList();
 
     var linesEn = sortedCorrespondences
-        .Select((c, i) => $"{i + 1}. Message from sender {senderNames[i] ?? c.Sender.WithoutPrefix()} dated {c.Published:dd.MM.yyyy}, this requires access to {c.ResourceId}")
+        .Select((c, i) => $"{i + 1}. Correspondence from sender {senderNames[i] ?? c.Sender.WithoutPrefix()} dated {c.Published:dd.MM.yyyy}, this requires access to {c.ResourceId}")
         .ToList();
 
     var lines = languageCode switch

--- a/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
@@ -105,7 +105,7 @@ public class GetUnreadConfidentialCorrespondencesHandler(
 
     var endingNb = "NB! Dette varselet forsvinner når alle uleste taushetsbelagte meldinger er åpnet.";
     var endingNn = "NB! Dette varselet forsvinn når alle ulesne tausheitsbelagte meldingar er opna.";
-    var endingEn = "NB! This notice will disappear when all unread confidential correspondences have been opened.";
+    var endingEn = "N.B. This notice will disappear when all unread confidential correspondences have been opened.";
 
     var ending = languageCode switch
     {

--- a/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
@@ -46,9 +46,9 @@ public class GetUnreadConfidentialCorrespondencesHandler(
     }
 
 
-    var defaultTextNb = "Under ligger en oversikt over hvilke meldinger som er uåpnet og viser til avsender, dato meldingen ble publisert og hvilken tjeneste som kreves. Hovedadministrator må delegere tilgang til denne tjenesten for at noen i din virksomhet skal kunne se meldingene. Se mer informasjon på våre hjelpesider: https://info.altinn.no/help/ny-tilgangsstyring/enkelttjenester/";
-    var defaultTextNn = "Under ligg ein oversikt over kva meldingar som er uopna og viser til avsendar, dato meldinga blei publisert og kva teneste som krevst. Hovudadministrator må delegere tilgang til denne tenesta for at nokon i verksemda di skal kunne sjå meldingane. Sjå meir informasjon på våre hjelpesider: https://info.altinn.no/nn/help/ny-tilgangsstyring/enkelttjenester/";
-    var defaultTextEn = "Below is an overview of which correspondences are unopened and shows the sender, the date the correspondence was published and which service is required. The main administrator must delegate access to this service for someone in your organization to be able to see the messages. See more information on our support pages: https://info.altinn.no/en/help/ny-tilgangsstyring/enkelttjenester/";
+    var defaultTextNb = "Under ligger en oversikt over hvilke meldinger som er uåpnet og viser til avsender, dato meldingen ble publisert og hvilken tjeneste som kreves. Hovedadministrator må delegere tilgang til denne tjenesten for at noen i din virksomhet skal kunne se meldingene. Se mer informasjon på våre hjelpesider: https://info.altinn.no/hjelp/ny-tilgangsstyring/taushetsbelagt-post/";
+    var defaultTextNn = "Under ligg ein oversikt over kva meldingar som er uopna og viser til avsendar, dato meldinga blei publisert og kva teneste som krevst. Hovudadministrator må delegere tilgang til denne tenesta for at nokon i verksemda di skal kunne sjå meldingane. Sjå meir informasjon på våre hjelpesider: https://info.altinn.no/nn/hjelp/ny-tilgangsstyring/taushetsbelagt-post/";
+    var defaultTextEn = "Below is an overview of which correspondences are unopened and shows the sender, the date the correspondence was published and which service is required. The main administrator must delegate access to this service for someone in your organization to be able to see the messages. See more information on our support pages: https://info.altinn.no/en/help/ny-tilgangsstyring/taushetsbelagt-post/";
 
     var defaultText = languageCode switch
     {

--- a/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetUnreadConfidentialCorrespondences/GetUnreadConfidentialCorrespondencesHandler.cs
@@ -15,7 +15,7 @@ public class GetUnreadConfidentialCorrespondencesHandler(
     IHostEnvironment hostEnvironment
     )
 {
-    public async Task<OneOf<GetUnreadConfidentialCorrespondencesResponse, Error>> Process(ClaimsPrincipal user, CancellationToken cancellationToken = default)
+    public async Task<OneOf<GetUnreadConfidentialCorrespondencesResponse, Error>> Process(ClaimsPrincipal user, string languageCode, CancellationToken cancellationToken = default)
 {
     var recipientOrg = user.GetCallerOrganizationId();
     if (string.IsNullOrEmpty(recipientOrg))
@@ -45,7 +45,19 @@ public class GetUnreadConfidentialCorrespondencesHandler(
         return CorrespondenceErrors.UnreadConfidentialCorrespondencesNotFound;
     }
 
-    var defaultText = "Under ligger en oversikt over hvilke meldinger som er uåpnet og viser til avsender, dato meldingen ble publisert og hvilken tilgang som kreves. Hovedadministrator må delegere denne tilgangen for at noen i din virksomhet skal kunne se meldingene. Se mer informasjon på våre hjelpesider: https://info.altinn.no/nyheter/tilgang-til-taushetsbelagt-post/";
+
+    var defaultTextNb = "Under ligger en oversikt over hvilke meldinger som er uåpnet og viser til avsender, dato meldingen ble publisert og hvilken tjeneste som kreves. Hovedadministrator må delegere tilgang til denne tjenesten for at noen i din virksomhet skal kunne se meldingene. Se mer informasjon på våre hjelpesider: https://info.altinn.no/help/ny-tilgangsstyring/enkelttjenester/";
+    var defaultTextNn = "Under ligg ein oversikt over kva meldingar som er uopna og viser til avsendar, dato meldinga blei publisert og kva teneste som krevst. Hovudadministrator må delegere tilgang til denne tenesta for at nokon i verksemda di skal kunne sjå meldingane. Sjå meir informasjon på våre hjelpesider: https://info.altinn.no/nn/help/ny-tilgangsstyring/enkelttjenester/";
+    var defaultTextEn = "Below is an overview of which correspondences are unopened and shows the sender, the date the correspondence was published and which service is required. The main administrator must delegate access to this service for someone in your organization to be able to see the messages. See more information on our support pages: https://info.altinn.no/en/help/ny-tilgangsstyring/enkelttjenester/";
+
+    var defaultText = languageCode switch
+    {
+        "nb" => defaultTextNb,
+        "nn" => defaultTextNn,
+        "en" => defaultTextEn,
+        _ => defaultTextNb
+    };
+
 
     var sortedCorrespondences = correspondences.OrderBy(c => c.Published).ToList();
     var senderNames = await Task.WhenAll(
@@ -70,12 +82,38 @@ public class GetUnreadConfidentialCorrespondencesHandler(
         })
     );
 
-    var lines = sortedCorrespondences
+    var linesNb = sortedCorrespondences
         .Select((c, i) => $"{i + 1}. Melding fra avsender {senderNames[i] ?? c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krever tilgang til {c.ResourceId}")
         .ToList();
 
-    var ending = "NB! Dette varselet forsvinner når alle uleste taushetsbelagte meldinger er åpnet.";
+    var linesNn = sortedCorrespondences
+        .Select((c, i) => $"{i + 1}. Melding frå avsendar {senderNames[i] ?? c.Sender.WithoutPrefix()} datert {c.Published:dd.MM.yyyy}, denne krev tilgang til {c.ResourceId}")
+        .ToList();
 
+    var linesEn = sortedCorrespondences
+        .Select((c, i) => $"{i + 1}. Message from sender {senderNames[i] ?? c.Sender.WithoutPrefix()} dated {c.Published:dd.MM.yyyy}, this requires access to {c.ResourceId}")
+        .ToList();
+
+    var lines = languageCode switch
+    {
+        "nb" => linesNb,
+        "nn" => linesNn,
+        "en" => linesEn,
+        _ => linesNb
+    };
+
+
+    var endingNb = "NB! Dette varselet forsvinner når alle uleste taushetsbelagte meldinger er åpnet.";
+    var endingNn = "NB! Dette varselet forsvinn når alle ulesne tausheitsbelagte meldingar er opna.";
+    var endingEn = "NB! This notice will disappear when all unread confidential correspondences have been opened.";
+
+    var ending = languageCode switch
+    {
+        "nb" => endingNb,
+        "nn" => endingNn,
+        "en" => endingEn,
+        _ => endingNb
+    };
     var fullText = defaultText + "\n\n" + string.Join("\n\n", lines) + "\n\n" + ending;
 
     var response = new GetUnreadConfidentialCorrespondencesResponse

--- a/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
+++ b/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
@@ -40,8 +40,8 @@ public class UnreadConfidentialCorrespondenceHandler(
         var reminder = new ConfidentialReminderDialogDto
         {
             Id = Guid.CreateVersion7(),
-            Title = "Din virksomhet har en uåpnet taushetsbelagt post",
-            Summary = "Din virksomhet har mottatt ett eller flere brev som er taushetsbelagte og som ikke er åpnet. Dette varselet inneholder informasjon om hvordan du kan lese disse",
+            Title = "", // Value for title and summary is assigned in the mapper based on the users language
+            Summary = "",
             Recipient = correspondence.Recipient.WithUrnPrefix(),
             ResourceId = "ttd-reminder-unopened-confidential-correspondences",
             SendersReference = "Digdir",

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -233,7 +233,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     },
                     new DialogValue()
                     {
-                        Value =  "Your organization has unopened confidential message",
+                        Value =  "Your organization has unopened confidential mail",
                         LanguageCode = "en"
                     }
                 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -223,8 +223,18 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 Value = new List<DialogValue> {
                     new DialogValue()
                     {
-                        Value =  reminderDto.Title ?? "",
+                        Value =  "Din virksomhet har uåpnet taushetsbelagt post",
                         LanguageCode = "nb"
+                    },
+                    new DialogValue()
+                    {
+                        Value =  "Din verksemd har uopna tausheitsbelagt post",
+                        LanguageCode = "nn"
+                    },
+                    new DialogValue()
+                    {
+                        Value =  "Your organization has unopened confidential message",
+                        LanguageCode = "en"
                     }
                 }
             };
@@ -235,8 +245,18 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 Value = new List<DialogValue> {
                     new DialogValue()
                     {
-                        Value = reminderDto.Summary ?? "",
+                        Value = "Din virksomhet har mottatt en eller flere meldinger som er taushetsbelagte og som ikke er åpnet. Dette varselet inneholder informasjon om hvordan du kan lese disse",
                         LanguageCode = "nb"
+                    },
+                    new DialogValue()
+                    {
+                        Value = "Din verksemd har mottatt ein eller fleire meldingar som er tausheitsbelagte og som ikkje er opna. Dette varselet inneheld informasjon om korleis du kan lese desse",
+                        LanguageCode = "nn"
+                    },
+                    new DialogValue()
+                    {
+                        Value = "Your organization has received one or more correspondences that are confidential and have not been opened. This notice contains information on how you can read them",
+                        LanguageCode = "en"
                     }
                 }
             };
@@ -248,7 +268,17 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                     new DialogValue()
                     {
                         LanguageCode = "nb",
-                        Value = $"{(baseUrl ?? "").TrimEnd('/')}/correspondence/api/v1/confidential-reminders"
+                        Value = $"{(baseUrl ?? "").TrimEnd('/')}/correspondence/api/v1/confidential-reminders?languageCode=nb"
+                    },
+                    new DialogValue()
+                    {
+                        LanguageCode = "nn",
+                        Value = $"{(baseUrl ?? "").TrimEnd('/')}/correspondence/api/v1/confidential-reminders?languageCode=nn"
+                    },
+                    new DialogValue()
+                    {
+                        LanguageCode = "en",
+                        Value = $"{(baseUrl ?? "").TrimEnd('/')}/correspondence/api/v1/confidential-reminders?languageCode=en"
                     }
                 }
             };


### PR DESCRIPTION
## Description
Dialogporten allows sending different languages in mainContentReference. This PR uses this in combination with the other relevant fields to allow the confidentialReminder to display different languages based on the users preference.

## Related Issue(s)
- #1937 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-language support for unread confidential correspondence reminders (nb, nn, en).
  * API endpoint accepts a languageCode query parameter so reminders are returned in the requested language.
  * Reminder dialog titles, summaries and content links are localized per language and include a language parameter.

* **Tests**
  * Updated tests to cover the language parameter and verify localized output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1939)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->