### PR TITLE
legacy doesnt delete confidential reminder

### DIFF
--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -218,6 +218,10 @@ public class GetCorrespondenceOverviewHandler(
                     await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(correspondence.Id, cancellationToken);
                 }
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception e)
             {
                 logger.LogError(e, "Failed to clean up confidential reminder for correspondence {CorrespondenceId}", correspondence.Id);

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -200,20 +200,27 @@ public class GetCorrespondenceOverviewHandler(
             logger.LogInformation("Successfully retrieved overview for correspondence {CorrespondenceId} with status {Status}", 
                 request.CorrespondenceId, 
                 latestStatus.Status);
-            if (correspondence.IsConfidential 
-                && hasAccessAsRecipient 
-                && !(user?.CallingAsSender() ?? false) 
-                && await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken))
+            try
             {
-                if (await confidentialReminderRepository.NumberOfRemindersForRecipient(correspondence.Recipient, cancellationToken) == 1)
+                if (correspondence.IsConfidential 
+                    && hasAccessAsRecipient 
+                    && !(user?.CallingAsSender() ?? false) 
+                    && await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken))
                 {
-                    var reminderDialogId = await confidentialReminderRepository.GetDialogIdOfReminderForRecipient(correspondence.Recipient, cancellationToken);
-                    if (reminderDialogId.HasValue)
+                    if (await confidentialReminderRepository.NumberOfRemindersForRecipient(correspondence.Recipient, cancellationToken) == 1)
                     {
-                        await dialogportenService.TrySoftDeleteDialog(reminderDialogId.Value.ToString());
+                        var reminderDialogId = await confidentialReminderRepository.GetDialogIdOfReminderForRecipient(correspondence.Recipient, cancellationToken);
+                        if (reminderDialogId.HasValue)
+                        {
+                            await dialogportenService.TrySoftDeleteDialog(reminderDialogId.Value.ToString());
+                        }
                     }
+                    await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(correspondence.Id, cancellationToken);
                 }
-                await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(correspondence.Id, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed to clean up confidential reminder for correspondence {CorrespondenceId}", correspondence.Id);
             }
             return response;
         }, logger, cancellationToken);

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -160,7 +160,7 @@ public class LegacyGetCorrespondenceOverviewHandler(
             logger.LogInformation("Successfully retrieved overview for correspondence {CorrespondenceId} for party {PartyId}", correspondence.Id, partyId);
             logger.LogInformation("IsConfidential: {IsConfidential}. Has access as recipient: {HasAccessAsRecipient}. Calling as sender: {CallingAsSender}. Has confidential reminder: {HasConfidentialReminder}", correspondence.IsConfidential, await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken), user?.CallingAsSender() ?? false, await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken));
             if (correspondence.IsConfidential 
-                && await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken) == false
+                && await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken)
                 && !(user?.CallingAsSender() ?? false) 
                 && await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken))
             {

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -17,6 +17,8 @@ public class LegacyGetCorrespondenceOverviewHandler(
     IAltinnRegisterService altinnRegisterService,
     ICorrespondenceRepository correspondenceRepository,
     ICorrespondenceStatusRepository correspondenceStatusRepository,
+    IConfidentialReminderRepository confidentialReminderRepository,
+    IDialogportenService dialogportenService,
     UserClaimsHelper userClaimsHelper,
     IBackgroundJobClient backgroundJobClient,
     ILogger<LegacyGetCorrespondenceOverviewHandler> logger) : IHandler<Guid, LegacyGetCorrespondenceOverviewResponse>
@@ -154,6 +156,22 @@ public class LegacyGetCorrespondenceOverviewHandler(
                 PropertyList = correspondence.PropertyList ?? new Dictionary<string, string>(),
                 InstanceOwnerPartyId = resourceOwnerParty.PartyId
             };
+
+            if (correspondence.IsConfidential 
+                && await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken) == false
+                && !(user?.CallingAsSender() ?? false) 
+                && await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken))
+            {
+                if (await confidentialReminderRepository.NumberOfRemindersForRecipient(correspondence.Recipient, cancellationToken) == 1)
+                {
+                    var reminderDialogId = await confidentialReminderRepository.GetDialogIdOfReminderForRecipient(correspondence.Recipient, cancellationToken);
+                    if (reminderDialogId.HasValue)
+                    {
+                        await dialogportenService.TrySoftDeleteDialog(reminderDialogId.Value.ToString());
+                    }
+                }
+                await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(correspondence.Id, cancellationToken);
+            }
             return response;
         }, logger, cancellationToken);
     }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -157,20 +157,27 @@ public class LegacyGetCorrespondenceOverviewHandler(
                 InstanceOwnerPartyId = resourceOwnerParty.PartyId
             };
 
-            if (correspondence.IsConfidential 
-                && await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken)
-                && !(user?.CallingAsSender() ?? false) 
-                && await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken))
+            try
             {
-                if (await confidentialReminderRepository.NumberOfRemindersForRecipient(correspondence.Recipient, cancellationToken) == 1)
+                if (correspondence.IsConfidential 
+                    && await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken)
+                    && !(user?.CallingAsSender() ?? false) 
+                    && await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken))
                 {
-                    var reminderDialogId = await confidentialReminderRepository.GetDialogIdOfReminderForRecipient(correspondence.Recipient, cancellationToken);
-                    if (reminderDialogId.HasValue)
+                    if (await confidentialReminderRepository.NumberOfRemindersForRecipient(correspondence.Recipient, cancellationToken) == 1)
                     {
-                        await dialogportenService.TrySoftDeleteDialog(reminderDialogId.Value.ToString());
+                        var reminderDialogId = await confidentialReminderRepository.GetDialogIdOfReminderForRecipient(correspondence.Recipient, cancellationToken);
+                        if (reminderDialogId.HasValue)
+                        {
+                            await dialogportenService.TrySoftDeleteDialog(reminderDialogId.Value.ToString());
+                        }
                     }
+                    await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(correspondence.Id, cancellationToken);
                 }
