### PR TITLE
Added a new maintenance endpoint to retrieve notification length statistics

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
@@ -370,7 +370,7 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
 
     /// <summary>
     /// Enqueue a job that computes hypothetical SMS notification length statistics for all
-    /// correspondences published within the given date range. Aggregated statistics are emitted to logs.
+    /// correspondences created within the given date range. Aggregated statistics are emitted to logs.
     /// </summary>
     /// <response code="200">Returns the enqueued job id and the resolved range</response>
     /// <response code="401">Unauthorized</response>

--- a/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
@@ -17,6 +17,7 @@ using Altinn.Correspondence.Application.MigrateForwardingEventsBatch;
 using Altinn.Correspondence.Application.CleanupBulkFetchStatuses;
 using Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
 using Altinn.Correspondence.Application.MaskinportenJwkRotation;
+using Altinn.Correspondence.Application.SmsNotificationLengthStatistics;
 
 namespace Altinn.Correspondence.API.Controllers;
 
@@ -365,6 +366,33 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
             jobId,
             message = "Maskinporten JWK rotation was enqueued."
         });
+    }
+
+    /// <summary>
+    /// Enqueue a job that computes hypothetical SMS notification length statistics for all
+    /// correspondences published within the given date range. Aggregated statistics are emitted to logs.
+    /// </summary>
+    /// <response code="200">Returns the enqueued job id and the resolved range</response>
+    /// <response code="401">Unauthorized</response>
+    /// <response code="403">Forbidden</response>
+    [HttpPost]
+    [Route("sms-notification-length-statistics")]
+    [Authorize(Policy = AuthorizationConstants.Maintenance)]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(SmsNotificationLengthStatisticsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult> GetSmsNotificationLengthStatistics(
+        [FromServices] SmsNotificationLengthStatisticsHandler handler,
+        [FromBody] SmsNotificationLengthStatisticsRequest request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Request to compute SMS notification length statistics received");
+        var result = await handler.Process(request, HttpContext.User, cancellationToken);
+        return result.Match(
+            Ok,
+            Problem
+        );
     }
 
     private ActionResult Problem(Error error) => ProblemDetailsHelper.ToProblemResult(error);

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -38,6 +38,7 @@ using Altinn.Correspondence.Application.GetUnreadConfidentialCorrespondences;
 using Altinn.Correspondence.Application.UnreadConfidentialCorrespondence;
 using Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
 using Altinn.Correspondence.Application.DownloadAllCorrespondenceAttachments;
+using Altinn.Correspondence.Application.SmsNotificationLengthStatistics;
 
 namespace Altinn.Correspondence.Application;
 
@@ -87,6 +88,7 @@ public static class DependencyInjection
         services.AddScoped<EnqueueMissingNotificationSentChecksHandler>();
         services.AddScoped<CleanupBulkFetchStatuses.CleanupBulkFetchStatusesHandler>();
         services.AddScoped<ManualRetryNotPublishedCorrespondencesHandler>();
+        services.AddScoped<SmsNotificationLengthStatisticsHandler>();
 
         // Statistics & Reporting
         services.AddScoped<GenerateDailySummaryReportHandler>();

--- a/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/RecipientCategory.cs
+++ b/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/RecipientCategory.cs
@@ -1,0 +1,24 @@
+using Altinn.Correspondence.Common.Constants;
+using Altinn.Correspondence.Core.Models.Entities;
+
+namespace Altinn.Correspondence.Application.SmsNotificationLengthStatistics;
+
+public enum RecipientCategory
+{
+    Organization,
+    Person
+}
+
+public static class RecipientCategoryClassifier
+{
+    public static RecipientCategory Classify(string? recipientType, string? recipient)
+    {
+        var effectiveType = string.IsNullOrWhiteSpace(recipientType)
+            ? CorrespondenceEntity.ComputeRecipientType(recipient)
+            : recipientType;
+
+        return string.Equals(effectiveType, UrnConstants.OrganizationNumberAttribute, StringComparison.Ordinal)
+            ? RecipientCategory.Organization
+            : RecipientCategory.Person;
+    }
+}

--- a/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsLengthStats.cs
+++ b/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsLengthStats.cs
@@ -1,0 +1,113 @@
+using System.Globalization;
+
+namespace Altinn.Correspondence.Application.SmsNotificationLengthStatistics;
+
+public class SmsLengthStats
+{
+    public long Count { get; private set; }
+    public long SumLength { get; private set; }
+    public int MinLength { get; private set; } = int.MaxValue;
+    public int MaxLength { get; private set; }
+
+    public long NameLookupFailures { get; set; }
+    public long ResourceLookupFailures { get; set; }
+    public long ProcessingFailures { get; set; }
+
+    public long RecipientNameSamples { get; private set; }
+    public long RecipientNameSumLength { get; private set; }
+    public int RecipientNameMinLength { get; private set; } = int.MaxValue;
+    public int RecipientNameMaxLength { get; private set; }
+
+    public long ResourceNameSamples { get; private set; }
+    public long ResourceNameSumLength { get; private set; }
+    public int ResourceNameMinLength { get; private set; } = int.MaxValue;
+    public int ResourceNameMaxLength { get; private set; }
+
+    private const int MaxTrackedLength = 1000;
+    private readonly long[] _lengthBuckets = new long[MaxTrackedLength + 1];
+
+    public void Record(int length)
+    {
+        Count++;
+        SumLength += length;
+        if (length < MinLength) MinLength = length;
+        if (length > MaxLength) MaxLength = length;
+
+        var bucketIndex = Math.Min(length, MaxTrackedLength);
+        _lengthBuckets[bucketIndex]++;
+    }
+
+    public void RecordRecipientNameLength(int length)
+    {
+        RecipientNameSamples++;
+        RecipientNameSumLength += length;
+        if (length < RecipientNameMinLength) RecipientNameMinLength = length;
+        if (length > RecipientNameMaxLength) RecipientNameMaxLength = length;
+    }
+
+    public void RecordResourceNameLength(int length)
+    {
+        ResourceNameSamples++;
+        ResourceNameSumLength += length;
+        if (length < ResourceNameMinLength) ResourceNameMinLength = length;
+        if (length > ResourceNameMaxLength) ResourceNameMaxLength = length;
+    }
+
+    public double AverageRecipientNameLength => RecipientNameSamples == 0 ? 0 : (double)RecipientNameSumLength / RecipientNameSamples;
+    public double AverageResourceNameLength => ResourceNameSamples == 0 ? 0 : (double)ResourceNameSumLength / ResourceNameSamples;
+
+    public double AverageLength => Count == 0 ? 0 : (double)SumLength / Count;
+
+    public int Percentile(double percentile)
+    {
+        if (Count == 0) return 0;
+        var target = (long)Math.Ceiling(percentile * Count / 100.0);
+        long running = 0;
+        for (int i = 0; i < _lengthBuckets.Length; i++)
+        {
+            running += _lengthBuckets[i];
+            if (running >= target)
+            {
+                return i;
+            }
+        }
+        return MaxLength;
+    }
+
+    public string ToLogString()
+    {
+        if (Count == 0) return "Count=0";
+        var min = MinLength == int.MaxValue ? 0 : MinLength;
+        var ci = CultureInfo.InvariantCulture;
+        var lengthBuckets = string.Join(",", new[]
+        {
+            $"<=100:{SumBuckets(0, 100)}",
+            $"101-140:{SumBuckets(101, 140)}",
+            $"141-160:{SumBuckets(141, 160)}",
+            $"161-200:{SumBuckets(161, 200)}",
+            $"201-280:{SumBuckets(201, 280)}",
+            $"281+:{SumBuckets(281, MaxTrackedLength)}"
+        });
+        var recipientNameMin = RecipientNameMinLength == int.MaxValue ? 0 : RecipientNameMinLength;
+        var resourceNameMin = ResourceNameMinLength == int.MaxValue ? 0 : ResourceNameMinLength;
+        return string.Format(
+            ci,
+            "TotalCorrespondencesChecked={0} Min={1} Max={2} Avg={3:F1} p50={4} p90={5} p95={6} p99={7} NameFails={8} ResourceFails={9} ProcFails={10} RecipientNameAvg={11:F1} RecipientNameMin={12} RecipientNameMax={13} RecipientNameSamples={14} ResourceNameAvg={15:F1} ResourceNameMin={16} ResourceNameMax={17} ResourceNameSamples={18} LengthBuckets=[{19}]",
+            Count, min, MaxLength, AverageLength,
+            Percentile(50), Percentile(90), Percentile(95), Percentile(99),
+            NameLookupFailures, ResourceLookupFailures, ProcessingFailures,
+            AverageRecipientNameLength, recipientNameMin, RecipientNameMaxLength, RecipientNameSamples,
+            AverageResourceNameLength, resourceNameMin, ResourceNameMaxLength, ResourceNameSamples,
+            lengthBuckets);
+    }
+
+    private long SumBuckets(int fromBucket, int toBucket)
+    {
+        long sum = 0;
+        for (int i = fromBucket; i <= toBucket && i < _lengthBuckets.Length; i++)
+        {
+            sum += _lengthBuckets[i];
+        }
+        return sum;
+    }
+}

--- a/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsNotificationLengthStatisticsHandler.cs
+++ b/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsNotificationLengthStatisticsHandler.cs
@@ -102,7 +102,7 @@ public class SmsNotificationLengthStatisticsHandler(
                         }
                         catch (Exception ex)
                         {
-                            logger.LogWarning(ex, "LookUpName failed for recipient {Recipient}", c.Recipient);
+                            logger.LogWarning(ex, "LookUpName failed for correspondence {CorrespondenceId}", c.Id);
                             recipientName = null;
                             totals.NameLookupFailures++;
                             batchStats.NameLookupFailures++;

--- a/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsNotificationLengthStatisticsHandler.cs
+++ b/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsNotificationLengthStatisticsHandler.cs
@@ -1,0 +1,195 @@
+using System.Security.Claims;
+using Altinn.Correspondence.Common.Helpers;
+using Altinn.Correspondence.Core.Repositories;
+using Altinn.Correspondence.Core.Services;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using OneOf;
+
+namespace Altinn.Correspondence.Application.SmsNotificationLengthStatistics;
+
+public class SmsNotificationLengthStatisticsHandler(
+    ICorrespondenceRepository correspondenceRepository,
+    IAltinnRegisterService altinnRegisterService,
+    IResourceRegistryService resourceRegistryService,
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<SmsNotificationLengthStatisticsHandler> logger) : IHandler<SmsNotificationLengthStatisticsRequest, SmsNotificationLengthStatisticsResponse>
+{
+    private static readonly DateTimeOffset DefaultFrom = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset DefaultTo = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private const int DefaultBatchSize = 1000;
+
+    public Task<OneOf<SmsNotificationLengthStatisticsResponse, Error>> Process(
+        SmsNotificationLengthStatisticsRequest request,
+        ClaimsPrincipal? user,
+        CancellationToken cancellationToken)
+    {
+        var from = request.From ?? DefaultFrom;
+        var to = request.To ?? DefaultTo;
+        var batchSize = request.BatchSize is > 0 ? request.BatchSize.Value : DefaultBatchSize;
+
+        logger.LogInformation(
+            "Enqueuing sms-notification-length-statistics job for range {From} to {To} with batchSize {BatchSize}",
+            from, to, batchSize);
+
+        var jobId = backgroundJobClient.Enqueue<SmsNotificationLengthStatisticsHandler>(
+            handler => handler.Execute(from, to, batchSize, CancellationToken.None));
+
+        return Task.FromResult<OneOf<SmsNotificationLengthStatisticsResponse, Error>>(
+            new SmsNotificationLengthStatisticsResponse
+            {
+                JobId = jobId,
+                From = from,
+                To = to,
+                BatchSize = batchSize
+            });
+    }
+
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(timeoutInSeconds: 86400)]
+    public async Task Execute(
+        DateTimeOffset from,
+        DateTimeOffset to,
+        int batchSize,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "Starting sms-notification-length-statistics: range {From}..{To} batchSize {BatchSize}",
+            from, to, batchSize);
+
+        var recipientNameCache = new Dictionary<string, string?>(StringComparer.Ordinal);
+        var resourceTitleCache = new Dictionary<string, string?>(StringComparer.Ordinal);
+        var totals = new SmsLengthStats();
+        var perCategoryTotals = new Dictionary<RecipientCategory, SmsLengthStats>
+        {
+            [RecipientCategory.Organization] = new SmsLengthStats(),
+            [RecipientCategory.Person] = new SmsLengthStats()
+        };
+
+        Guid? cursor = null;
+        var batchIndex = 0;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var batch = await correspondenceRepository.GetCorrespondencesCreatedInRange(
+                from, to, cursor, batchSize, cancellationToken);
+
+            if (batch.Count == 0)
+            {
+                break;
+            }
+
+            batchIndex++;
+            var batchStats = new SmsLengthStats();
+
+            foreach (var c in batch)
+            {
+                try
+                {
+                    var category = RecipientCategoryClassifier.Classify(c.RecipientType, c.Recipient);
+                    var categoryStats = perCategoryTotals[category];
+                    var recipientNumber = c.Recipient.WithoutPrefix();
+
+                    if (!recipientNameCache.TryGetValue(c.Recipient, out var recipientName))
+                    {
+                        try
+                        {
+                            recipientName = await altinnRegisterService.LookUpName(recipientNumber, cancellationToken);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogWarning(ex, "LookUpName failed for recipient {Recipient}", c.Recipient);
+                            recipientName = null;
+                            totals.NameLookupFailures++;
+                            batchStats.NameLookupFailures++;
+                            categoryStats.NameLookupFailures++;
+                        }
+                        recipientNameCache[c.Recipient] = recipientName;
+                    }
+
+                    if (!resourceTitleCache.TryGetValue(c.ResourceId, out var resourceName))
+                    {
+                        try
+                        {
+                            resourceName = await resourceRegistryService.GetResourceTitle(c.ResourceId, "nb", cancellationToken);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogWarning(ex, "GetResourceTitle failed for resource {ResourceId}", c.ResourceId);
+                            resourceName = null;
+                            totals.ResourceLookupFailures++;
+                            batchStats.ResourceLookupFailures++;
+                            categoryStats.ResourceLookupFailures++;
+                        }
+                        resourceTitleCache[c.ResourceId] = resourceName;
+                    }
+
+                    var effectiveRecipientName = string.IsNullOrWhiteSpace(recipientName) ? recipientNumber : recipientName;
+                    var effectiveResourceName = string.IsNullOrWhiteSpace(resourceName) ? c.ResourceId : resourceName;
+                    var effectiveTitle = c.Content?.MessageTitle ?? string.Empty;
+
+                    var body = $"{effectiveRecipientName} ({recipientNumber}) har mottatt «{effectiveTitle}» i Altinn. For å lese kreves tilgang til {effectiveResourceName}.";
+                    var length = body.Length;
+
+                    totals.Record(length);
+                    batchStats.Record(length);
+                    categoryStats.Record(length);
+
+                    if (!string.IsNullOrWhiteSpace(recipientName))
+                    {
+                        totals.RecordRecipientNameLength(recipientName.Length);
+                        batchStats.RecordRecipientNameLength(recipientName.Length);
+                        categoryStats.RecordRecipientNameLength(recipientName.Length);
+                    }
+                    if (!string.IsNullOrWhiteSpace(resourceName))
+                    {
+                        totals.RecordResourceNameLength(resourceName.Length);
+                        batchStats.RecordResourceNameLength(resourceName.Length);
+                        categoryStats.RecordResourceNameLength(resourceName.Length);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to compute SMS length for correspondence {CorrespondenceId}", c.Id);
+                    totals.ProcessingFailures++;
+                    batchStats.ProcessingFailures++;
+                }
+            }
+
+            cursor = batch[^1].Id;
+
+            logger.LogInformation(
+                "SMS length batch {BatchIndex} processed {ProcessedInBatch} correspondences. TotalCorrespondencesCheckedSoFar={TotalCorrespondencesCheckedSoFar}. Batch stats: {BatchStats}",
+                batchIndex, batch.Count, totals.Count, batchStats.ToLogString());
+
+            if (batch.Count < batchSize)
+            {
+                break;
+            }
+        }
+
+        logger.LogInformation(
+            "Completed sms-notification-length-statistics for range {From}..{To}. TotalCorrespondencesChecked={TotalCorrespondencesChecked}. Totals: {TotalStats}",
+            from, to, totals.Count, totals.ToLogString());
+
+        foreach (var category in new[] { RecipientCategory.Organization, RecipientCategory.Person })
+        {
+            var categoryStats = perCategoryTotals[category];
+            logger.LogInformation(
+                "sms-notification-length-statistics by RecipientCategory={RecipientCategory} CorrespondencesChecked={CorrespondencesChecked}. Stats: {CategoryStats}",
+                category, categoryStats.Count, categoryStats.ToLogString());
+        }
+    }
+}

