### PR TITLE
filenames over 255 bytes dont appear in zip

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Helpers/AttachmentHelper.cs
+++ b/Test/Altinn.Correspondence.Tests/Helpers/AttachmentHelper.cs
@@ -55,12 +55,16 @@ namespace Altinn.Correspondence.Tests.Helpers
             return attachmentId;
         }
 
-        public async static Task<Guid> GetPublishedAttachment(HttpClient client, JsonSerializerOptions responseSerializerOptions, string? resourceId = null)
+        public async static Task<Guid> GetPublishedAttachment(HttpClient client, JsonSerializerOptions responseSerializerOptions, string? resourceId = null, string? fileName = null)
         {
             var attachmentBuilder = new AttachmentBuilder().CreateAttachment();
             if (resourceId != null)
             {
                 attachmentBuilder.WithResourceId(resourceId);
+            }
+            if (fileName != null)
+            {
+                attachmentBuilder.WithFileName(fileName);
             }
             var attachment = attachmentBuilder.Build();
             var initializeAttachmentResponse = await client.PostAsJsonAsync("correspondence/api/v1/attachment", attachment);

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
@@ -16,6 +16,7 @@ using System.Net.Http.Json;
 using System.Security.Claims;
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.Settings;
+using System.IO.Compression;
 
 namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 {
@@ -858,6 +859,57 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             {
                 Assert.Contains(archive.Entries, e => e.Name.EndsWith(fileType, StringComparison.OrdinalIgnoreCase));
             }
+        }
+
+        [Fact]
+        public async Task DownloadAllCorrespondenceAttachments_WithFileNameOver255Bytes_ReturnsTruncated()
+        {
+            using var customFactory = new UnitWebApplicationFactory((IServiceCollection services) =>
+            {
+                var mockAltinnAuthorization = new Mock<IAltinnAuthorizationService>();
+                mockAltinnAuthorization
+                    .Setup(x => x.CheckAccessAsRecipient(It.IsAny<ClaimsPrincipal?>(), It.IsAny<CorrespondenceEntity>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+                mockAltinnAuthorization
+                    .Setup(x => x.CheckAttachmentAccessAsRecipient(It.IsAny<ClaimsPrincipal?>(), It.IsAny<CorrespondenceEntity>(), It.IsAny<AttachmentEntity>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+
+                var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IAltinnAuthorizationService));
+                if (existing != null) services.Remove(existing);
+                services.AddScoped(_ => mockAltinnAuthorization.Object);
+            });
+
+            var recipientClient = customFactory.CreateClientWithAddedClaims(("notSender", "true"), ("scope", AuthorizationConstants.RecipientScope));
+
+            // Arrange
+            var attachmentId1 = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions, fileName: new string('å', 251) + ".pdf");
+            var attachmentId2 = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions);
+
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithExistingAttachments([attachmentId1, attachmentId2])
+                .Build();
+
+            var initializeResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            initializeResponse.EnsureSuccessStatusCode();
+            var initializeContent = await initializeResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+            var correspondenceId = initializeContent!.Correspondences.First().CorrespondenceId;
+            await CorrespondenceHelper.WaitForCorrespondenceStatusUpdate(_senderClient, _responseSerializerOptions, correspondenceId, CorrespondenceStatusExt.Published);
+
+            // Act
+            var downloadResponse = await recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/attachments/downloadall");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
+            var zipStream = await downloadResponse.Content.ReadAsStreamAsync();
+            using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+
+            Assert.Equal(2, archive.Entries.Count);
+
+            var originalFileName = new string('å', 251) + ".pdf";
+            var truncatedEntry = archive.Entries.FirstOrDefault(e => e.Name != originalFileName && e.Name.EndsWith(".pdf"));
+            Assert.NotNull(truncatedEntry);
+            Assert.True(truncatedEntry!.Name.Length < originalFileName.Length);
         }
 
     }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
@@ -914,5 +914,54 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             Assert.True(Encoding.UTF8.GetByteCount(truncatedEntry.Name) <= 255);
         }
 
