### PR TITLE
Update email regex to new version

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Correspondence.API.Models;
+using Altinn.Correspondence.API.Models;
 using Altinn.Correspondence.API.Models.Enums;
 using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Core.Models.Notifications;
@@ -403,12 +403,12 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithCustomNotificationRecipient(customRecipient)
                 .Build();
 
-            payload.Correspondence.Notification.EmailBody = email != null ? "Test $recipientName$" : null;
+            payload.Correspondence.Notification.EmailBody = email != null ? "Test message" : null;
 
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             var problemDetails = await initResponse.Content.ReadFromJsonAsync<ProblemDetails>(_responseSerializerOptions);
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
-            Assert.Equal(NotificationErrors.CustomRecipientWithNumberOrEmailNotAllowedWithKeyWordRecipientName.Message, problemDetails?.Detail);
+            Assert.Equal(NotificationErrors.InvalidEmailProvided.Message, problemDetails?.Detail);
         }
 
         [Fact]

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -240,29 +240,6 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
-        public async Task Correspondence_CustomRecipient_InvalidEmail_GivesBadRequest()
-        {
-            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
-            var customRecipient = new NotificationRecipientExt()
-            {
-                EmailAddress = "andreas.hammerbeckdigir.no"
-            };
-
-            var payload = new CorrespondenceBuilder()
-                .CreateCorrespondence()
-                .WithRecipients([recipient])
-                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
-                .WithNotificationChannel(NotificationChannelExt.Email)
-                .WithCustomNotificationRecipient(customRecipient)
-                .Build();
-
-            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
-            var problemDetails = await initResponse.Content.ReadFromJsonAsync<ProblemDetails>(_responseSerializerOptions);
-            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
-            Assert.Equal(NotificationErrors.InvalidEmailProvided.Message, problemDetails?.Detail);
-        }
-
-        [Fact]
         public async Task Correspondence_CustomRecipient_InvalidPhoneNumber_GivesBadRequest()
         {
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
@@ -387,10 +364,11 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 
 
         [Theory]
+        [InlineData("andreas.hammerbeckdigir.no")]
         [InlineData("test@example.com;test2@example.com")]
         [InlineData("not-an-email")]
         [InlineData("@nodomain.com")]
-        public async Task Correspondence_CustomRecipient_InvalidEmailFormat_GivesBadRequest(string email)
+        public async Task Correspondence_CustomRecipient_InvalidEmail_GivesBadRequest(string email)
         {
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
             var customRecipient = new NotificationRecipientExt()

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -388,7 +388,9 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 
         [Theory]
         [InlineData("test@example.com;test2@example.com")]
-        public async Task Correspondence_CustomRecipient_WithSemicolonSeparatedEmail_GivesBadRequest(string? email)
+        [InlineData("not-an-email")]
+        [InlineData("@nodomain.com")]
+        public async Task Correspondence_CustomRecipient_InvalidEmailFormat_GivesBadRequest(string email)
         {
             var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
             var customRecipient = new NotificationRecipientExt()
@@ -403,12 +405,32 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                 .WithCustomNotificationRecipient(customRecipient)
                 .Build();
 
-            payload.Correspondence.Notification.EmailBody = email != null ? "Test message" : null;
+            payload.Correspondence.Notification.EmailBody = "Test message";
 
             var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
             var problemDetails = await initResponse.Content.ReadFromJsonAsync<ProblemDetails>(_responseSerializerOptions);
             Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
             Assert.Equal(NotificationErrors.InvalidEmailProvided.Message, problemDetails?.Detail);
+        }
+
+        [Fact]
+        public async Task Correspondence_CustomRecipient_QuotedLocalPartEmail_GivesOk()
+        {
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+            var customRecipient = new NotificationRecipientExt()
+            {
+                EmailAddress = "\"quoted.user\"@example.com"
+            };
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationChannel(NotificationChannelExt.Email)
+                .WithCustomNotificationRecipient(customRecipient)
+                .Build();
+
+            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            Assert.Equal(HttpStatusCode.OK, initResponse.StatusCode);
         }
 
         [Fact]

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceNotificationTests.cs
@@ -385,6 +385,32 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             Assert.Equal(NotificationErrors.CustomRecipientWithNumberOrEmailNotAllowedWithKeyWordRecipientName.Message, problemDetails?.Detail);
         }
 
+
+        [Theory]
+        [InlineData("test@example.com;test2@example.com")]
+        public async Task Correspondence_CustomRecipient_WithSemicolonSeparatedEmail_GivesBadRequest(string? email)
+        {
+            var recipient = $"{UrnConstants.OrganizationNumberAttribute}:991825827";
+            var customRecipient = new NotificationRecipientExt()
+            {
+                EmailAddress = email
+            };
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithRecipients([recipient])
+                .WithNotificationTemplate(NotificationTemplateExt.GenericAltinnMessage)
+                .WithNotificationChannel(NotificationChannelExt.Email)
+                .WithCustomNotificationRecipient(customRecipient)
+                .Build();
+
+            payload.Correspondence.Notification.EmailBody = email != null ? "Test $recipientName$" : null;
+
+            var initResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            var problemDetails = await initResponse.Content.ReadFromJsonAsync<ProblemDetails>(_responseSerializerOptions);
+            Assert.Equal(HttpStatusCode.BadRequest, initResponse.StatusCode);
+            Assert.Equal(NotificationErrors.CustomRecipientWithNumberOrEmailNotAllowedWithKeyWordRecipientName.Message, problemDetails?.Detail);
+        }
+
         [Fact]
         public async Task Correspondence_CustomRecipient_RecipientLookupNull_Returns_Success()
         {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -22,7 +22,7 @@ namespace Altinn.Correspondence.Application.Helpers
         ServiceOwnerHelper serviceOwnerHelper,
         ILogger<InitializeCorrespondenceHelper> logger)
     {
-        private static readonly Regex emailRegex = new Regex(@"((""[^\\""]+"")|(([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))");
+        private static readonly Regex emailRegex = new Regex(@"^((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9æøåÆØÅ!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9æøåÆØÅ!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))$");
 
         public Error? ValidateDateConstraints(CorrespondenceEntity correspondence)
         {
@@ -238,7 +238,7 @@ namespace Altinn.Correspondence.Application.Helpers
             }
 
             // Validate that the email address is valid
-            if (customRecipient.EmailAddress is not null && !emailRegex.IsMatch(customRecipient.EmailAddress))
+            if (customRecipient.EmailAddress is not null && !emailRegex.IsMatch(customRecipient.EmailAddress) && customRecipient.EmailAddress.Split(';').Count() == 1)
             {
                 return NotificationErrors.InvalidEmailProvided;
             }

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -22,7 +22,7 @@ namespace Altinn.Correspondence.Application.Helpers
         ServiceOwnerHelper serviceOwnerHelper,
         ILogger<InitializeCorrespondenceHelper> logger)
     {
-        private static readonly Regex emailRegex = new Regex(@"^((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9æøåÆØÅ!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9æøåÆØÅ!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))$");
+        private static readonly Regex emailRegex = new Regex(@"^((""[^""]+"")|(([a-zA-Z0-9æøåÆØÅ!#$%&'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9æøåÆØÅ!#$%&'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))$");
 
         public Error? ValidateDateConstraints(CorrespondenceEntity correspondence)
         {

--- a/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/InitializeCorrespondenceHelper.cs
@@ -238,7 +238,7 @@ namespace Altinn.Correspondence.Application.Helpers
             }
 
             // Validate that the email address is valid
-            if (customRecipient.EmailAddress is not null && !emailRegex.IsMatch(customRecipient.EmailAddress) && customRecipient.EmailAddress.Split(';').Count() == 1)
+            if (customRecipient.EmailAddress is not null && (!emailRegex.IsMatch(customRecipient.EmailAddress) || customRecipient.EmailAddress.Contains(';')))
             {
                 return NotificationErrors.InvalidEmailProvided;
             }


### PR DESCRIPTION
## Description
We use the same one as Notifications so invalid emails fail quickly at us with a 400 error.
https://github.com/Altinn/altinn-notifications/commit/3bc6f6f84881bcbd9f81fb30d72c4810dd044535
It has been expanded to include semicolon-separated email addresses (that are not supported).

We have not html encoded our email so our regex looks slightly different.

## Related Issue(s)
- #1913 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for custom notification recipient email addresses.

* **Bug Fixes**
  * Updated email validation for custom notification recipients to properly reject semicolon-separated email addresses with appropriate error messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1943)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->