### PR TITLE
Altinn hosted Github runners

### DIFF
--- a/.github/actions/migrate-database/action.yml
+++ b/.github/actions/migrate-database/action.yml
@@ -45,6 +45,15 @@ runs:
         dotnet-version: |
           10.0.x
 
+    # setup-dotnet addPath does not propagate in composite actions on self-hosted runners
+    - name: Configure .NET environment
+      shell: bash
+      env:
+        DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
+      run: |
+        echo "${DOTNET_INSTALL_DIR}" >> "$GITHUB_PATH"
+        echo "DOTNET_ROOT=${DOTNET_INSTALL_DIR}" >> "$GITHUB_ENV"
+
     - name: Get version
       id: get-version
       uses: ./.github/actions/get-current-version
@@ -79,13 +88,19 @@ runs:
 
     - name: Install EF Core CLI
       shell: bash
+      env:
+        DOTNET_ROOT: ${{ github.workspace }}/.dotnet
       run: |
+        export PATH="${DOTNET_ROOT}:${HOME}/.dotnet/tools:${PATH}"
         dotnet tool install --global dotnet-ef --version 9.0.*
         dotnet tool restore
 
     - name: Create migration script
       shell: bash
+      env:
+        DOTNET_ROOT: ${{ github.workspace }}/.dotnet
       run: |
+        export PATH="${DOTNET_ROOT}:${HOME}/.dotnet/tools:${PATH}"
         dotnet ef migrations bundle --project ./src/Altinn.Correspondence.Persistence --startup-project ./src/Altinn.Correspondence.API --self-contained -r linux-x64 -o ./src/Altinn.Correspondence.Persistence/Migrations/bundle.exe --force
 
     - name: Upload Migration Files to Azure File Share

--- a/.github/actions/migrate-database/action.yml
+++ b/.github/actions/migrate-database/action.yml
@@ -102,33 +102,27 @@ runs:
         export PATH="${DOTNET_INSTALL_DIR}:${HOME}/.dotnet/tools:${PATH}"
         "${DOTNET_INSTALL_DIR}/dotnet" ef migrations bundle --project ./src/Altinn.Correspondence.Persistence --startup-project ./src/Altinn.Correspondence.API --self-contained -r linux-x64 -o ./src/Altinn.Correspondence.Persistence/Migrations/bundle.exe --force
 
+    # azure/CLI@v2 runs inside Docker; use host az CLI on self-hosted runners without Docker
     - name: Upload Migration Files to Azure File Share
-      uses: azure/CLI@v2
-      with:
-        azcliversion: 2.72.0
-        inlineScript: |
-          az storage file upload --share-name migrations --account-name ${{ inputs.AZURE_STORAGE_ACCOUNT_NAME }} \
-            --source ./src/Altinn.Correspondence.Persistence/Migrations/bundle.exe --path bundle.exe \
-            --auth-mode login --enable-file-backup-request-intent
-          az storage file upload --share-name migrations --account-name ${{ inputs.AZURE_STORAGE_ACCOUNT_NAME }} \
-            --source ./src/Altinn.Correspondence.API/appsettings.json --path appsettings.json \
-            --auth-mode login --enable-file-backup-request-intent
+      shell: bash
+      run: |
+        az storage file upload --share-name migrations --account-name "${{ inputs.AZURE_STORAGE_ACCOUNT_NAME }}" \
+          --source ./src/Altinn.Correspondence.Persistence/Migrations/bundle.exe --path bundle.exe \
+          --auth-mode login --enable-file-backup-request-intent
+        az storage file upload --share-name migrations --account-name "${{ inputs.AZURE_STORAGE_ACCOUNT_NAME }}" \
+          --source ./src/Altinn.Correspondence.API/appsettings.json --path appsettings.json \
+          --auth-mode login --enable-file-backup-request-intent
 
     - name: Start migration job
-      uses: azure/CLI@v2
-      with:
-        azcliversion: 2.72.0
-        inlineScript: |
-          az containerapp job start -n ${{ steps.migration-job.outputs.name }} -g ${{ inputs.AZURE_NAME_PREFIX }}-rg
+      shell: bash
+      run: |
+        az containerapp job start -n "${{ steps.migration-job.outputs.name }}" -g "${{ inputs.AZURE_NAME_PREFIX }}-rg"
 
     - name: Verify migration