+        [Fact]
+        public async Task DownloadAllCorrespondenceAttachments_WithDuplicateFileNames_ReturnsSuffixedEntries()
+        {
+            using var customFactory = new UnitWebApplicationFactory((IServiceCollection services) =>
+            {
+                var mockAltinnAuthorization = new Mock<IAltinnAuthorizationService>();
+                mockAltinnAuthorization
+                    .Setup(x => x.CheckAccessAsRecipient(It.IsAny<ClaimsPrincipal?>(), It.IsAny<CorrespondenceEntity>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+                mockAltinnAuthorization
+                    .Setup(x => x.CheckAttachmentAccessAsRecipient(It.IsAny<ClaimsPrincipal?>(), It.IsAny<CorrespondenceEntity>(), It.IsAny<AttachmentEntity>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+
+                var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IAltinnAuthorizationService));
+                if (existing != null) services.Remove(existing);
+                services.AddScoped(_ => mockAltinnAuthorization.Object);
+            });
+
+            var recipientClient = customFactory.CreateClientWithAddedClaims(("notSender", "true"), ("scope", AuthorizationConstants.RecipientScope));
+
+            // Arrange
+            const string sharedFileName = "duplicate.pdf";
+            var attachmentId1 = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions, fileName: sharedFileName);
+            var attachmentId2 = await AttachmentHelper.GetPublishedAttachment(_senderClient, _responseSerializerOptions, fileName: sharedFileName);
+
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithExistingAttachments([attachmentId1, attachmentId2])
+                .Build();
+
+            var initializeResponse = await _senderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload, _responseSerializerOptions);
+            initializeResponse.EnsureSuccessStatusCode();
+            var initializeContent = await initializeResponse.Content.ReadFromJsonAsync<InitializeCorrespondencesResponseExt>(_responseSerializerOptions);
+            var correspondenceId = initializeContent!.Correspondences.First().CorrespondenceId;
+            await CorrespondenceHelper.WaitForCorrespondenceStatusUpdate(_senderClient, _responseSerializerOptions, correspondenceId, CorrespondenceStatusExt.Published);
+
+            // Act
+            var downloadResponse = await recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/attachments/downloadall");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
+            var zipStream = await downloadResponse.Content.ReadAsStreamAsync();
+            using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+
+            Assert.Equal(2, archive.Entries.Count);
+            Assert.Contains(archive.Entries, e => e.Name == sharedFileName);
+            Assert.Contains(archive.Entries, e => e.Name == "duplicate(1).pdf");
+        }
+
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceAttachmentTests.cs
@@ -17,6 +17,7 @@ using System.Security.Claims;
 using Altinn.Correspondence.Application;
 using Altinn.Correspondence.Application.Settings;
 using System.IO.Compression;
+using System.Text;
 
 namespace Altinn.Correspondence.Tests.TestingController.Correspondence
 {
@@ -910,6 +911,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var truncatedEntry = archive.Entries.FirstOrDefault(e => e.Name != originalFileName && e.Name.EndsWith(".pdf"));
             Assert.NotNull(truncatedEntry);
             Assert.True(truncatedEntry!.Name.Length < originalFileName.Length);
+            Assert.True(Encoding.UTF8.GetByteCount(truncatedEntry.Name) <= 255);
         }
 
     }

--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
@@ -114,19 +114,7 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
                     _logger.LogInformation("Attachment {AttachmentId} in correspondence {CorrespondenceId} has a filename that exceeds the maximum length for zip entries. It will be truncated to fit within the limit.", attachment.Id, request.CorrespondenceId);
                     var ext = Path.GetExtension(originalFileName);
                     var nameWithoutExt = Path.GetFileNameWithoutExtension(originalFileName);
-                    var maxBaseBytes = 255 - Encoding.UTF8.GetByteCount(ext);
-                    var byteCount = 0;
-                    var sb = new StringBuilder();
-                    foreach (var c in nameWithoutExt)
-                    {
-                        var charBytes = Encoding.UTF8.GetByteCount(new[] { c });
-                        if (byteCount + charBytes > maxBaseBytes)
-                            break;
-                        sb.Append(c);
-                        byteCount += charBytes;
-                    }
-                    sb.Append(ext);
-                    zipEntryName = sb.ToString();
+                    zipEntryName = TruncateToUtf8Bytes(nameWithoutExt, 255 - Encoding.UTF8.GetByteCount(ext)) + ext;
                 }
                 var baseName = zipEntryName;
                 var uniqueName = baseName;
@@ -135,7 +123,9 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
                 {
                     var ext = Path.GetExtension(baseName);
                     var nameWithoutExt = Path.GetFileNameWithoutExtension(baseName);
-                    uniqueName = $"{nameWithoutExt}({counter}){ext}";
+                    var suffix = $"({counter})";
+                    var truncatedName = TruncateToUtf8Bytes(nameWithoutExt, 255 - Encoding.UTF8.GetByteCount(ext) - Encoding.UTF8.GetByteCount(suffix));
+                    uniqueName = $"{truncatedName}{suffix}{ext}";
                     counter++;
                 }
                 var entry = archive.CreateEntry(uniqueName);
@@ -179,5 +169,20 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
 
         _logger.LogInformation("Successfully processed download of all attachments for correspondence {CorrespondenceId}", request.CorrespondenceId);
         return new DownloadAllCorrespondenceAttachmentsResponse { Stream = zipStream, zipFileName = attachmentHelper.GetZipFileNameForCorrespondence(correspondence) };
