### PR TITLE
Disable automatic retry of queuing job

### DIFF
--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -142,7 +142,7 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
             throw;
         }
     }
-    [DisableConcurrentExecution(timeoutInSeconds: 120)]
+    [AutomaticRetry(Attempts = 0)]
     public async Task<OneOf<MakeCorrespondenceAvailableResponse, Error>> MakeCorrespondenceAvailable(MakeCorrespondenceAvailableRequest request, CancellationToken cancellationToken)
     {
         string? dialogId;
@@ -206,8 +206,6 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
                     "Migration queue has {EnqueuedJobs} jobs (limit {Limit}), rescheduling in 1 minute",
                     enqueuedJobs,
                     migrationQueueLimit);
-
-                JobStorage.Current.GetMonitoringApi().EnqueuedCount(HangfireQueues.LiveMigration);
 
                 backgroundJobClient.Schedule<MigrateCorrespondenceHandler>(
                     HangfireQueues.LiveMigration,

--- a/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/MigrateCorrespondence/MigrateCorrespondenceHandler.cs
@@ -142,7 +142,7 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
             throw;
         }
     }
-
+    [DisableConcurrentExecution(timeoutInSeconds: 120)]
     public async Task<OneOf<MakeCorrespondenceAvailableResponse, Error>> MakeCorrespondenceAvailable(MakeCorrespondenceAvailableRequest request, CancellationToken cancellationToken)
     {
         string? dialogId;
@@ -206,6 +206,8 @@ ILogger<MigrateCorrespondenceHandler> logger) : IHandler<MigrateCorrespondenceRe
                     "Migration queue has {EnqueuedJobs} jobs (limit {Limit}), rescheduling in 1 minute",
                     enqueuedJobs,
                     migrationQueueLimit);
+
+                JobStorage.Current.GetMonitoringApi().EnqueuedCount(HangfireQueues.LiveMigration);
 
                 backgroundJobClient.Schedule<MigrateCorrespondenceHandler>(
                     HangfireQueues.LiveMigration,

--- a/src/Altinn.Correspondence.Core/Options/GeneralSettings.cs
+++ b/src/Altinn.Correspondence.Core/Options/GeneralSettings.cs
@@ -9,7 +9,7 @@ public class GeneralSettings
     public string RedisConnectionString { get; set; } = string.Empty;
     public string ContactReservationRegistryBaseUrl { get; set; } = string.Empty;
     public string ApplicationInsightsConnectionString { get; set; } = string.Empty;
-    public bool DisableTelemetryForMigration { get; set; } = false;
+    public bool DisableTelemetryForMigration { get; set; } = true;
     public bool DisableTelemetryForSync { get; set; } = false;
     public string MalwareScanBypassWhiteList { get; set; } = string.Empty;
     public int MigrationWorkerCountPerReplica { get; set; } = 2;


### PR DESCRIPTION
## Description
Occasionally it would fail on one of the thousand background jobs it created, and retry. This lead to two threads queuing jobs where the second thread enqueued the ones the first had already processed. As our migration jobs are idempotent, this did not lead to duplicates, but we did get slower speed due to all the noops.

The caveat with this approach is that it may fail before a new job is enqueued and stop the job, but the likelihood is much lower and we can just restart it when that happens.

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic retry behavior for correspondence migration operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->