-      uses: azure/CLI@v2
-      id: verify-migration
-      with:
-        azcliversion: 2.72.0
-        inlineScript: |
-          chmod +x ./.github/tools/containerAppJobVerifier.sh
-          ./.github/tools/containerAppJobVerifier.sh ${{ steps.migration-job.outputs.name }} '${{ inputs.AZURE_NAME_PREFIX }}-rg' ${{ steps.get-version.outputs.imageTag }}
+      shell: bash
+      run: |
+        chmod +x ./.github/tools/containerAppJobVerifier.sh
+        ./.github/tools/containerAppJobVerifier.sh "${{ steps.migration-job.outputs.name }}" "${{ inputs.AZURE_NAME_PREFIX }}-rg" "${{ steps.get-version.outputs.imageTag }}"
 
     - name: Logout from azure
       shell: bash

--- a/.github/actions/migrate-database/action.yml
+++ b/.github/actions/migrate-database/action.yml
@@ -91,7 +91,7 @@ runs:
         DOTNET_INSTALL_DIR="${GITHUB_WORKSPACE}/.dotnet"
         export DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
         export PATH="${DOTNET_INSTALL_DIR}:${HOME}/.dotnet/tools:${PATH}"
-        "${DOTNET_INSTALL_DIR}/dotnet" tool install --global dotnet-ef --version 9.0.*
+        "${DOTNET_INSTALL_DIR}/dotnet" tool install --global dotnet-ef --version 10.0.*
         "${DOTNET_INSTALL_DIR}/dotnet" tool restore
 
     - name: Create migration script

--- a/.github/actions/migrate-database/action.yml
+++ b/.github/actions/migrate-database/action.yml
@@ -92,7 +92,6 @@ runs:
         export DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
         export PATH="${DOTNET_INSTALL_DIR}:${HOME}/.dotnet/tools:${PATH}"
         "${DOTNET_INSTALL_DIR}/dotnet" tool install --global dotnet-ef --version 10.0.*
-        "${DOTNET_INSTALL_DIR}/dotnet" tool restore
 
     - name: Create migration script
       shell: bash
@@ -100,6 +99,7 @@ runs:
         DOTNET_INSTALL_DIR="${GITHUB_WORKSPACE}/.dotnet"
         export DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
         export PATH="${DOTNET_INSTALL_DIR}:${HOME}/.dotnet/tools:${PATH}"
+        "${DOTNET_INSTALL_DIR}/dotnet" restore Altinn.Correspondence.sln
         "${DOTNET_INSTALL_DIR}/dotnet" ef migrations bundle --project ./src/Altinn.Correspondence.Persistence --startup-project ./src/Altinn.Correspondence.API --self-contained -r linux-x64 -o ./src/Altinn.Correspondence.Persistence/Migrations/bundle.exe --force
 
     # azure/CLI@v2 runs inside Docker; use host az CLI on self-hosted runners without Docker

--- a/.github/actions/migrate-database/action.yml
+++ b/.github/actions/migrate-database/action.yml
@@ -34,8 +34,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Checkout repository"
-      uses: actions/checkout@v6
+    - name: Get version
+      id: get-version
+      uses: ./.github/actions/get-current-version
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
@@ -45,18 +46,16 @@ runs:
         dotnet-version: |
           10.0.x
 
-    # setup-dotnet addPath does not propagate in composite actions on self-hosted runners
     - name: Configure .NET environment
       shell: bash
-      env:
-        DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
       run: |
+        DOTNET_INSTALL_DIR="${GITHUB_WORKSPACE}/.dotnet"
+        if [ ! -x "${DOTNET_INSTALL_DIR}/dotnet" ]; then
+          echo "::error::dotnet not found at ${DOTNET_INSTALL_DIR}/dotnet after setup-dotnet"
+          exit 1
+        fi
         echo "${DOTNET_INSTALL_DIR}" >> "$GITHUB_PATH"
         echo "DOTNET_ROOT=${DOTNET_INSTALL_DIR}" >> "$GITHUB_ENV"
-
-    - name: Get version
-      id: get-version
-      uses: ./.github/actions/get-current-version
 
     - name: OIDC Login to Azure Public Cloud
       uses: azure/login@v2
@@ -88,20 +87,20 @@ runs:
 
     - name: Install EF Core CLI
       shell: bash
-      env:
-        DOTNET_ROOT: ${{ github.workspace }}/.dotnet
       run: |
-        export PATH="${DOTNET_ROOT}:${HOME}/.dotnet/tools:${PATH}"
-        dotnet tool install --global dotnet-ef --version 9.0.*
-        dotnet tool restore
+        DOTNET_INSTALL_DIR="${GITHUB_WORKSPACE}/.dotnet"
+        export DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
+        export PATH="${DOTNET_INSTALL_DIR}:${HOME}/.dotnet/tools:${PATH}"
+        "${DOTNET_INSTALL_DIR}/dotnet" tool install --global dotnet-ef --version 9.0.*
+        "${DOTNET_INSTALL_DIR}/dotnet" tool restore
 
     - name: Create migration script
       shell: bash
