### PR TITLE
increase max size for download all attachments to 2gb

### DIFF
--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
@@ -92,7 +92,7 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
             return AuthorizationErrors.CouldNotFindPartyUuid;
         }   
 
-        const long maxAttachmentSizeForZip = 25_000_000; // 25 MB
+        const long maxAttachmentSizeForZip = 2_000_000_000; // 2 GB
         var totalSize = attachments.Sum(a => a.AttachmentSize);
         if (totalSize > maxAttachmentSizeForZip)
         {

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -655,7 +655,7 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
 
             if (enableDownloadAll
                 && correspondence.Content?.Attachments?.Count >= 2
-                && correspondence.Content.Attachments.Sum(a => a.Attachment?.AttachmentSize ?? 0) < 25_000_000)
+                && correspondence.Content.Attachments.Sum(a => a.Attachment?.AttachmentSize ?? 0) < 2_000_000_000)
             {
                 attachments.Insert(0, new Attachment
                 {


### PR DESCRIPTION
## Description
Increased the limit to enable download all attachments to 2gb

## Related Issue(s)
- #1979

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)