-                await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(correspondence.Id, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed to clean up confidential reminder for correspondence {CorrespondenceId}", correspondence.Id);
             }
             return response;
         }, logger, cancellationToken);

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -157,26 +157,20 @@ public class LegacyGetCorrespondenceOverviewHandler(
                 InstanceOwnerPartyId = resourceOwnerParty.PartyId
             };
 
-            logger.LogInformation("Successfully retrieved overview for correspondence {CorrespondenceId} for party {PartyId}", correspondence.Id, partyId);
-            logger.LogInformation("IsConfidential: {IsConfidential}. Has access as recipient: {HasAccessAsRecipient}. Calling as sender: {CallingAsSender}. Has confidential reminder: {HasConfidentialReminder}", correspondence.IsConfidential, await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken), user?.CallingAsSender() ?? false, await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken));
             if (correspondence.IsConfidential 
                 && await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken)
                 && !(user?.CallingAsSender() ?? false) 
                 && await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken))
             {
-                logger.LogInformation("Processing confidential reminder for correspondence {CorrespondenceId} for party {PartyId}", correspondence.Id, partyId);
                 if (await confidentialReminderRepository.NumberOfRemindersForRecipient(correspondence.Recipient, cancellationToken) == 1)
                 {
                     var reminderDialogId = await confidentialReminderRepository.GetDialogIdOfReminderForRecipient(correspondence.Recipient, cancellationToken);
                     if (reminderDialogId.HasValue)
                     {
-                        logger.LogInformation("Soft deleting dialog {DialogId} for confidential reminder for party {PartyId}", reminderDialogId.Value, partyId);
                         await dialogportenService.TrySoftDeleteDialog(reminderDialogId.Value.ToString());
-                        logger.LogInformation("Soft deleted dialog {DialogId} for confidential reminder for party {PartyId}", reminderDialogId.Value, partyId);
                     }
                 }
                 await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(correspondence.Id, cancellationToken);
-                logger.LogInformation("Removed confidential reminder for correspondence {CorrespondenceId} for party {PartyId}", correspondence.Id, partyId);
             }
             return response;
         }, logger, cancellationToken);

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -158,6 +158,7 @@ public class LegacyGetCorrespondenceOverviewHandler(
             };
 
             logger.LogInformation("Successfully retrieved overview for correspondence {CorrespondenceId} for party {PartyId}", correspondence.Id, partyId);
+            logger.LogInformation("IsConfidential: {IsConfidential}. Has access as recipient: {HasAccessAsRecipient}. Calling as sender: {CallingAsSender}. Has confidential reminder: {HasConfidentialReminder}", correspondence.IsConfidential, await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken), user?.CallingAsSender() ?? false, await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken));
             if (correspondence.IsConfidential 
                 && await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken) == false
                 && !(user?.CallingAsSender() ?? false) 

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -175,6 +175,10 @@ public class LegacyGetCorrespondenceOverviewHandler(
                     await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(correspondence.Id, cancellationToken);
                 }
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception e)
             {
                 logger.LogError(e, "Failed to clean up confidential reminder for correspondence {CorrespondenceId}", correspondence.Id);

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/LegacyGetCorrespondenceOverviewHandler.cs
@@ -157,20 +157,25 @@ public class LegacyGetCorrespondenceOverviewHandler(
                 InstanceOwnerPartyId = resourceOwnerParty.PartyId
             };
 
+            logger.LogInformation("Successfully retrieved overview for correspondence {CorrespondenceId} for party {PartyId}", correspondence.Id, partyId);
             if (correspondence.IsConfidential 
                 && await altinnAuthorizationService.CheckAccessAsRecipient(user, correspondence, cancellationToken) == false
                 && !(user?.CallingAsSender() ?? false) 
                 && await confidentialReminderRepository.CorrespondenceHasReminder(correspondence.Id, cancellationToken))
             {
+                logger.LogInformation("Processing confidential reminder for correspondence {CorrespondenceId} for party {PartyId}", correspondence.Id, partyId);
                 if (await confidentialReminderRepository.NumberOfRemindersForRecipient(correspondence.Recipient, cancellationToken) == 1)
                 {
                     var reminderDialogId = await confidentialReminderRepository.GetDialogIdOfReminderForRecipient(correspondence.Recipient, cancellationToken);
                     if (reminderDialogId.HasValue)
                     {
+                        logger.LogInformation("Soft deleting dialog {DialogId} for confidential reminder for party {PartyId}", reminderDialogId.Value, partyId);
                         await dialogportenService.TrySoftDeleteDialog(reminderDialogId.Value.ToString());
+                        logger.LogInformation("Soft deleted dialog {DialogId} for confidential reminder for party {PartyId}", reminderDialogId.Value, partyId);
                     }
                 }
                 await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(correspondence.Id, cancellationToken);
+                logger.LogInformation("Removed confidential reminder for correspondence {CorrespondenceId} for party {PartyId}", correspondence.Id, partyId);
             }
             return response;
         }, logger, cancellationToken);


### PR DESCRIPTION
## Description
Confidential correspondences opened in A2 did not previously have the logic to remove confidentialReminders. Added logic to mirror A3.

## Related Issue(s)
- #1945 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of confidential reminders when viewing confidential correspondence: reminders (and an associated dialog link when exactly one recipient reminder exists) are now removed when conditions are met. Cleanup runs inside the existing overview flow and any failures are caught and logged so overview retrieval continues uninterrupted; genuine cancellation still propagates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->