-      env:
-        DOTNET_ROOT: ${{ github.workspace }}/.dotnet
       run: |
-        export PATH="${DOTNET_ROOT}:${HOME}/.dotnet/tools:${PATH}"
-        dotnet ef migrations bundle --project ./src/Altinn.Correspondence.Persistence --startup-project ./src/Altinn.Correspondence.API --self-contained -r linux-x64 -o ./src/Altinn.Correspondence.Persistence/Migrations/bundle.exe --force
+        DOTNET_INSTALL_DIR="${GITHUB_WORKSPACE}/.dotnet"
+        export DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
+        export PATH="${DOTNET_INSTALL_DIR}:${HOME}/.dotnet/tools:${PATH}"
+        "${DOTNET_INSTALL_DIR}/dotnet" ef migrations bundle --project ./src/Altinn.Correspondence.Persistence --startup-project ./src/Altinn.Correspondence.API --self-contained -r linux-x64 -o ./src/Altinn.Correspondence.Persistence/Migrations/bundle.exe --force
 
     - name: Upload Migration Files to Azure File Share
       uses: azure/CLI@v2

--- a/.github/actions/migrate-database/action.yml
+++ b/.github/actions/migrate-database/action.yml
@@ -39,6 +39,8 @@ runs:
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
+      env:
+        DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
       with:
         dotnet-version: |
           10.0.x

--- a/.github/actions/release-version/action.yml
+++ b/.github/actions/release-version/action.yml
@@ -70,15 +70,13 @@ runs:
         failOnStdErr: false
         parameters: ./.azure/applications/api/params.bicepparam
 
+    # azure/CLI@v2 runs inside Docker; use host az CLI on self-hosted runners without Docker
     - name: Verify deployment
-      uses: azure/CLI@v2
       id: verify-deployment
-      with:
-        timeout-minutes: 3
-        azcliversion: 2.72.0
-        inlineScript: |
-          chmod +x ./.github/tools/revisionVerifier.sh
-          ./.github/tools/revisionVerifier.sh ${{ steps.deploy.outputs.revisionName }} ${{ inputs.AZURE_NAME_PREFIX }}-rg ${{ inputs.AZURE_NAME_PREFIX}}-app
+      shell: bash
+      run: |
+        chmod +x ./.github/tools/revisionVerifier.sh
+        ./.github/tools/revisionVerifier.sh "${{ steps.deploy.outputs.revisionName }}" "${{ inputs.AZURE_NAME_PREFIX }}-rg" "${{ inputs.AZURE_NAME_PREFIX }}-app"
 
     - name: Logout from azure
       shell: bash

--- a/.github/actions/remediate-standard-tags/action.yml
+++ b/.github/actions/remediate-standard-tags/action.yml
@@ -27,15 +27,16 @@ runs:
         subscription-id: ${{ inputs.AZURE_SUBSCRIPTION_ID }}
 
     - name: Remediate standard tags policy
-      shell: pwsh
+      shell: bash
       run: |
