### PR TITLE
Fix correct actorid on Read/Confirm Activities in CreateDialog for Migrated Correspondence

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Altinn.Correspondence.Common.Constants;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Options;
@@ -62,6 +63,7 @@ public class DialogportenServiceTests
         var mockResourceRegistryService = new Mock<IResourceRegistryService>();
         var mockCorrespondenceForwardingEventRepository = new Mock<ICorrespondenceForwardingEventRepository>();
         var mockAltinnRegisterService = new Mock<IAltinnRegisterService>();
+        var mockPartyUrnHelper = new Mock<Core.Services.PartyUrnHelper>(mockAltinnRegisterService.Object, Mock.Of<ILogger<Core.Services.PartyUrnHelper>>());
         var options = Options.Create(new GeneralSettings { CorrespondenceBaseUrl = "https://correspondence.example" });
 
         var service = new DialogportenService(httpClient,
@@ -71,7 +73,8 @@ public class DialogportenServiceTests
                                               options,
                                               mockLogger.Object,
                                               mockIdem.Object,
-                                              mockResourceRegistryService.Object);
+                                              mockResourceRegistryService.Object,
+                                              mockPartyUrnHelper.Object);
         return (service, () => capturedRequestBody);
     }
 
@@ -119,6 +122,8 @@ public class DialogportenServiceTests
         var mockResourceRegistryService = new Mock<IResourceRegistryService>();
         var mockCorrespondenceForwardingEventRepository = new Mock<ICorrespondenceForwardingEventRepository>();
         var mockAltinnRegisterService = new Mock<IAltinnRegisterService>();
+        var mockPartyUrnHelperLogger = new Mock<ILogger<Core.Services.PartyUrnHelper>>();
+        var mockPartyUrnHelper = new Mock<Core.Services.PartyUrnHelper>(mockAltinnRegisterService.Object, mockPartyUrnHelperLogger.Object);
         var options = Options.Create(new GeneralSettings { CorrespondenceBaseUrl = "https://correspondence.example" });
 
         // Setup forwarding event repository to track DialogActivityId assignments
@@ -133,7 +138,8 @@ public class DialogportenServiceTests
                                               options,
                                               mockLogger.Object,
                                               mockIdem.Object,
-                                              mockResourceRegistryService.Object);
+                                              mockResourceRegistryService.Object,
+                                              mockPartyUrnHelper.Object);
         return (service, mockCorrespondenceForwardingEventRepository, mockAltinnRegisterService, () => capturedRequestBody);
     }
 
@@ -629,5 +635,219 @@ public class DialogportenServiceTests
 
         Assert.NotNull(forwardingActivity);
         Assert.Equal(existingDialogActivityId.ToString(), forwardingActivity!.Id);
+    }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialogForMigratedCorrespondence_WithReadStatus_ShouldUsePersonActorIdNotOrganization()
+    {
+        // Arrange - Reproduces Issue #1951
+        var correspondenceId = Guid.NewGuid();
+        var personPartyUuid = new Guid("b96ca314-021d-49b8-a267-376d55acd01f");
+        var readTimestamp = new DateTimeOffset(new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc));
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithRecipient($"{UrnConstants.OrganizationNumberAttribute}:910000001") // Fabricated test organization
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow)
+            .Build();
+
+        // Add Read status with correct PartyUuid
+        correspondence.Statuses.Add(new CorrespondenceStatusEntity
+        {
+            Status = CorrespondenceStatus.Read,
+            StatusChanged = readTimestamp,
+            PartyUuid = personPartyUuid
+        });
+
+        var (service, forwardingRepoMock, altinnRegisterMock, getBody) = CreateServiceWithForwardingEventSupport(correspondence);
+
+        // Setup party lookup to return the person who actually performed the read action
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(personPartyUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = personPartyUuid,
+                SSN = "12345678901",
+                PartyTypeName = PartyType.Person,
+                Name = "Test Person"
+            });
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialogForMigratedCorrespondence(correspondenceId, correspondence);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+
+        var capturedRequestBody = getBody();
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.Activities);
+
+        // Find the Read activity
+        var readActivity = deserialized.Activities.FirstOrDefault(a => a.Type == "CorrespondenceOpened");
+
+        Assert.NotNull(readActivity);
+        Assert.Equal("PartyRepresentative", readActivity!.PerformedBy.ActorType);
+
+        // ActorId should be the person URN, NOT the organization URN
+        Assert.Contains("urn:altinn:person:identifier-no:12345678901", readActivity.PerformedBy.ActorId);
+        Assert.DoesNotContain("urn:altinn:organizationnumber:910000001", readActivity.PerformedBy.ActorId);
+    }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialogForMigratedCorrespondence_WithConfirmedStatus_ShouldUsePersonActorIdNotOrganization()
+    {
+        // Arrange - Reproduces Issue #1951
+        var correspondenceId = Guid.NewGuid();
+        var personPartyUuid = new Guid("b96ca314-021d-49b8-a267-376d55acd01f");
+        var readTimestamp = new DateTimeOffset(new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc));
+        var confirmTimestamp = new DateTimeOffset(new DateTime(2024, 1, 15, 10, 35, 0, DateTimeKind.Utc));
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithRecipient($"{UrnConstants.OrganizationNumberAttribute}:910000001") // Fabricated test organization
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow)
+            .Build();
+
+        correspondence.IsConfirmationNeeded = true;
+
+        // Add Read and Confirmed statuses with correct PartyUuids
+        correspondence.Statuses.Add(new CorrespondenceStatusEntity
+        {
+            Status = CorrespondenceStatus.Read,
+            StatusChanged = readTimestamp,
+            PartyUuid = personPartyUuid
+        });
+        correspondence.Statuses.Add(new CorrespondenceStatusEntity
+        {
+            Status = CorrespondenceStatus.Confirmed,
+            StatusChanged = confirmTimestamp,
+            PartyUuid = personPartyUuid
+        });
+
+        var (service, forwardingRepoMock, altinnRegisterMock, getBody) = CreateServiceWithForwardingEventSupport(correspondence);
+
+        // Setup party lookup
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(personPartyUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = personPartyUuid,
+                SSN = "12345678901",
+                PartyTypeName = PartyType.Person,
+                Name = "Test Person"
+            });
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialogForMigratedCorrespondence(correspondenceId, correspondence);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+
+        var capturedRequestBody = getBody();
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.Activities);
+
+        // Find the Confirmed activity
+        var confirmedActivity = deserialized.Activities.FirstOrDefault(a => a.Type == "CorrespondenceConfirmed");
+
+        Assert.NotNull(confirmedActivity);
+        Assert.Equal("PartyRepresentative", confirmedActivity!.PerformedBy.ActorType);
+
+        // ActorId should be the person URN, NOT the organization URN
+        Assert.Contains("urn:altinn:person:identifier-no:12345678901", confirmedActivity.PerformedBy.ActorId);
+        Assert.DoesNotContain("urn:altinn:organizationnumber:910000001", confirmedActivity.PerformedBy.ActorId);
+    }
+
+    [Fact]
+    public async Task CreateCorrespondenceDialogForMigratedCorrespondence_WithBothReadAndConfirmedStatus_ShouldUseCorrectActorForEach()
+    {
+        // Arrange - Test case where different persons read and confirmed
+        var correspondenceId = Guid.NewGuid();
+        var personWhoReadUuid = new Guid("b96ca314-021d-49b8-a267-376d55acd01f");
+        var personWhoConfirmedUuid = new Guid("c86ea314-021d-49b8-a267-376d55acd02a");
+        var readTimestamp = new DateTimeOffset(new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc));
+        var confirmTimestamp = new DateTimeOffset(new DateTime(2024, 1, 15, 11, 00, 0, DateTimeKind.Utc));
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithRecipient($"{UrnConstants.OrganizationNumberAttribute}:910000001") // Fabricated test organization
+            .WithStatus(CorrespondenceStatus.Published, DateTimeOffset.UtcNow)
+            .Build();
+
+        correspondence.IsConfirmationNeeded = true;
+
+        // Add Read and Confirmed statuses with different PartyUuids
+        correspondence.Statuses.Add(new CorrespondenceStatusEntity
+        {
+            Status = CorrespondenceStatus.Read,
+            StatusChanged = readTimestamp,
+            PartyUuid = personWhoReadUuid
+        });
+        correspondence.Statuses.Add(new CorrespondenceStatusEntity
+        {
+            Status = CorrespondenceStatus.Confirmed,
+            StatusChanged = confirmTimestamp,
+            PartyUuid = personWhoConfirmedUuid
+        });
+
+        var (service, forwardingRepoMock, altinnRegisterMock, getBody) = CreateServiceWithForwardingEventSupport(correspondence);
+
+        // Setup party lookups for both persons
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(personWhoReadUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = personWhoReadUuid,
+                SSN = "11111111111",
+                PartyTypeName = PartyType.Person,
+                Name = "Person One"
+            });
+
+        altinnRegisterMock
+            .Setup(a => a.LookUpPartyByPartyUuid(personWhoConfirmedUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Party
+            {
+                PartyUuid = personWhoConfirmedUuid,
+                SSN = "22222222222",
+                PartyTypeName = PartyType.Person,
+                Name = "Person Two"
+            });
+
+        // Act
+        var resultId = await service.CreateCorrespondenceDialogForMigratedCorrespondence(correspondenceId, correspondence);
+
+        // Assert
+        Assert.Equal("dialog-id", resultId);
+
+        var capturedRequestBody = getBody();
+        var deserialized = JsonSerializer.Deserialize<CreateDialogRequest>(capturedRequestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.Activities);
+
+        var readActivity = deserialized.Activities.FirstOrDefault(a => a.Type == "CorrespondenceOpened");
+        var confirmedActivity = deserialized.Activities.FirstOrDefault(a => a.Type == "CorrespondenceConfirmed");
+
+        Assert.NotNull(readActivity);
+        Assert.NotNull(confirmedActivity);
+
+        // Verify read activity uses the person who read
+        Assert.Contains("urn:altinn:person:identifier-no:11111111111", readActivity!.PerformedBy.ActorId);
+
+        // Verify confirmed activity uses the person who confirmed
+        Assert.Contains("urn:altinn:person:identifier-no:22222222222", confirmedActivity!.PerformedBy.ActorId);
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/MigrateCorrespondenceHandlerTests.cs
@@ -75,6 +75,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 _idempotencyKeyRepositoryMock.Object,
                 new Mock<ILogger<PurgeCorrespondenceHelper>>().Object);
 