--- a/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsNotificationLengthStatisticsRequest.cs
+++ b/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsNotificationLengthStatisticsRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Correspondence.Application.SmsNotificationLengthStatistics;
+
+public class SmsNotificationLengthStatisticsRequest
+{
+    public DateTimeOffset? From { get; set; }
+
+    public DateTimeOffset? To { get; set; }
+
+    [Range(100, 5000)]
+    public int? BatchSize { get; set; }
+}

--- a/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsNotificationLengthStatisticsResponse.cs
+++ b/src/Altinn.Correspondence.Application/SmsNotificationLengthStatistics/SmsNotificationLengthStatisticsResponse.cs
@@ -1,0 +1,9 @@
+namespace Altinn.Correspondence.Application.SmsNotificationLengthStatistics;
+
+public class SmsNotificationLengthStatisticsResponse
+{
+    public required string JobId { get; set; }
+    public required DateTimeOffset From { get; set; }
+    public required DateTimeOffset To { get; set; }
+    public required int BatchSize { get; set; }
+}

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -109,5 +109,12 @@ namespace Altinn.Correspondence.Core.Repositories
             Guid? cursorId,
             CancellationToken cancellationToken);
         Task<List<CorrespondenceEntity>> GetUnopenedConfidentialCorrespondencesForParty(string partyId, TimeSpan minAge, CancellationToken cancellationToken);