+    }
+
+    private static string TruncateToUtf8Bytes(string text, int maxBytes)
+    {
+        var byteCount = 0;
+        var sb = new StringBuilder();
+        foreach (var c in text)
+        {
+            var charBytes = Encoding.UTF8.GetByteCount(new[] { c });
+            if (byteCount + charBytes > maxBytes)
+                break;
+            sb.Append(c);
+            byteCount += charBytes;
+        }
+        return sb.ToString();
     }
 }

--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
@@ -106,29 +106,29 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
             var usedEntryNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var attachment in attachments)
             {
-                var fileNameBytes = Encoding.UTF8.GetByteCount(attachment.FileName ?? string.Empty);
-                if (fileNameBytes > 255)                {
+                var originalFileName = attachment.FileName ?? attachment.Id.ToString();
+                var zipEntryName = originalFileName;
+                var fileNameBytes = Encoding.UTF8.GetByteCount(originalFileName);
+                if (fileNameBytes > 255)
+                {
                     _logger.LogInformation("Attachment {AttachmentId} in correspondence {CorrespondenceId} has a filename that exceeds the maximum length for zip entries. It will be truncated to fit within the limit.", attachment.Id, request.CorrespondenceId);
-                    var ext = Path.GetExtension(attachment.FileName ?? string.Empty);
-                    var nameWithoutExt = Path.GetFileNameWithoutExtension(attachment.FileName ?? string.Empty);
+                    var ext = Path.GetExtension(originalFileName);
+                    var nameWithoutExt = Path.GetFileNameWithoutExtension(originalFileName);
                     var maxBaseBytes = 255 - Encoding.UTF8.GetByteCount(ext);
-                    
                     var byteCount = 0;
                     var sb = new StringBuilder();
                     foreach (var c in nameWithoutExt)
                     {
                         var charBytes = Encoding.UTF8.GetByteCount(new[] { c });
                         if (byteCount + charBytes > maxBaseBytes)
-                        {
                             break;
-                        }
                         sb.Append(c);
                         byteCount += charBytes;
                     }
                     sb.Append(ext);
-                    attachment.FileName = sb.ToString();
+                    zipEntryName = sb.ToString();
                 }
-                var baseName = attachment.FileName ?? attachment.Id.ToString();
+                var baseName = zipEntryName;
                 var uniqueName = baseName;
                 var counter = 1;
                 while (!usedEntryNames.Add(uniqueName))

--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Security.Claims;
+using System.Text;
 using Altinn.Correspondence.Application.Helpers;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
@@ -105,6 +106,28 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
             var usedEntryNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var attachment in attachments)
             {
+                var fileNameBytes = Encoding.UTF8.GetByteCount(attachment.FileName ?? string.Empty);
+                if (fileNameBytes > 255)                {
+                    _logger.LogInformation("Attachment {AttachmentId} in correspondence {CorrespondenceId} has a filename that exceeds the maximum length for zip entries. It will be truncated to fit within the limit.", attachment.Id, request.CorrespondenceId);
+                    var ext = Path.GetExtension(attachment.FileName ?? string.Empty);
+                    var nameWithoutExt = Path.GetFileNameWithoutExtension(attachment.FileName ?? string.Empty);
+                    var maxBaseBytes = 255 - Encoding.UTF8.GetByteCount(ext);
+                    
+                    var byteCount = 0;
+                    var sb = new StringBuilder();
+                    foreach (var c in nameWithoutExt)
+                    {
+                        var charBytes = Encoding.UTF8.GetByteCount(new[] { c });
+                        if (byteCount + charBytes > maxBaseBytes)
+                        {
+                            break;
+                        }
+                        sb.Append(c);
+                        byteCount += charBytes;
+                    }
+                    sb.Append(ext);
+                    attachment.FileName = sb.ToString();
+                }
                 var baseName = attachment.FileName ?? attachment.Id.ToString();
                 var uniqueName = baseName;
                 var counter = 1;


### PR DESCRIPTION
## Description
When using the download all functionality if an attachment has a fileName which exceeds 255 bytes filesystems are not able to handle this appropriately and as a consequence it is not included in the zip-file which the user downloads.

Handle this by trimming the length of the fileName when downloading to the maximum number of characters + file extension while still staying under 255 bytes.

## Related Issue(s)
- #1948
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved handling of attachment filenames exceeding 255 bytes when downloading all correspondence attachments. Long filenames are now automatically truncated while preserving file extensions.

* **Tests**
  * Added integration test to verify proper truncation of filenames during bulk attachment downloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->