+            var mockPartyUrnHelper = new Mock<Core.Services.PartyUrnHelper>(_altinnRegisterServiceMock.Object, Mock.Of<ILogger<Core.Services.PartyUrnHelper>>());
+
             var correspondenceEventHelper = new CorrespondenceMigrationEventHelper(
                 _correspondenceStatusRepositoryMock.Object,
                 _correspondenceDeleteRepositoryMock.Object,
@@ -84,6 +86,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 purgeCorrespondenceHelper,
                 _idempotencyKeyRepositoryMock.Object,
                 _backgroundJobClientMock.Object,
+                mockPartyUrnHelper.Object,
                 _eventHelperLoggerMock.Object);
 
             // Ensure Create returns a non-null job id by default (needed for continuations)

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceForwardingEventRequestTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceForwardingEventRequestTests.cs
@@ -61,6 +61,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 _idempotencyKeyRepositoryMock.Object,
                 _purgeLoggerMock.Object);
 
+            var mockPartyUrnHelper = new Mock<Core.Services.PartyUrnHelper>(_altinnRegisterServiceMock.Object, Mock.Of<ILogger<Core.Services.PartyUrnHelper>>());
+
             var correspondenceMigrationEventHelper = new CorrespondenceMigrationEventHelper(
                 _correspondenceStatusRepositoryMock.Object,
                 _correspondenceDeleteRepositoryMock.Object,
@@ -70,6 +72,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 purgeCorrespondenceHelper,
                 _idempotencyKeyRepositoryMock.Object,
                 _backgroundJobClientMock.Object,
+                mockPartyUrnHelper.Object,
                 _eventHelperLoggerMock.Object);
 
             _handler = new SyncCorrespondenceForwardingEventHandler(

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceNotificationEventHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceNotificationEventHandlerTests.cs
@@ -62,6 +62,8 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 _idempotencyKeyRepositoryMock.Object,
                 _purgeLoggerMock.Object);
 
+            var mockPartyUrnHelper = new Mock<Core.Services.PartyUrnHelper>(_altinnRegisterServiceMock.Object, Mock.Of<ILogger<Core.Services.PartyUrnHelper>>());
+
             var correspondenceMigrationEventHelper = new CorrespondenceMigrationEventHelper(
                 _correspondenceStatusRepositoryMock.Object,
                 _correspondenceDeleteRepositoryMock.Object,
@@ -71,6 +73,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 purgeCorrespondenceHelper,
                 _idempotencyKeyRepositoryMock.Object,
                 _backgroundJobClientMock.Object,
+                mockPartyUrnHelper.Object,
                 _eventHelperLoggerMock.Object);
 
             _handler = new SyncCorrespondenceNotificationEventHandler(

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
@@ -71,6 +71,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 _correspondenceRepositoryMock.Object,
                 _idempotencyKeyRepositoryMock.Object,
                 new Mock<ILogger<PurgeCorrespondenceHelper>>().Object);
+            var mockPartyUrnHelper = new Mock<Core.Services.PartyUrnHelper>(_altinnRegisterServiceMock.Object, Mock.Of<ILogger<Core.Services.PartyUrnHelper>>());
             var correspondenceEventHelper = new CorrespondenceMigrationEventHelper(
                 _correspondenceStatusRepositoryMock.Object,
                 _correspondenceDeleteEventRepositoryMock.Object,
@@ -80,6 +81,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 _purgeHelper,
                 _idempotencyKeyRepositoryMock.Object,
                 _backgroundJobClientMock.Object,
+                mockPartyUrnHelper.Object,
                 new Mock<ILogger<CorrespondenceMigrationEventHelper>>().Object);
             _loggerMock = new Mock<ILogger<SyncCorrespondenceStatusEventHandler>>();
 

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SyncCorrespondenceStatusEventHandlerTests.cs
@@ -7,14 +7,12 @@ using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
-using Altinn.Correspondence.Integrations.Hangfire;
 using Altinn.Correspondence.Tests.Factories;
 using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
 using Microsoft.Extensions.Logging;
 using Moq;
