### PR TITLE
purge dialog and delete reminder for read correspondences

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
@@ -18,6 +18,7 @@ using Altinn.Correspondence.Application.CleanupBulkFetchStatuses;
 using Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
 using Altinn.Correspondence.Application.MaskinportenJwkRotation;
 using Altinn.Correspondence.API.Swagger;
+using Altinn.Correspondence.Application.PurgeDialogAndDeleteReminderForReadCorrespondences;
 
 namespace Altinn.Correspondence.API.Controllers;
 
@@ -366,6 +367,26 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
             jobId,
             message = "Maskinporten JWK rotation was enqueued."
         });
+    }
+
+
+    [HttpGet]
+    [Route("purge-dialog-and-delete-reminder-for-read-correspondences")]
+    [Authorize(Policy = AuthorizationConstants.Maintenance)]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult> PurgeDialogAndDeleteReminderForReadCorrespondences(
+        [FromServices] PurgeDialogAndDeleteReminderForReadCorrespondencesHandler handler,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Request to purge dialog and delete reminder for read correspondences received");
+        var result = await handler.Process(HttpContext.User, cancellationToken);
+        return result.Match(
+            Ok,
+            Problem
+        );
     }
 
     private ActionResult Problem(Error error) => ProblemDetailsHelper.ToProblemResult(error);

--- a/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/MaintenanceController.cs
@@ -370,7 +370,7 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
     }
 
 
-    [HttpGet]
+    [HttpPost]
     [Route("purge-dialog-and-delete-reminder-for-read-correspondences")]
     [Authorize(Policy = AuthorizationConstants.Maintenance)]
     [Produces("application/json")]

--- a/src/Altinn.Correspondence.Application/DependencyInjection.cs
+++ b/src/Altinn.Correspondence.Application/DependencyInjection.cs
@@ -38,6 +38,7 @@ using Altinn.Correspondence.Application.GetUnreadConfidentialCorrespondences;
 using Altinn.Correspondence.Application.UnreadConfidentialCorrespondence;
 using Altinn.Correspondence.Application.ManualRetryNotPublishedCorrespondences;
 using Altinn.Correspondence.Application.DownloadAllCorrespondenceAttachments;
+using Altinn.Correspondence.Application.PurgeDialogAndDeleteReminderForReadCorrespondences;
 using Altinn.Correspondence.Core.Services;
 
 namespace Altinn.Correspondence.Application;
@@ -88,6 +89,7 @@ public static class DependencyInjection
         services.AddScoped<EnqueueMissingNotificationSentChecksHandler>();
         services.AddScoped<CleanupBulkFetchStatuses.CleanupBulkFetchStatusesHandler>();
         services.AddScoped<ManualRetryNotPublishedCorrespondencesHandler>();
+        services.AddScoped<PurgeDialogAndDeleteReminderForReadCorrespondencesHandler>();
 
         // Statistics & Reporting
         services.AddScoped<GenerateDailySummaryReportHandler>();

