### PR TITLE
improve check for confidential reminders

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/UnreadConfidentialCorrespondenceReminderHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/UnreadConfidentialCorrespondenceReminderHandlerTests.cs
@@ -99,6 +99,37 @@ public class UnreadConfidentialCorrespondenceReminderHandlerTests
             Times.Never);
     }
 
+    [Theory]
+    [InlineData(CorrespondenceStatus.Initialized)]
+    [InlineData(CorrespondenceStatus.ReadyForPublish)]
+    [InlineData(CorrespondenceStatus.Failed)]
+    public async Task Process_CorrespondenceNotAvailableForRecipient_ReturnsEarlyWithoutCreatingReminder(CorrespondenceStatus status)
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithStatus(status)
+            .Build();
+        _correspondenceRepositoryMock
+            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(correspondence);
+
+        // Act
+        await _handler.Process(correspondenceId, CancellationToken.None);
+
+        // Assert
+        _backgroundJobClientMock.Verify(
+            x => x.Create(It.IsAny<Job>(), It.IsAny<IState>()),
+            Times.Never);
+        _confidentialReminderRepositoryMock.Verify(
+            x => x.AddConfidentialReminder(It.IsAny<ConfidentialReminderEntity>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _dialogportenServiceMock.Verify(
+            x => x.CreateConfidentialReminderDialog(It.IsAny<ConfidentialReminderDialogDto>()),
+            Times.Never);
+    }
+
     [Fact]
     public async Task Process_NoExistingRemindersForRecipient_CreatesNewDialogAndSavesReminder()
     {

--- a/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
+++ b/src/Altinn.Correspondence.Application/UnreadConfidentialCorrespondenceReminder/UnreadConfidentialCorrespondenceReminderHandler.cs
@@ -30,7 +30,8 @@ public class UnreadConfidentialCorrespondenceHandler(
             logger.LogError("Correspondence with id {correspondenceId} not found when processing unread confidential correspondence", correspondenceId);
             return;
         }
-        if (correspondence.StatusHasBeen(CorrespondenceStatus.Read))
+        var latestStatus = correspondence.GetHighestStatus();
+        if (correspondence.StatusHasBeen(CorrespondenceStatus.Read) || !latestStatus.Status.IsAvailableForRecipient())
         {
             return;
         }


### PR DESCRIPTION
## Description
The check to create confidential reminders only checked if the correspondence had been read. An instance has occured in which the correspondence creation failed, which lead to a confidential reminder being created. This should not have happened since the correspondence was never available for the recipient to begin with. Added the availability check so that confidentialReminders are only to be created if the correspondence has not been read and is available for the recipient.

## Related Issue(s)
- #1940 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated unread correspondence reminder logic to properly verify correspondence availability before creating reminders.

* **Tests**
  * Added test coverage for reminder behavior with unavailable correspondence across multiple states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1941)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->