-using ReverseMarkdown.Converters;
 
 namespace Altinn.Correspondence.Tests.TestingHandler
 {
@@ -71,7 +69,9 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 _correspondenceRepositoryMock.Object,
                 _idempotencyKeyRepositoryMock.Object,
                 new Mock<ILogger<PurgeCorrespondenceHelper>>().Object);
-            var mockPartyUrnHelper = new Mock<Core.Services.PartyUrnHelper>(_altinnRegisterServiceMock.Object, Mock.Of<ILogger<Core.Services.PartyUrnHelper>>());
+            var _partyUrnHelper = new Core.Services.PartyUrnHelper(
+                _altinnRegisterServiceMock.Object,
+                new Mock<ILogger<Core.Services.PartyUrnHelper>>().Object);
             var correspondenceEventHelper = new CorrespondenceMigrationEventHelper(
                 _correspondenceStatusRepositoryMock.Object,
                 _correspondenceDeleteEventRepositoryMock.Object,
@@ -81,7 +81,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 _purgeHelper,
                 _idempotencyKeyRepositoryMock.Object,
                 _backgroundJobClientMock.Object,
-                mockPartyUrnHelper.Object,
+                _partyUrnHelper,
                 new Mock<ILogger<CorrespondenceMigrationEventHelper>>().Object);
             _loggerMock = new Mock<ILogger<SyncCorrespondenceStatusEventHandler>>();
 

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -38,6 +38,7 @@ using Altinn.Correspondence.Application.GetUnreadConfidentialCorrespondences;
 using Altinn.Correspondence.Application.UnreadConfidentialCorrespondence;
 using Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
 using Altinn.Correspondence.Application.DownloadAllCorrespondenceAttachments;
+using Altinn.Correspondence.Core.Services;
 
 namespace Altinn.Correspondence.Application;
 
@@ -102,6 +103,7 @@ public static class DependencyInjection
         services.AddScoped<NotificationMapper>();
         services.AddScoped<CorrespondenceMigrationEventHelper>();
         services.AddScoped<InitializeCorrespondenceValidationHelper>();
