### PR TITLE
Allow sender to get archived correspondences

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
@@ -70,6 +70,34 @@ namespace Altinn.Correspondence.Tests.TestingRepository
             Assert.Equal(addedCorrespondence.Id, correspondences?.FirstOrDefault()?.Id);
         }
 
+        [Fact]
+        public async Task GetCorrespondences_AsSender_ReturnsArchivedCorrespondence()
+        {
+            // Arrange
+            await using var context = _fixture.CreateDbContext();
+            var correspondenceRepository = new CorrespondenceRepository(context, new NullLogger<ICorrespondenceRepository>());
+            var baseTime = new DateTimeOffset(new DateTime(2002, 1, 1, 0, 0, 0), TimeSpan.Zero);
+            var from = baseTime.AddDays(-1);
+            var to = baseTime.AddDays(1);
+            var senderOrgNo = "991825827";
+            var resource = Guid.NewGuid().ToString();
+            var entity = new CorrespondenceEntityBuilder()
+                .WithResourceId(resource)
+                .WithRequestedPublishTime(baseTime)
+                .WithStatus(CorrespondenceStatus.Published, baseTime.AddMinutes(1))
+                .WithStatus(CorrespondenceStatus.Archived, baseTime.AddMinutes(2))
+                .Build();
+            var addedCorrespondence = await correspondenceRepository.CreateCorrespondence(entity, CancellationToken.None);
+
+            // Act
+            var byArchivedStatus = await correspondenceRepository.GetCorrespondences(resource, 1000, from, to, CorrespondenceStatus.Archived, senderOrgNo, CorrespondencesRoleType.Sender, null, default, CancellationToken.None);
+            var withoutStatus = await correspondenceRepository.GetCorrespondences(resource, 1000, from, to, null, senderOrgNo, CorrespondencesRoleType.Sender, null, default, CancellationToken.None);
+
+            // Assert
+            Assert.Contains(addedCorrespondence.Id, byArchivedStatus);
+            Assert.Contains(addedCorrespondence.Id, withoutStatus);
+        }
+
         [Theory]
         [InlineData("SEnDeROrgNuMBeR")]
         [InlineData("senderorgnumber")]

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -20,10 +20,7 @@ namespace Altinn.Correspondence.Persistence.Helpers
 
         public static IQueryable<CorrespondenceEntity> FilterByStatus(this IQueryable<CorrespondenceEntity> query, CorrespondenceStatus? status, string orgNo, CorrespondencesRoleType role)
         {
-            var blacklistSender = new List<CorrespondenceStatus?>
-            {
-                CorrespondenceStatus.Archived,
-            };
+            var blacklistSender = new List<CorrespondenceStatus?>();
 
             var blacklistRecipient = new List<CorrespondenceStatus?>
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR allows sender to get archved correspondences, since they are available frm dialogporten anyways.

## Related Issue(s)
- #1982 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification test for archived correspondence retrieval when querying as a sender.

* **Bug Fixes**
  * Fixed filtering logic to ensure archived correspondence is properly returned in sender queries, including when no specific status filter is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->