### PR TITLE
Only check role when IsConfidential is set

### DIFF
--- a/src/Altinn.Correspondence.Application/ApplicationConstants.cs
+++ b/src/Altinn.Correspondence.Application/ApplicationConstants.cs
@@ -40,19 +40,6 @@ public static class ApplicationConstants
         ".gif",
         ".bmp"
     ];
-    public static readonly List<string> RequiredOrganizationRolesForCorrespondenceRecipient = 
-    [
-        "bestyrende-reder",
-        "daglig-leder",
-        "deltaker-delt-ansvar",
-        "deltaker-fullt-ansvar",
-        "innehaver",
-        "styreleder",
-        "komplementar",
-        "bostyrer",
-        "kontaktperson-ados",
-        "norsk-representant",
-    ];
 
     public static readonly List<string> RequiredOrganizationRolesForConfidentialCorrespondenceRecipient = 
     [

--- a/src/Altinn.Correspondence.Application/Helpers/AltinnRegisterServiceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/AltinnRegisterServiceExtensions.cs
@@ -6,26 +6,22 @@ namespace Altinn.Correspondence.Application.Helpers
 {
     public static class AltinnRegisterServiceExtensions
     {
-        public static async Task<bool> HasRequiredOrganizationRoles(this IAltinnRegisterService altinnRegisterService, string partyUuid, bool isConfidential, CancellationToken cancellationToken)
+        public static async Task<bool> HasRequiredOrganizationRoles(this IAltinnRegisterService altinnRegisterService, string partyUuid, CancellationToken cancellationToken)
         {
             var roles = await altinnRegisterService.LookUpPartyRoles(partyUuid, cancellationToken);
-            if (isConfidential)
-            {
-                return roles.Any(r => ApplicationConstants.RequiredOrganizationRolesForConfidentialCorrespondenceRecipient.Contains(r.Role.Identifier));
-            }
-            return roles.Any(r => ApplicationConstants.RequiredOrganizationRolesForCorrespondenceRecipient.Contains(r.Role.Identifier));
+            return roles.Any(r => ApplicationConstants.RequiredOrganizationRolesForConfidentialCorrespondenceRecipient.Contains(r.Role.Identifier));
         }
 
-        public static async Task<bool> HasPartyRequiredRoles(this IAltinnRegisterService altinnRegisterService, string recipientUrn, Guid partyUuid, bool isConfidential, CancellationToken cancellationToken)
+        public static async Task<bool> HasPartyRequiredRolesForConfidential(this IAltinnRegisterService altinnRegisterService, string recipientUrn, Guid partyUuid, CancellationToken cancellationToken)
         {
             var mainUnits = await altinnRegisterService.LookUpMainUnits(recipientUrn.WithoutPrefix().WithUrnPrefix(), cancellationToken);
             if (!mainUnits.Any())
             {
-                return await altinnRegisterService.HasRequiredOrganizationRoles(partyUuid.ToString(), isConfidential, cancellationToken);
+                return await altinnRegisterService.HasRequiredOrganizationRoles(partyUuid.ToString(), cancellationToken);
             }
             else
             {
-                return await altinnRegisterService.HasRequiredOrganizationRoles(mainUnits.First().PartyUuid.ToString(), isConfidential, cancellationToken);
+                return await altinnRegisterService.HasRequiredOrganizationRoles(mainUnits.First().PartyUuid.ToString(), cancellationToken);
             }
         }
     }

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceValidationHelper.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceValidationHelper.cs
@@ -318,10 +318,13 @@ namespace Altinn.Correspondence.Application.InitializeCorrespondences
                 }
 
                 if (string.IsNullOrEmpty(recipientParty.OrgNumber)) continue;
-                var hasRequired = await altinnRegisterService.HasPartyRequiredRoles(recipient, recipientParty.PartyUuid.Value, request.Correspondence.IsConfidential, cancellationToken);
-                if (!hasRequired)
+                if (request.Correspondence.IsConfidential)
                 {
-                    recipientsWithoutRequiredRoles.Add(recipient);
+                    var hasRequired = await altinnRegisterService.HasPartyRequiredRolesForConfidential(recipient, recipientParty.PartyUuid.Value, cancellationToken);
+                    if (!hasRequired)
+                    {
+                        recipientsWithoutRequiredRoles.Add(recipient);
+                    }
                 }
             }
 

--- a/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
+++ b/src/Altinn.Correspondence.Application/PublishCorrespondence/PublishCorrespondenceHandler.cs
@@ -78,9 +78,8 @@ public class PublishCorrespondenceHandler(
         else if (
             correspondence.IsConfidential &&
             !string.IsNullOrEmpty(recipientParty!.OrgNumber) &&
-            !await altinnRegisterService.HasPartyRequiredRoles(correspondence.Recipient, recipientPartyUuid.Value, correspondence.IsConfidential, cancellationToken))
+            !await altinnRegisterService.HasPartyRequiredRolesForConfidential(correspondence.Recipient, recipientPartyUuid.Value, cancellationToken))
         {
-            // Only check for confidential pending #1444. Remove IsConfidential condition after Register has been updated.
             errorMessage = $"Recipient of {correspondenceId} lacks roles required to read correspondence. Consider sending physical mail to this recipient instead.";
         }
         CorrespondenceStatusEntity status;


### PR DESCRIPTION
## Description
Only check role when IsConfidential is set. We found several cases where messages that triggered the warning were read, hence it's noise.

## Related Issue(s)
- #1444 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined organization role validation logic for confidential correspondence recipients, consolidating separate role-checking paths into a dedicated confidential-specific implementation to improve code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->