+        services.AddScoped<PartyUrnHelper>();
 
         // Legacy
         services.AddScoped<LegacyGetCorrespondencesHandler>();

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceMigrationEventHelper.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceMigrationEventHelper.cs
@@ -28,11 +28,12 @@ public class CorrespondenceMigrationEventHelper(
     PurgeCorrespondenceHelper purgeCorrespondenceHelper,
     IIdempotencyKeyRepository idempotencyKeyRepository,
     IBackgroundJobClient backgroundJobClient,
+    PartyUrnHelper partyUrnHelper,
     ILogger<CorrespondenceMigrationEventHelper> logger)
 {
-    private static readonly CorrespondenceStatus[] _validSyncStatuses = { CorrespondenceStatus.Read, CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived };    
+    private static readonly CorrespondenceStatus[] _validSyncStatuses = { CorrespondenceStatus.Read, CorrespondenceStatus.Confirmed, CorrespondenceStatus.Archived };
 
-    public async Task<bool> ProcessStatusEvent(Guid correspondenceId, CorrespondenceEntity correspondence, Dictionary<Guid, string> enduserIdByPartyUuid, CorrespondenceStatusEntity eventToExecute, MigrationOperationType operationName, CancellationToken cancellationToken)
+    public async Task<bool> ProcessStatusEvent(Guid correspondenceId, CorrespondenceEntity correspondence, Dictionary<Guid, string> actorIdByPartyUuid, CorrespondenceStatusEntity eventToExecute, MigrationOperationType operationName, CancellationToken cancellationToken)
     {
         logger.LogDebug("Process {OperationName} status event {Status} for {CorrespondenceId}", operationName, eventToExecute.Status, correspondenceId);
         
@@ -74,13 +75,13 @@ public class CorrespondenceMigrationEventHelper(
                     case CorrespondenceStatus.Confirmed:
                         {
                             var patchJobId = backgroundJobClient.Enqueue<IDialogportenService>(HangfireQueues.LiveMigration, (dialogportenService) => dialogportenService.PatchCorrespondenceDialogToConfirmed(correspondenceId, CancellationToken.None));
-                            if (!enduserIdByPartyUuid.TryGetValue(eventToExecute.PartyUuid, out var endUserId))
+                            if (!actorIdByPartyUuid.TryGetValue(eventToExecute.PartyUuid, out var actorId))
                             {
-                                logger.LogWarning("Skipping updating dialog for Confirm for correspondence {CorrespondenceId} at {StatusChanged} due to missing Dialogporten enduserId for party {PartyUuid}.", correspondence.Id, eventToExecute.StatusChanged, eventToExecute.PartyUuid);
+                                logger.LogWarning("Skipping updating dialog for Confirm for correspondence {CorrespondenceId} at {StatusChanged} due to missing Dialogporten actorId for party {PartyUuid}.", correspondence.Id, eventToExecute.StatusChanged, eventToExecute.PartyUuid);
                             }
                             else
                             {
-                                backgroundJobClient.ContinueJobWith<IDialogportenService>(parentId: patchJobId, queue: HangfireQueues.LiveMigration, methodCall: (dialogportenService) => dialogportenService.CreateConfirmedActivity(correspondenceId, DialogportenActorType.Recipient, eventToExecute.StatusChanged, endUserId), options: JobContinuationOptions.OnlyOnSucceededState); // Set the operationtime to the time the status was changed in Altinn 2                            
+                                backgroundJobClient.ContinueJobWith<IDialogportenService>(parentId: patchJobId, queue: HangfireQueues.LiveMigration, methodCall: (dialogportenService) => dialogportenService.CreateConfirmedActivity(correspondenceId, DialogportenActorType.Recipient, eventToExecute.StatusChanged, actorId), options: JobContinuationOptions.OnlyOnSucceededState); // Set the operationtime to the time the status was changed in Altinn 2                            
                             }                        
                             backgroundJobClient.Enqueue<IEventBus>(HangfireQueues.LiveMigration, (eventBus) => eventBus.Publish(AltinnEventType.CorrespondenceReceiverConfirmed, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, CancellationToken.None));
                             break;
@@ -88,14 +89,14 @@ public class CorrespondenceMigrationEventHelper(
 
                     case CorrespondenceStatus.Read:
                         {
-                        
-                            if (!enduserIdByPartyUuid.TryGetValue(eventToExecute.PartyUuid, out var endUserId))
+
+                            if (!actorIdByPartyUuid.TryGetValue(eventToExecute.PartyUuid, out var actorId))
                             {
-                                logger.LogWarning("Skipping updating dialog for Read for correspondence {CorrespondenceId} at {StatusChanged} due to missing Dialogporten enduserId for party {PartyUuid}.", correspondence.Id, eventToExecute.StatusChanged, eventToExecute.PartyUuid);
+                                logger.LogWarning("Skipping updating dialog for Read for correspondence {CorrespondenceId} at {StatusChanged} due to missing Dialogporten actorId for party {PartyUuid}.", correspondence.Id, eventToExecute.StatusChanged, eventToExecute.PartyUuid);
                             }
                             else
                             {
-                                backgroundJobClient.Enqueue<IDialogportenService>(HangfireQueues.LiveMigration, (dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, eventToExecute.StatusChanged, endUserId));
+                                backgroundJobClient.Enqueue<IDialogportenService>(HangfireQueues.LiveMigration, (dialogportenService) => dialogportenService.CreateOpenedActivity(correspondence.Id, DialogportenActorType.Recipient, eventToExecute.StatusChanged, actorId));
                             }
                             backgroundJobClient.Enqueue<IEventBus>(HangfireQueues.LiveMigration, (eventBus) => eventBus.Publish(AltinnEventType.CorrespondenceReceiverRead, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, CancellationToken.None));
                             break;
@@ -103,13 +104,13 @@ public class CorrespondenceMigrationEventHelper(
 
                     case CorrespondenceStatus.Archived:
                         {
-                            if (!enduserIdByPartyUuid.TryGetValue(eventToExecute.PartyUuid, out var endUserId))
+                            if (!actorIdByPartyUuid.TryGetValue(eventToExecute.PartyUuid, out var actorId))
                             {
-                                logger.LogWarning("Skipping updating dialog for Archived for correspondence {CorrespondenceId} at {StatusChanged} due to missing Dialogporten enduserId for party {PartyUuid}.", correspondence.Id, eventToExecute.StatusChanged, eventToExecute.PartyUuid);
+                                logger.LogWarning("Skipping updating dialog for Archived for correspondence {CorrespondenceId} at {StatusChanged} due to missing Dialogporten actorId for party {PartyUuid}.", correspondence.Id, eventToExecute.StatusChanged, eventToExecute.PartyUuid);
                             }
                             else
                             {
-                                backgroundJobClient.Enqueue<IDialogportenService>(HangfireQueues.LiveMigration, service => service.UpdateSystemLabelsOnDialog(correspondence.Id, endUserId, DialogportenActorType.PartyRepresentative, new List<DialogPortenSystemLabel> { DialogPortenSystemLabel.Archive }, null));
+                                backgroundJobClient.Enqueue<IDialogportenService>(HangfireQueues.LiveMigration, service => service.UpdateSystemLabelsOnDialog(correspondence.Id, actorId, DialogportenActorType.PartyRepresentative, new List<DialogPortenSystemLabel> { DialogPortenSystemLabel.Archive }, null));
                             }                        
                             break;
                         }
@@ -131,7 +132,7 @@ public class CorrespondenceMigrationEventHelper(
         }
     }
 
-    public async Task<bool> ProcessDeleteEvent(Guid correspondenceId, CorrespondenceEntity correspondence, Dictionary<Guid, string> enduserIdByPartyUuid, CorrespondenceDeleteEventEntity deletionEvent, MigrationOperationType operationName, CancellationToken cancellationToken)
+    public async Task<bool> ProcessDeleteEvent(Guid correspondenceId, CorrespondenceEntity correspondence, Dictionary<Guid, string> actorIdByPartyUuid, CorrespondenceDeleteEventEntity deletionEvent, MigrationOperationType operationName, CancellationToken cancellationToken)
     {
         logger.LogDebug("Process {OperationName} delete event {EventType} for {CorrespondenceId}", operationName, deletionEvent.EventType, correspondenceId);
 
@@ -141,8 +142,8 @@ public class CorrespondenceMigrationEventHelper(
             case CorrespondenceDeleteEventType.HardDeletedByRecipient:
                 if (ValidatePerformPurge(correspondence))
                 {
-                    enduserIdByPartyUuid.TryGetValue(deletionEvent.PartyUuid, out var endUserId);
-                    return await PurgeCorrespondence(correspondence, deletionEvent, operationName, cancellationToken, endUserId);
+                    actorIdByPartyUuid.TryGetValue(deletionEvent.PartyUuid, out var actorId);
+                    return await PurgeCorrespondence(correspondence, deletionEvent, operationName, cancellationToken, actorId);
                 }
                 else
                 {
@@ -150,7 +151,7 @@ public class CorrespondenceMigrationEventHelper(
                 }
             case CorrespondenceDeleteEventType.SoftDeletedByRecipient:
             case CorrespondenceDeleteEventType.RestoredByRecipient:
-                return await SoftDeleteOrRestoreCorrespondence(correspondence, deletionEvent, enduserIdByPartyUuid, cancellationToken);                
+                return await SoftDeleteOrRestoreCorrespondence(correspondence, deletionEvent, actorIdByPartyUuid, cancellationToken);
             default:
                 throw new ArgumentException($"Unknown Deletion Event Type {deletionEvent.EventType} for Correspondence {correspondenceId}");
         }
@@ -242,45 +243,9 @@ public class CorrespondenceMigrationEventHelper(
         return filteredStatusEvents;
     }
 
-    public async Task<Dictionary<Guid, string>> GetDialogPortenEndUserIdsForEvents(List<CorrespondenceStatusEntity>? statusEventsToExecute, List<CorrespondenceDeleteEventEntity>? deletionEventsToExecute, CancellationToken cancellationToken)
+    public async Task<Dictionary<Guid, string>> GetDialogPortenActorIdsForEvents(List<CorrespondenceStatusEntity>? statusEventsToExecute, List<CorrespondenceDeleteEventEntity>? deletionEventsToExecute, CancellationToken cancellationToken)
     {
-        var enduserIdByPartyUuid = new Dictionary<Guid, string>();
-        
-        var partyUuidsToLookup = (statusEventsToExecute ?? Enumerable.Empty<CorrespondenceStatusEntity>())            
-            .Select(e => e.PartyUuid)
-            .Distinct();
-
-        partyUuidsToLookup = partyUuidsToLookup
-           .Concat((deletionEventsToExecute ?? Enumerable.Empty<CorrespondenceDeleteEventEntity>())               
-               .Select(e => e.PartyUuid))
-           .Distinct(); // Handles all duplicates
-        
-        foreach (var uuid in partyUuidsToLookup)
-        {
-            var party = await altinnRegisterService.LookUpPartyByPartyUuid(uuid, cancellationToken);
-            if (party is null)
-            {
-                logger.LogWarning("Party with UUID {PartyUuid} not found in Altinn Register. Skipping Dialogporten mapping, which may lead to issues later on.", uuid);
-                continue;
-            }
-            switch (party.PartyTypeName)
-            {
-                case PartyType.Person:
-                    enduserIdByPartyUuid[uuid] = $"{UrnConstants.PersonIdAttribute}:{party.SSN}";
-                    break;
-                case PartyType.Organization:
-                    enduserIdByPartyUuid[uuid] = $"{UrnConstants.OrganizationNumberAttribute}:{party.OrgNumber}";
-                    break;
-                case PartyType.SelfIdentified:
-                    enduserIdByPartyUuid[uuid] = $"{UrnConstants.PersonLegacySelfIdentifiedAttribute}:{party.Username}";
-                    break;
-                default:
-                    logger.LogWarning("Party with UUID {PartyUuid} has unsupported PartyType {PartyTypeName}. Cannot map to Dialogporten enduserId.", uuid, party.PartyTypeName);
-                    break;
-            }
-        }
-
-        return enduserIdByPartyUuid;
+        return await partyUrnHelper.GetDialogPortenActorIdsForEvents(statusEventsToExecute, deletionEventsToExecute, cancellationToken);
     }
 
     /// <summary>
@@ -410,7 +375,7 @@ public class CorrespondenceMigrationEventHelper(
         }
     }
 
-    public async Task<bool> SoftDeleteOrRestoreCorrespondence(CorrespondenceEntity correspondence, CorrespondenceDeleteEventEntity deleteEventToSync, Dictionary<Guid, string> enduserIdByPartyUuid, CancellationToken cancellationToken)
+    public async Task<bool> SoftDeleteOrRestoreCorrespondence(CorrespondenceEntity correspondence, CorrespondenceDeleteEventEntity deleteEventToSync, Dictionary<Guid, string> actorIdByPartyUuid, CancellationToken cancellationToken)
     {
         if (CorrespondenceDeleteEventType.SoftDeletedByRecipient != deleteEventToSync.EventType && CorrespondenceDeleteEventType.RestoredByRecipient != deleteEventToSync.EventType)
         {
@@ -442,15 +407,15 @@ public class CorrespondenceMigrationEventHelper(
                 {
                     logger.LogWarning("Skipping updating dialog for {EventType} for correspondence {CorrespondenceId} at {EventOccurred} due to the Correspondence being purged.", deleteEventToSync.EventType, correspondence.Id, deleteEventToSync.EventOccurred);
                 }
-                else if (!enduserIdByPartyUuid.TryGetValue(deleteEventToSync.PartyUuid, out var endUserId))
+                else if (!actorIdByPartyUuid.TryGetValue(deleteEventToSync.PartyUuid, out var actorId))
                 {
-                    logger.LogWarning("Skipping updating dialog for {EventType} for correspondence {CorrespondenceId} at {EventOccurred} due to missing Dialogporten enduserId for party {PartyUuid}.", deleteEventToSync.EventType, correspondence.Id, deleteEventToSync.EventOccurred, deleteEventToSync.PartyUuid);
+                    logger.LogWarning("Skipping updating dialog for {EventType} for correspondence {CorrespondenceId} at {EventOccurred} due to missing Dialogporten actorId for party {PartyUuid}.", deleteEventToSync.EventType, correspondence.Id, deleteEventToSync.EventOccurred, deleteEventToSync.PartyUuid);
                 }
                 else
                 {
                     // Enqueue SoftDelete or Restore in Dialogporten
                     bool isArchived = correspondence.StatusHasBeen(CorrespondenceStatus.Archived);
-                    SetSoftDeleteOrRestoreOnDialog(correspondence.Id, endUserId, deleteEventToSync.EventType, isArchived);
+                    SetSoftDeleteOrRestoreOnDialog(correspondence.Id, actorId, deleteEventToSync.EventType, isArchived);
                 }
             }
             
@@ -793,8 +758,8 @@ public class CorrespondenceMigrationEventHelper(
         MigrationOperationType operationName,
         CancellationToken cancellationToken)
     {
-        // Get dialog porten end user IDs for the events that need them
-        var enduserIdsByPartyUuids = await GetDialogPortenEndUserIdsForEvents(statusEvents, deleteEvents, cancellationToken);
+        // Get dialog porten actor IDs for the events that need them
+        var actorIdsByPartyUuids = await GetDialogPortenActorIdsForEvents(statusEvents, deleteEvents, cancellationToken);
 
         // After filtering both collections, combine them into a single sorted collection, sorted by timestamp they occurred
         var allEventsToProcess = statusEvents
@@ -817,11 +782,11 @@ public class CorrespondenceMigrationEventHelper(
                 bool wasSaved = false;
                 if (evt.EventType == "Status")
                 {
-                    wasSaved = await ProcessStatusEvent(correspondenceId, correspondence, enduserIdsByPartyUuids, (CorrespondenceStatusEntity)evt.Event, operationName, cancellationToken);
+                    wasSaved = await ProcessStatusEvent(correspondenceId, correspondence, actorIdsByPartyUuids, (CorrespondenceStatusEntity)evt.Event, operationName, cancellationToken);
                 }
                 else if (evt.EventType == "Delete")
                 {
-                    wasSaved = await ProcessDeleteEvent(correspondenceId, correspondence, enduserIdsByPartyUuids, (CorrespondenceDeleteEventEntity)evt.Event, operationName, cancellationToken);
+                    wasSaved = await ProcessDeleteEvent(correspondenceId, correspondence, actorIdsByPartyUuids, (CorrespondenceDeleteEventEntity)evt.Event, operationName, cancellationToken);
                 }
 
                 if (wasSaved)

--- a/src/Altinn.Correspondence.Core/Services/PartyUrnHelper.cs
+++ b/src/Altinn.Correspondence.Core/Services/PartyUrnHelper.cs
@@ -25,7 +25,7 @@ public class PartyUrnHelper
     /// </summary>
     /// <param name="party">The party to convert</param>
     /// <returns>URN string in format "urn:altinn:person:identifier-no:123..." or similar</returns>
-    /// <exception cref="ArgumentException">If party type is not supported</exception>
+    /// <exception cref="ArgumentException">If party type is not supported or required identifier is missing</exception>
     public string ConvertPartyToUrn(Party party)
     {
         if (party is null)
@@ -35,9 +35,15 @@ public class PartyUrnHelper
 
         return party.PartyTypeName switch
         {
-            PartyType.Person => $"{UrnConstants.PersonIdAttribute}:{party.SSN}",
-            PartyType.Organization => $"{UrnConstants.OrganizationNumberAttribute}:{party.OrgNumber}",
-            PartyType.SelfIdentified => $"{UrnConstants.PersonLegacySelfIdentifiedAttribute}:{party.Username}",
+            PartyType.Person => string.IsNullOrEmpty(party.SSN)
+                ? throw new ArgumentException($"Party of type {party.PartyTypeName} is missing required SSN field", nameof(party))
+                : $"{UrnConstants.PersonIdAttribute}:{party.SSN}",
+            PartyType.Organization => string.IsNullOrEmpty(party.OrgNumber)
+                ? throw new ArgumentException($"Party of type {party.PartyTypeName} is missing required OrgNumber field", nameof(party))
+                : $"{UrnConstants.OrganizationNumberAttribute}:{party.OrgNumber}",
+            PartyType.SelfIdentified => string.IsNullOrEmpty(party.Username)
+                ? throw new ArgumentException($"Party of type {party.PartyTypeName} is missing required Username field", nameof(party))
+                : $"{UrnConstants.PersonLegacySelfIdentifiedAttribute}:{party.Username}",
             _ => throw new ArgumentException($"Unsupported party type: {party.PartyTypeName}", nameof(party))
         };
     }

--- a/src/Altinn.Correspondence.Core/Services/PartyUrnHelper.cs
+++ b/src/Altinn.Correspondence.Core/Services/PartyUrnHelper.cs
@@ -1,0 +1,134 @@
+using Altinn.Correspondence.Common.Constants;
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.Correspondence.Core.Services;
+
+/// <summary>
+/// Helper class for converting Party entities to Dialogporten-compatible URN strings.
+/// Centralizes the logic for party URN conversion to avoid duplication across the codebase.
+/// </summary>
+public class PartyUrnHelper
+{
+    private readonly IAltinnRegisterService _altinnRegisterService;
+    private readonly ILogger<PartyUrnHelper> _logger;
+
+    public PartyUrnHelper(IAltinnRegisterService altinnRegisterService, ILogger<PartyUrnHelper> logger)
+    {
+        _altinnRegisterService = altinnRegisterService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Converts a Party entity to a Dialogporten-compatible URN string.
+    /// </summary>
+    /// <param name="party">The party to convert</param>
+    /// <returns>URN string in format "urn:altinn:person:identifier-no:123..." or similar</returns>
+    /// <exception cref="ArgumentException">If party type is not supported</exception>
+    public string ConvertPartyToUrn(Party party)
+    {
+        if (party is null)
+        {
+            throw new ArgumentNullException(nameof(party));
+        }
+
+        return party.PartyTypeName switch
+        {
+            PartyType.Person => $"{UrnConstants.PersonIdAttribute}:{party.SSN}",
+            PartyType.Organization => $"{UrnConstants.OrganizationNumberAttribute}:{party.OrgNumber}",
+            PartyType.SelfIdentified => $"{UrnConstants.PersonLegacySelfIdentifiedAttribute}:{party.Username}",
+            _ => throw new ArgumentException($"Unsupported party type: {party.PartyTypeName}", nameof(party))
+        };
+    }
+
+    /// <summary>
+    /// Looks up a party by PartyUuid and converts it to a Dialogporten-compatible URN string.
+    /// Returns null if party is not found.
+    /// </summary>
+    /// <param name="partyUuid">The PartyUuid to lookup</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>URN string or null if party not found</returns>
+    public async Task<string?> GetPartyUrnByUuid(Guid partyUuid, CancellationToken cancellationToken)
+    {
+        var party = await _altinnRegisterService.LookUpPartyByPartyUuid(partyUuid, cancellationToken);
+        if (party is null)
+        {
+            _logger.LogWarning("Party with UUID {PartyUuid} not found in Altinn Register", partyUuid);
+            return null;
+        }
+
+        try
+        {
+            return ConvertPartyToUrn(party);
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogWarning(ex, "Failed to convert party {PartyUuid} with type {PartyType} to URN", partyUuid, party.PartyTypeName);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Looks up multiple parties by their PartyUuids and returns a dictionary mapping PartyUuid to URN.
+    /// Parties that cannot be found or converted are logged and skipped.
+    /// </summary>
+    /// <param name="partyUuids">Collection of PartyUuids to lookup</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Dictionary mapping PartyUuid to URN string</returns>
+    public async Task<Dictionary<Guid, string>> GetPartyUrnsByUuids(IEnumerable<Guid> partyUuids, CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<Guid, string>();
+        var distinctUuids = partyUuids.Distinct().ToList();
+
+        foreach (var uuid in distinctUuids)
+        {
+            var urn = await GetPartyUrnByUuid(uuid, cancellationToken);
+            if (urn != null)
+            {
+                result[uuid] = urn;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets Dialogporten actor IDs for status events.
+    /// Looks up parties for Read and Confirmed status events and converts them to URNs.
+    /// </summary>
+    /// <param name="statusEvents">List of status events</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Dictionary mapping PartyUuid to URN string</returns>
+    public async Task<Dictionary<Guid, string>> GetDialogPortenActorIdsForStatusEvents(List<CorrespondenceStatusEntity> statusEvents, CancellationToken cancellationToken)
+    {
+        var partyUuidsToLookup = statusEvents
+            .Where(e => e.Status == CorrespondenceStatus.Read || e.Status == CorrespondenceStatus.Confirmed)
+            .Select(e => e.PartyUuid)
+            .Distinct();
+
+        return await GetPartyUrnsByUuids(partyUuidsToLookup, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets Dialogporten actor IDs for status and deletion events.
+    /// Combines PartyUuids from both event types and looks them up.
+    /// </summary>
+    /// <param name="statusEventsToExecute">List of status events</param>
+    /// <param name="deletionEventsToExecute">List of deletion events</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Dictionary mapping PartyUuid to URN string</returns>
+    public async Task<Dictionary<Guid, string>> GetDialogPortenActorIdsForEvents(
+        List<CorrespondenceStatusEntity>? statusEventsToExecute,
+        List<CorrespondenceDeleteEventEntity>? deletionEventsToExecute,
+        CancellationToken cancellationToken)
+    {
+        var partyUuidsToLookup = (statusEventsToExecute ?? Enumerable.Empty<CorrespondenceStatusEntity>())
+            .Select(e => e.PartyUuid)
+            .Concat((deletionEventsToExecute ?? Enumerable.Empty<CorrespondenceDeleteEventEntity>())
+                .Select(e => e.PartyUuid))
+            .Distinct();
+
+        return await GetPartyUrnsByUuids(partyUuidsToLookup, cancellationToken);
+    }
+}

--- a/src/Altinn.Correspondence.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Integrations/DependencyInjection.cs
@@ -39,6 +39,7 @@ public static class DependencyInjection
         services.AddSingleton<IMaskinportenTokenService, MaskinportenTokenService>();
         services.AddSingleton<IKeyVaultSecretStore, KeyVaultSecretStore>();
         services.AddSingleton<IContainerAppRefreshService, AzureContainerAppRefreshService>();
+        services.AddScoped<PartyUrnHelper>();
 
         if (string.IsNullOrWhiteSpace(maskinportenSettings.ClientId))
         {

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -27,7 +27,8 @@ public class DialogportenService(HttpClient _httpClient,
                                  IOptions<GeneralSettings> generalSettings,
                                  ILogger<DialogportenService> logger,
                                  IIdempotencyKeyRepository _idempotencyKeyRepository,
-                                 IResourceRegistryService _resourceRegistryService) : IDialogportenService
+                                 IResourceRegistryService _resourceRegistryService,
+                                 PartyUrnHelper partyUrnHelper) : IDialogportenService
 {
     public async Task<string> CreateCorrespondenceDialog(Guid correspondenceId)
     {
@@ -890,7 +891,13 @@ public class DialogportenService(HttpClient _httpClient,
     }
 
 
-    #region MigrationRelated    
+    #region MigrationRelated
+   
+    private async Task<Dictionary<Guid, string>> GetDialogPortenActorIdsForStatusEvents(List<CorrespondenceStatusEntity> statusEvents, CancellationToken cancellationToken)
+    {
+        return await partyUrnHelper.GetDialogPortenActorIdsForStatusEvents(statusEvents, cancellationToken);
+    }
+
     /// <summary>
     /// Create Dialog in Dialogportern without creating any events. Used in regards to old correspondences being migrated from Altinn 2 to Altinn 3.
     /// </summary>
@@ -913,6 +920,9 @@ public class DialogportenService(HttpClient _httpClient,
 
         var forwardingActivities = await BuildForwardingActivities(correspondence, cancellationToken);
 
+        // Get party URNs for status events (Read and Confirmed) to use correct actor IDs
+        var partyUrnsByPartyUuid = await GetDialogPortenActorIdsForStatusEvents(correspondence.Statuses, cancellationToken);
+
         var createDialogRequest = CreateDialogRequestMapper.CreateCorrespondenceDialog(
             correspondence: correspondence,
             baseUrl: generalSettings.Value.CorrespondenceBaseUrl,
@@ -923,7 +933,8 @@ public class DialogportenService(HttpClient _httpClient,
             isSoftDeleted: isSoftDeleted,
             dialogParty: dialogParty,
             forwardingActivities: forwardingActivities,
-            enableDownloadAll: generalSettings.Value.EnableDownloadAll);
+            enableDownloadAll: generalSettings.Value.EnableDownloadAll,
+            partyUrnsByPartyUuid: partyUrnsByPartyUuid);
         string updateType = enableEvents ? "" : "?IsSilentUpdate=true";
         var response = await _httpClient.PostAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs{updateType}", createDialogRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
@@ -1174,12 +1185,9 @@ public class DialogportenService(HttpClient _httpClient,
         }
 
         string? forwardedByUrn;
-        if (forwardedByParty.PartyTypeName == PartyType.Person)
+        if (forwardedByParty.PartyTypeName == PartyType.SelfIdentified)
         {
-            forwardedByUrn = UrnConstants.PersonIdAttribute + ":" + forwardedByParty.SSN;
-        }
-        else if (forwardedByParty.PartyTypeName == PartyType.SelfIdentified)
-        {
+            // Special handling for self-identified users in dialog activities
             forwardedByUrn = await GetDialogActivityParty(forwardedByParty.ExternalUrn);
             if (string.IsNullOrWhiteSpace(forwardedByUrn))
             {
@@ -1188,7 +1196,15 @@ public class DialogportenService(HttpClient _httpClient,
         }
         else
         {
-            throw new Exception($"Unsupported party type {forwardedByParty.PartyTypeName} for ForwardedByPartyUuid {forwardingEvent.ForwardedByPartyUuid} in forwarding event {forwardingEvent.Id}");
+            // Use the common helper for Person and Organization types
+            try
+            {
+                forwardedByUrn = partyUrnHelper.ConvertPartyToUrn(forwardedByParty);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new Exception($"Unsupported party type {forwardedByParty.PartyTypeName} for ForwardedByPartyUuid {forwardingEvent.ForwardedByPartyUuid} in forwarding event {forwardingEvent.Id}", ex);
+            }
         }
 
         // Determine forwarding type and create appropriate activity

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -309,13 +309,13 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             var readStatus = orderedStatuses.FirstOrDefault(s => s.Status == CorrespondenceStatus.Read);
             if (readStatus != null && !string.IsNullOrWhiteSpace(openedActivityIdempotencyKey))
             {
-                activities.Add(GetActivityFromStatus(correspondence, readStatus, openedActivityIdempotencyKey, dialogParty, partyUrnsByPartyUuid));
+                activities.Add(GetActivityFromStatus(correspondence, readStatus, partyUrnsByPartyUuid, openedActivityIdempotencyKey));
             }
 
             var confirmedStatus = orderedStatuses.FirstOrDefault(s => s.Status == CorrespondenceStatus.Confirmed);
             if (confirmedStatus != null && !string.IsNullOrWhiteSpace(confirmedActivityIdempotencyKey))
             {
-                activities.Add(GetActivityFromStatus(correspondence, confirmedStatus, confirmedActivityIdempotencyKey, dialogParty, partyUrnsByPartyUuid));
+                activities.Add(GetActivityFromStatus(correspondence, confirmedStatus, partyUrnsByPartyUuid, confirmedActivityIdempotencyKey));
             }
 
             activities.AddRange(GetActivitiesFromNotifications(correspondence));
@@ -328,19 +328,20 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             return activities.OrderBy(a => a.CreatedAt).ToList();
         }
 
-        private static Activity GetActivityFromStatus(CorrespondenceEntity correspondence, CorrespondenceStatusEntity status, string? activityId = null, string? dialogParty = null, Dictionary<Guid, string>? partyUrnsByPartyUuid = null)
+        private static Activity GetActivityFromStatus(CorrespondenceEntity correspondence, CorrespondenceStatusEntity status, Dictionary<Guid, string> partyUrnsByPartyUuid, string? activityId = null)
         {
             bool isConfirmation = status.Status == CorrespondenceStatus.Confirmed;
 
             Activity activity = new Activity();
             activity.Id = string.IsNullOrWhiteSpace(activityId) ? Uuid.NewDatabaseFriendly(Database.PostgreSql).ToString() : activityId;
 
-            // Use the actual person who performed the action from the lookup dictionary
-            // Fall back to dialogParty/recipient if not found (shouldn't happen for migrated data with correct PartyUuid)
-            string actorId = dialogParty ?? correspondence.GetRecipientUrn();
-            if (partyUrnsByPartyUuid != null && partyUrnsByPartyUuid.TryGetValue(status.PartyUuid, out var partyUrn))
+            // Look up the correct actor URN for the party who performed this action
+            if (!partyUrnsByPartyUuid.TryGetValue(status.PartyUuid, out var actorId))
             {
-                actorId = partyUrn;
+                throw new InvalidOperationException(
+                    $"Failed to find party URN for PartyUuid {status.PartyUuid} in activity for correspondence {correspondence.Id}. " +
+                    $"Status: {status.Status}, StatusChanged: {status.StatusChanged}. " +
+                    "This indicates a data inconsistency - the party should have been looked up before creating the dialog.");
             }
 
             activity.PerformedBy = new PerformedBy()

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -61,7 +61,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 ApiActions = GetApiActionsForCorrespondence(baseUrl, correspondence),
                 GuiActions = GetGuiActionsForCorrespondence(baseUrl, correspondence),
                 Attachments = GetAttachmentsForCorrespondence(baseUrl, correspondence, enableDownloadAll),
-                Activities = includeActivities ? GetActivitiesForMigratedCorrespondence(correspondence, openedActivityIdempotencyKey, confirmedActivityIdempotencyKey, dialogParty, forwardingActivities, partyUrnsByPartyUuid) : new List<Activity>(),
+                Activities = includeActivities ? GetActivitiesForMigratedCorrespondence(correspondence, partyUrnsByPartyUuid!, openedActivityIdempotencyKey, confirmedActivityIdempotencyKey, forwardingActivities) : new List<Activity>(), // Only happens for Migrated Correspondences, and we only want to include activities for those, as they are used to backfill the activity history in Dialogporten.
                 Transmissions = new List<Transmission>(),
                 SystemLabel = GetSystemLabelForCorrespondence(correspondence, isSoftDeleted),
                 ServiceOwnerContext = GetServiceOwnerContextForCorrespondence(correspondence)
@@ -301,7 +301,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
         }
 
 
-        private static List<Activity> GetActivitiesForMigratedCorrespondence(CorrespondenceEntity correspondence, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, string? dialogParty = null, List<Activity>? forwardingActivities = null, Dictionary<Guid, string>? partyUrnsByPartyUuid = null)
+        private static List<Activity> GetActivitiesForMigratedCorrespondence(CorrespondenceEntity correspondence, Dictionary<Guid, string> partyUrnsByPartyUuid, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, List<Activity>? forwardingActivities = null)
         {
             List<Activity> activities = new();
             var orderedStatuses = correspondence.Statuses.OrderBy(s => s.StatusChanged);

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -21,7 +21,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
     internal static class CreateDialogRequestMapper
     {
-        internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl, bool includeActivities = false, ILogger? logger = null, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, bool isSoftDeleted = false, DateTimeOffset? currentUtcNow = null, string? dialogParty = null, List<Activity>? forwardingActivities = null, bool enableDownloadAll = false)
+        internal static CreateDialogRequest CreateCorrespondenceDialog(CorrespondenceEntity correspondence, string baseUrl, bool includeActivities = false, ILogger? logger = null, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, bool isSoftDeleted = false, DateTimeOffset? currentUtcNow = null, string? dialogParty = null, List<Activity>? forwardingActivities = null, bool enableDownloadAll = false, Dictionary<Guid, string>? partyUrnsByPartyUuid = null)
         {
             DateTimeOffset currentDateTimeUtcNow = currentUtcNow ?? DateTimeOffset.UtcNow;
             var dialogId = GetDialogId(correspondence, currentDateTimeUtcNow, logger);
@@ -61,7 +61,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 ApiActions = GetApiActionsForCorrespondence(baseUrl, correspondence),
                 GuiActions = GetGuiActionsForCorrespondence(baseUrl, correspondence),
                 Attachments = GetAttachmentsForCorrespondence(baseUrl, correspondence, enableDownloadAll),
-                Activities = includeActivities ? GetActivitiesForMigratedCorrespondence(correspondence, openedActivityIdempotencyKey, confirmedActivityIdempotencyKey, dialogParty, forwardingActivities) : new List<Activity>(),
+                Activities = includeActivities ? GetActivitiesForMigratedCorrespondence(correspondence, openedActivityIdempotencyKey, confirmedActivityIdempotencyKey, dialogParty, forwardingActivities, partyUrnsByPartyUuid) : new List<Activity>(),
                 Transmissions = new List<Transmission>(),
                 SystemLabel = GetSystemLabelForCorrespondence(correspondence, isSoftDeleted),
                 ServiceOwnerContext = GetServiceOwnerContextForCorrespondence(correspondence)
@@ -301,7 +301,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
         }
 
 
-        private static List<Activity> GetActivitiesForMigratedCorrespondence(CorrespondenceEntity correspondence, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, string? dialogParty = null, List<Activity>? forwardingActivities = null)
+        private static List<Activity> GetActivitiesForMigratedCorrespondence(CorrespondenceEntity correspondence, string? openedActivityIdempotencyKey = null, string? confirmedActivityIdempotencyKey = null, string? dialogParty = null, List<Activity>? forwardingActivities = null, Dictionary<Guid, string>? partyUrnsByPartyUuid = null)
         {
             List<Activity> activities = new();
             var orderedStatuses = correspondence.Statuses.OrderBy(s => s.StatusChanged);
@@ -309,13 +309,13 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             var readStatus = orderedStatuses.FirstOrDefault(s => s.Status == CorrespondenceStatus.Read);
             if (readStatus != null && !string.IsNullOrWhiteSpace(openedActivityIdempotencyKey))
             {
-                activities.Add(GetActivityFromStatus(correspondence, readStatus, openedActivityIdempotencyKey, dialogParty));
+                activities.Add(GetActivityFromStatus(correspondence, readStatus, openedActivityIdempotencyKey, dialogParty, partyUrnsByPartyUuid));
             }
 
             var confirmedStatus = orderedStatuses.FirstOrDefault(s => s.Status == CorrespondenceStatus.Confirmed);
             if (confirmedStatus != null && !string.IsNullOrWhiteSpace(confirmedActivityIdempotencyKey))
             {
-                activities.Add(GetActivityFromStatus(correspondence, confirmedStatus, confirmedActivityIdempotencyKey, dialogParty));
+                activities.Add(GetActivityFromStatus(correspondence, confirmedStatus, confirmedActivityIdempotencyKey, dialogParty, partyUrnsByPartyUuid));
             }
 
             activities.AddRange(GetActivitiesFromNotifications(correspondence));
@@ -328,15 +328,24 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
             return activities.OrderBy(a => a.CreatedAt).ToList();
         }
 
-        private static Activity GetActivityFromStatus(CorrespondenceEntity correspondence, CorrespondenceStatusEntity status, string? activityId = null, string? dialogParty = null)
+        private static Activity GetActivityFromStatus(CorrespondenceEntity correspondence, CorrespondenceStatusEntity status, string? activityId = null, string? dialogParty = null, Dictionary<Guid, string>? partyUrnsByPartyUuid = null)
         {
             bool isConfirmation = status.Status == CorrespondenceStatus.Confirmed;
 
             Activity activity = new Activity();
             activity.Id = string.IsNullOrWhiteSpace(activityId) ? Uuid.NewDatabaseFriendly(Database.PostgreSql).ToString() : activityId;
+
+            // Use the actual person who performed the action from the lookup dictionary
+            // Fall back to dialogParty/recipient if not found (shouldn't happen for migrated data with correct PartyUuid)
+            string actorId = dialogParty ?? correspondence.GetRecipientUrn();
+            if (partyUrnsByPartyUuid != null && partyUrnsByPartyUuid.TryGetValue(status.PartyUuid, out var partyUrn))
+            {
+                actorId = partyUrn;
+            }
+
             activity.PerformedBy = new PerformedBy()
             {
-                ActorId = dialogParty ?? correspondence.GetRecipientUrn(),
+                ActorId = actorId,
                 ActorType = "PartyRepresentative"
             };
             activity.CreatedAt = status.StatusChanged;


### PR DESCRIPTION
Fixed invalid handling of Parties for Status Events during dialog creation by adding party lookup/urn mapping per-event instead of using the recipient party for all events.

## Description
Also moved the party lookup and urn mapping to a separate helper to re-use code for Migration and sync.

## Related Issue(s)
- #1951 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialog activities for migrated correspondence now use person actor identifiers for Read and Confirmed statuses.

* **Bug Fixes**
  * Dialog updates now skip when corresponding actor identifiers are unavailable, preventing incorrect actor assignments.

* **Tests**
  * Added tests to verify actor identifier selection for dialog activities across status, forwarding, migration, and deletion scenarios.

* **Chores**
  * Centralized party-to-URN resolution and adjusted dependency wiring for more reliable identifier lookup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->