+
+        Task<List<CorrespondenceEntity>> GetCorrespondencesCreatedInRange(
+            DateTimeOffset from,
+            DateTimeOffset to,
+            Guid? cursorId,
+            int batchSize,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -708,5 +708,28 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .Where(c => c.RequestedPublishTime < cutoff)
                 .ToListAsync(cancellationToken);
         }
+
+        public async Task<List<CorrespondenceEntity>> GetCorrespondencesCreatedInRange(
+            DateTimeOffset from,
+            DateTimeOffset to,
+            Guid? cursorId,
+            int batchSize,
+            CancellationToken cancellationToken)
+        {
+            var query = _context.Correspondences
+                .AsNoTracking()
+                .Where(c => c.Created >= from && c.Created < to);
+
+            if (cursorId.HasValue)
+            {
+                query = query.Where(c => c.Id < cursorId.Value);
+            }
+
+            return await query
+                .OrderByDescending(c => c.Id)
+                .Take(batchSize)
+                .Include(c => c.Content)
+                .ToListAsync(cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a correspondenceNotification exceeds 160 chars, more than 1 sms will be sendt which is costly. We intend to change the generic correspondence notifciation text. And for this change we want statistics on how long this new notification text length will be, so that we can find how many notifcations would exceed the 160 threshold with the new notification text.

This PR adds a new maintenanceendpoint to gather statistics on the new notification length with tokens replaced.

## Related Issue(s)
- #1722 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New maintenance API endpoint to start SMS notification length statistics runs. Accepts an optional date range and batch size, returns a job identifier and resolved parameters.

* **Chores**
  * Background job handler registered to enqueue and execute the statistics computation, including per-recipient-category aggregation and robust per-item error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->