-        $rgName = "${{ inputs.AZURE_NAME_PREFIX }}-rg"
-        $subscriptionId = "${{ inputs.AZURE_SUBSCRIPTION_ID }}"
-        $assignmentId = "/subscriptions/$subscriptionId/resourceGroups/$rgName/providers/Microsoft.Authorization/policyAssignments/correspondence-standard-tags"
-        az policy remediation create `
-          --name "correspondence-standard-tags-remediation" `
-          --policy-assignment $assignmentId `
-          --resource-group $rgName
+        set -euo pipefail
+        rg_name="${{ inputs.AZURE_NAME_PREFIX }}-rg"
+        subscription_id="${{ inputs.AZURE_SUBSCRIPTION_ID }}"
+        assignment_id="/subscriptions/${subscription_id}/resourceGroups/${rg_name}/providers/Microsoft.Authorization/policyAssignments/correspondence-standard-tags"
+        az policy remediation create \
+          --name "correspondence-standard-tags-remediation" \
+          --policy-assignment "$assignment_id" \
+          --resource-group "$rg_name"
 
     - name: Logout from azure
       shell: bash

--- a/.github/workflows/check-label-for-pr.yml
+++ b/.github/workflows/check-label-for-pr.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, reopened, ready_for_review, labeled, unlabeled]
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -13,7 +13,7 @@ jobs:
 
   get-version: 
     name: Get version
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       imageTag: ${{ steps.get-version.outputs.imageTag }}
       version: ${{ steps.get-version.outputs.version }}
@@ -43,7 +43,7 @@ jobs:
 
   deploy-test:
     name: Internal test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: test
     if: always() && !failure() && !cancelled() 
     needs: [get-version, publish, test]
@@ -74,7 +74,7 @@ jobs:
           GRAFANA_MONITORING_PRINCIPAL_ID: ${{ secrets.GRAFANA_MONITORING_PRINCIPAL_ID }}
   deploy-staging:
     name: Internal staging
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: staging
     if: always() && !failure() && !cancelled() 
     needs: [ 
@@ -107,7 +107,7 @@ jobs:
           GRAFANA_MONITORING_PRINCIPAL_ID: ${{ secrets.GRAFANA_MONITORING_PRINCIPAL_ID }}
   deploy-production:
     name: Production
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: production
     if: (!failure() && !cancelled())
     needs: [
@@ -140,7 +140,7 @@ jobs:
           GRAFANA_MONITORING_PRINCIPAL_ID: ${{ secrets.GRAFANA_MONITORING_PRINCIPAL_ID }}
   check-version-bump:
     name: Check if version was bumped
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [get-version, deploy-production]
     if: ${{ !failure() && !cancelled()}}
     outputs:
@@ -170,7 +170,7 @@ jobs:
 
   release-to-git:  
     name: Release to git
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [check-version-bump]
     if: ${{ needs.check-version-bump.outputs.should-release == 'true' }}
     permissions: 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: self-hosted
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,6 +61,8 @@ jobs:
 
     # Set up .NET SDK version 10
     - name: Setup .NET SDK
+      env:
+        DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -24,7 +24,7 @@ run-name: Deploy to ${{ inputs.environment }}
 jobs:
   get-version: 
     name: Get version
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       imageTag: ${{ steps.get-version.outputs.imageTag }}
     permissions: 
@@ -51,7 +51,7 @@ jobs:
           imageTag: ${{ needs.get-version.outputs.imageTag }}
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [get-version, publish]
     environment: ${{ inputs.environment }}
     permissions: 

--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
+        env:
+          DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
         with:
           dotnet-version: |
             10.0.x

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -113,7 +113,7 @@ permissions:
 run-name: ${{ inputs.tag }} ${{ inputs.vus }}/${{ inputs.duration }}/${{ inputs.parallelism }}
 jobs:
   k6-performance:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ inputs.environment }}
     steps:
     - name: Checkout code

--- a/.github/workflows/validate-formatting.yml
+++ b/.github/workflows/validate-formatting.yml
@@ -14,6 +14,8 @@ jobs:
 
         - name: Setup .NET
           uses: actions/setup-dotnet@v5
+          env:
+            DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
           with:
            dotnet-version: |
             10.0.x

--- a/.github/workflows/validate-formatting.yml
+++ b/.github/workflows/validate-formatting.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-formatting:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
         - uses: actions/checkout@v6
 

--- a/.github/workflows/validate-formatting.yml
+++ b/.github/workflows/validate-formatting.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-formatting:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v6
 

--- a/.github/workflows/verify-db-migration.yml
+++ b/.github/workflows/verify-db-migration.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   determine-commits:
     name: Determine commits to test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       old_commit: ${{ steps.set-commits.outputs.old_commit }}
       new_commit: ${{ steps.set-commits.outputs.new_commit }}

--- a/.github/workflows/verify-db-migration.yml
+++ b/.github/workflows/verify-db-migration.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
+        env:
+          DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
         with:
           dotnet-version: |
             10.0.x

--- a/.github/workflows/verify-db-migration.yml
+++ b/.github/workflows/verify-db-migration.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   determine-commits:
     name: Determine commits to test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       old_commit: ${{ steps.set-commits.outputs.old_commit }}
       new_commit: ${{ steps.set-commits.outputs.new_commit }}


### PR DESCRIPTION
## Description
The free Github runners have gotten way too slow. As long as they do not use Docker, they can run on the ones hosted by Platform (running as DIS-managed container apps).

Will test for a little while before also putting use case tests on it.

## Related Issue(s)
- #1097 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD and workflow jobs moved to self-hosted runners.
  * .NET SDK installation now targets a workspace-local directory in relevant CI jobs and composite actions.
  * Deployment verification and database migration steps switched to run via local shell commands on runners.
  * No changes to application behavior, permissions, or end-user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->