### PR TITLE
Fix Dialogporten transmission scheduling for past publish time

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/InitializeCorrespondencesHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/InitializeCorrespondencesHandlerTests.cs
@@ -1,0 +1,70 @@
+using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Application.InitializeCorrespondences;
+using Altinn.Correspondence.Common.Caching;
+using Altinn.Correspondence.Core.Repositories;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Altinn.Correspondence.Tests.TestingHandler;
+
+public class InitializeCorrespondencesHandlerTests
+{
+    [Fact]
+    public async Task ScheduleTransmissionAndPublishJobs_WithPastRequestedPublishTime_SchedulesTransmissionImmediately()
+    {
+        var correspondenceId = Guid.NewGuid();
+        var hangfireBackgroundJobClient = new Mock<IBackgroundJobClient>();
+        var correspondenceRepository = new Mock<ICorrespondenceRepository>();
+
+        hangfireBackgroundJobClient
+            .Setup(x => x.Create(It.IsAny<Job>(), It.IsAny<IState>()))
+            .Returns("transmission-job-id");
+
+        correspondenceRepository
+            .Setup(x => x.AreAllAttachmentsPublished(correspondenceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var hangfireScheduleHelper = new HangfireScheduleHelper(
+            hangfireBackgroundJobClient.Object,
+            Mock.Of<IHybridCacheWrapper>(),
+            correspondenceRepository.Object,
+            NullLogger<HangfireScheduleHelper>.Instance);
+
+        var handler = new InitializeCorrespondencesHandler(
+            null!,
+            correspondenceRepository.Object,
+            hangfireBackgroundJobClient.Object,
+            null!,
+            null!,
+            hangfireScheduleHelper,
+            null!,
+            null!,
+            null!,
+            NullLogger<InitializeCorrespondencesHandler>.Instance);
+
+        await handler.ScheduleTransmissionAndPublishJobs(
+            correspondenceId,
+            attachmentsCount: 0,
+            requestedPublishTime: DateTimeOffset.MinValue,
+            CancellationToken.None);
+
+        hangfireBackgroundJobClient.Verify(x => x.Create(
+            It.Is<Job>(job => job.Method.Name == nameof(InitializeCorrespondencesHandler.CreateDialogportenTransmission)),
+            It.Is<IState>(state => IsImmediateScheduledState(state))),
+            Times.Once);
+
+        hangfireBackgroundJobClient.Verify(x => x.Create(
+            It.Is<Job>(job => job.Method.Name == nameof(HangfireScheduleHelper.SchedulePublishAtPublishTime)),
+            It.Is<IState>(state => state is AwaitingState)),
+            Times.Once);
+    }
+
+    private static bool IsImmediateScheduledState(IState state)
+    {
+        return state is ScheduledState scheduledState &&
+            scheduledState.EnqueueAt > DateTime.UtcNow.AddMinutes(-1);
+    }
+}

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -260,7 +260,10 @@ public class InitializeCorrespondencesHandler(
 
     public async Task ScheduleTransmissionAndPublishJobs(Guid correspondenceId, int attachmentsCount, DateTimeOffset requestedPublishTime, CancellationToken cancellationToken)
     {
-        var transmissionJob = backgroundJobClient.Schedule(() => CreateDialogportenTransmission(correspondenceId), requestedPublishTime);
+        var scheduleAt = requestedPublishTime < DateTimeOffset.UtcNow
+            ? DateTimeOffset.UtcNow
+            : requestedPublishTime;
+        var transmissionJob = backgroundJobClient.Schedule(() => CreateDialogportenTransmission(correspondenceId), scheduleAt);
         if (await correspondenceRepository.AreAllAttachmentsPublished(correspondenceId, cancellationToken))
         {
             await hangfireScheduleHelper.SchedulePublishAfterTransmissionCreated(correspondenceId, transmissionJob, cancellationToken);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes an issue where Dialogporten transmission jobs could be scheduled with DateTimeOffset.MinValue when RequestedPublishTime was -infinity/in the past.

The transmission schedule time is now normalized to DateTimeOffset.UtcNow when needed, so the transmission job can run and the publish continuation can proceed. Added a handler test covering this case.

## Related Issue(s)
- #1966 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transmission job scheduling to properly handle past-dated publication requests. When a correspondence is requested to be published at a past time, the transmission job will now be scheduled to execute immediately rather than using the expired timestamp. This prevents scheduling failures and ensures reliable job execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->