--- a/src/Altinn.Correspondence.Application/PurgeDialogAndDeleteReminderForReadCorrespondences/PurgeDialogAndDeleteReminderForReadCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeDialogAndDeleteReminderForReadCorrespondences/PurgeDialogAndDeleteReminderForReadCorrespondencesHandler.cs
@@ -87,18 +87,6 @@ public class PurgeDialogAndDeleteReminderForReadCorrespondencesHandler(
     {
         try
         {
-        await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(reminder.CorrespondenceId, cancellationToken);
-        logger.LogInformation(
-            "Deleted confidential reminder {reminderId} | CorrespondenceId: {correspondenceId} | DialogId: {dialogId}",
-            reminder.Id, reminder.CorrespondenceId, reminder.DialogId);
-            
-        } catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to delete confidential reminder {reminderId} for correspondence {correspondenceId}", reminder.Id, reminder.CorrespondenceId);
-            throw;
-        }
-        try
-        {
             if (!reminder.DialogId.HasValue)
             {
                 logger.LogWarning("No DialogId found for confidential reminder {reminderId}, skipping dialog deletion", reminder.Id);
@@ -109,6 +97,18 @@ public class PurgeDialogAndDeleteReminderForReadCorrespondencesHandler(
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to soft delete dialog {dialogId} linked to confidential reminder {reminderId}", reminder.DialogId, reminder.Id);
+            throw;
+        }
+        try
+        {
+        await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(reminder.CorrespondenceId, cancellationToken);
+        logger.LogInformation(
+            "Deleted confidential reminder {reminderId} | CorrespondenceId: {correspondenceId} | DialogId: {dialogId}",
+            reminder.Id, reminder.CorrespondenceId, reminder.DialogId);
+            
+        } catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete confidential reminder {reminderId} for correspondence {correspondenceId}", reminder.Id, reminder.CorrespondenceId);
             throw;
         }
 

--- a/src/Altinn.Correspondence.Application/PurgeDialogAndDeleteReminderForReadCorrespondences/PurgeDialogAndDeleteReminderForReadCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeDialogAndDeleteReminderForReadCorrespondences/PurgeDialogAndDeleteReminderForReadCorrespondencesHandler.cs
@@ -1,0 +1,117 @@
+using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Repositories;
+using Microsoft.Extensions.Logging;
+using OneOf;
+using System.Security.Claims;
+using Hangfire;
+using Altinn.Correspondence.Core.Services;
+
+namespace Altinn.Correspondence.Application.PurgeDialogAndDeleteReminderForReadCorrespondences;
+
+public class PurgeDialogAndDeleteReminderForReadCorrespondencesHandler(
+    IConfidentialReminderRepository confidentialReminderRepository,
+    IDialogportenService dialogportenService,
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<PurgeDialogAndDeleteReminderForReadCorrespondencesHandler> logger) : IHandler<PurgeDialogAndDeleteReminderForReadCorrespondencesResponse>
+{
+    public Task<OneOf<PurgeDialogAndDeleteReminderForReadCorrespondencesResponse, Error>> Process(ClaimsPrincipal? user, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Enqueueing deletion job for confidential reminders linked to read correspondences");
+
+        var jobId = backgroundJobClient.Enqueue(() => ExecuteDeleteInBackground(CancellationToken.None));
+
+        logger.LogInformation("Deletion job {jobId} has been enqueued", jobId);
+
+        return Task.FromResult<OneOf<PurgeDialogAndDeleteReminderForReadCorrespondencesResponse, Error>>(new PurgeDialogAndDeleteReminderForReadCorrespondencesResponse
+        {
+            JobId = jobId,
+            Message = "Deletion job has been enqueued"
+        });
+    }
+
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(timeoutInSeconds: 43200)]
+    public async Task ExecuteDeleteInBackground(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Executing deletion of confidential reminders linked to read correspondences");
+
+        var totalProcessed = 0;
+        var totalDeleted = 0;
+        var totalSkipped = 0;
+        var totalErrors = 0;
+        var allErrors = new List<string>();
+
+        try
+        {
+            var reminders = await confidentialReminderRepository.GetConfidentialRemindersLinkedToReadCorrespondences(
+                cancellationToken);
+
+            logger.LogInformation("Found {count} reminders to process", reminders.Count);
+
+            foreach (var reminder in reminders)
+            {
+                try
+                {
+                    totalProcessed++;
+                    var deleted = await ProcessSingleReminder(reminder, cancellationToken);
+                    if (deleted)
+                        totalDeleted++;
+                    else
+                        totalSkipped++;
+                }
+                catch (Exception ex)
+                {
+                    totalErrors++;
+                    allErrors.Add($"Error processing reminder {reminder.Id}: {ex.Message}");
+                    logger.LogError(ex, "Failed to process reminder {reminderId}", reminder.Id);
+                }
+            }
+
+            logger.LogInformation(
+                "Deletion job completed. Total processed: {totalProcessed}, Deleted: {totalDeleted}, Skipped: {totalSkipped}, Errors: {totalErrors}",
+                totalProcessed, totalDeleted, totalSkipped, totalErrors);
+
+            if (allErrors.Count > 0)
+            {
+                logger.LogWarning("Deletion job completed with {errorCount} errors: {errors}", totalErrors, string.Join("; ", allErrors));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Fatal error during deletion of confidential reminders");
+            throw;
+        }
+    }
+
+    private async Task<bool> ProcessSingleReminder(ConfidentialReminderEntity reminder, CancellationToken cancellationToken)
+    {
+        try
+        {
+        await confidentialReminderRepository.RemoveConfidentialReminderByCorrespondenceId(reminder.CorrespondenceId, cancellationToken);
+        logger.LogInformation(
+            "Deleted confidential reminder {reminderId} | CorrespondenceId: {correspondenceId} | DialogId: {dialogId}",
+            reminder.Id, reminder.CorrespondenceId, reminder.DialogId);
+            
+        } catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete confidential reminder {reminderId} for correspondence {correspondenceId}", reminder.Id, reminder.CorrespondenceId);
+            throw;
+        }
+        try
+        {
+            if (!reminder.DialogId.HasValue)
+            {
+                logger.LogWarning("No DialogId found for confidential reminder {reminderId}, skipping dialog deletion", reminder.Id);
+                return true;
+            }
+            await dialogportenService.TrySoftDeleteDialog(reminder.DialogId.Value.ToString());
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to soft delete dialog {dialogId} linked to confidential reminder {reminderId}", reminder.DialogId, reminder.Id);
+            throw;
+        }
+
+        return true;
+    }
+}

--- a/src/Altinn.Correspondence.Application/PurgeDialogAndDeleteReminderForReadCorrespondences/PurgeDialogAndDeleteReminderForReadCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/PurgeDialogAndDeleteReminderForReadCorrespondences/PurgeDialogAndDeleteReminderForReadCorrespondencesHandler.cs
@@ -87,12 +87,15 @@ public class PurgeDialogAndDeleteReminderForReadCorrespondencesHandler(
     {
         try
         {
+            if (await confidentialReminderRepository.NumberOfRemindersForRecipient(reminder.Recipient, cancellationToken) == 1){
+
             if (!reminder.DialogId.HasValue)
             {
                 logger.LogWarning("No DialogId found for confidential reminder {reminderId}, skipping dialog deletion", reminder.Id);
                 return true;
             }
             await dialogportenService.TrySoftDeleteDialog(reminder.DialogId.Value.ToString());
+        }
         }
         catch (Exception ex)
         {

--- a/src/Altinn.Correspondence.Application/PurgeDialogAndDeleteReminderForReadCorrespondences/PurgeDialogAndDeleteReminderForReadCorrespondencesResponse.cs
+++ b/src/Altinn.Correspondence.Application/PurgeDialogAndDeleteReminderForReadCorrespondences/PurgeDialogAndDeleteReminderForReadCorrespondencesResponse.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Correspondence.Application.PurgeDialogAndDeleteReminderForReadCorrespondences;
+
+public class PurgeDialogAndDeleteReminderForReadCorrespondencesResponse
+{
+    public string JobId { get; set; }
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Altinn.Correspondence.Core/Repositories/IConfidentialReminderRepository.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/IConfidentialReminderRepository.cs
@@ -9,5 +9,6 @@ namespace Altinn.Correspondence.Core.Repositories
         Task<int> NumberOfRemindersForRecipient(string recipient, CancellationToken cancellationToken);
         Task<bool> CorrespondenceHasReminder(Guid correspondenceId, CancellationToken cancellationToken);
         Task<Guid?> GetDialogIdOfReminderForRecipient(string recipient, CancellationToken cancellationToken);
+        Task<List<ConfidentialReminderEntity>> GetConfidentialRemindersLinkedToReadCorrespondences(CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/ConfidentialReminderRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/ConfidentialReminderRepository.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -52,5 +53,14 @@ public class ConfidentialReminderRepository(ApplicationDbContext context) : ICon
             return null;
         }
         return reminder.DialogId;
+    }
+
+   public async Task<List<ConfidentialReminderEntity>> GetConfidentialRemindersLinkedToReadCorrespondences(CancellationToken cancellationToken)
+    {
+    return await _context.ConfidentialReminders
+        .Where(cr => _context.CorrespondenceStatuses
+            .Any(cs => cs.CorrespondenceId == cr.CorrespondenceId 
+                    && cs.Status == CorrespondenceStatus.Read))
+        .ToListAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
## Description
Reminders that were opened in A2 were not handled correctly previously and as a result we have some opened confidential correspondences which still have a reminder linked to them. This job removes the reminder and purges the dialog.

## Related Issue(s)
- #1968 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a maintenance endpoint to purge dialog content and delete reminders for correspondences marked as read, enabling automated cleanup.
  * Cleanup starts asynchronously and returns a job reference when initiated.
  * Processing removes confidential reminders and soft-deletes dialogs when appropriate; individual errors are isolated so other items continue processing.
  * Endpoint is protected by the maintenance authorization policy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-correspondence/pull/1970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->