### PR TITLE
Fix/all attachments wrong index

### DIFF
--- a/src/Altinn.Correspondence.Application/UpdateOldCorrespondencesWithDownloadAll/UpdateOldCorrespondencesWithDownloadAllHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateOldCorrespondencesWithDownloadAll/UpdateOldCorrespondencesWithDownloadAllHandler.cs
@@ -151,8 +151,8 @@ public class UpdateOldCorrespondencesWithDownloadAllHandler(
         }
         try
         {
-            var updated = await dialogportenService.TryAddDownloadAllAttachmentsToDialog(dialogId, correspondence, cancellationToken);
-            return updated;
+            _backgroundJobClient.Enqueue<IDialogportenService>(service => service.TryAddDownloadAllAttachmentsToDialog(dialogId, correspondence, CancellationToken.None));
+            return true;
         }
         catch (Exception ex)
         {

--- a/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
+++ b/src/Altinn.Correspondence.Core/Services/IDialogportenService.cs
@@ -35,5 +35,5 @@ public interface IDialogportenService
     Task AddForwardingEvent(Guid forwardingEventId, CancellationToken cancellationToken);
     Task<string> CreateConfidentialReminderDialog(ConfidentialReminderDialogDto reminder);
     Task<bool> HasDownloadAllAttachments(string dialogId, CancellationToken cancellationToken = default);
-    Task<bool> TryAddDownloadAllAttachmentsToDialog(string dialogId, CorrespondenceEntity correspondence, CancellationToken cancellationToken = default);
+    Task TryAddDownloadAllAttachmentsToDialog(string dialogId, CorrespondenceEntity correspondence, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenDevService.cs
@@ -151,9 +151,9 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
             return Task.FromResult(false);
         }
 
-        public Task<bool> TryAddDownloadAllAttachmentsToDialog(string dialogId, CorrespondenceEntity correspondence, CancellationToken cancellationToken = default)
+        public Task TryAddDownloadAllAttachmentsToDialog(string dialogId, CorrespondenceEntity correspondence, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(true);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Options;
 using System.Net;
 using System.Net.Http.Json;
 using UUIDNext;
+using Hangfire;
 
 namespace Altinn.Correspondence.Integrations.Dialogporten;
 
@@ -898,7 +899,8 @@ public class DialogportenService(HttpClient _httpClient,
         return dialog.Attachments?.Any(a => a.Urls != null && a.Urls.Any(u => u.Url.Contains("downloadall"))) ?? false; 
     }
 
-    public async Task<bool> TryAddDownloadAllAttachmentsToDialog(string dialogId, CorrespondenceEntity correspondence, CancellationToken cancellationToken = default)
+    [AutomaticRetry(Attempts = 10)]
+    public async Task TryAddDownloadAllAttachmentsToDialog(string dialogId, CorrespondenceEntity correspondence, CancellationToken cancellationToken = default)
     {
         var dialog = await GetDialog(dialogId);
         if (dialog is null)
@@ -906,16 +908,37 @@ public class DialogportenService(HttpClient _httpClient,
             throw new Exception($"Dialog {dialogId} not found when attempting to add download all attachments");
         }
 
+        List<Attachment> attachments = dialog.Attachments ?? new List<Attachment>();
+        bool hasAttachments = attachments.Count > 0;
+        if (!hasAttachments){
+            var correspondenceEntity = await _correspondenceRepository.GetCorrespondenceById(correspondence.Id, true, true, false, cancellationToken);
+            if (correspondenceEntity is null)            {
+                logger.LogError("Correspondence with id {correspondenceId} not found", correspondence.Id);
+                throw new ArgumentException($"Correspondence with id {correspondence.Id} not found", nameof(correspondence.Id));
+            }
+            attachments = CreateDialogRequestMapper.GetAttachmentsForDialogPatchRequest(correspondenceEntity, generalSettings.Value.CorrespondenceBaseUrl);
+        } else{
+            logger.LogInformation("Trying to remove attachments from correspondence: {correspondenceId}", correspondence.Id);
+            var patchRequestBuilderRemoveAttachments = new DialogPatchRequestBuilder()
+                .WithRemoveAttachmentsOperation();
+            var patchRequestRemoveAttachments = patchRequestBuilderRemoveAttachments.Build();
+            var responseRemoveAttachments = await _httpClient.PatchAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}?isSilentUpdate=true", patchRequestRemoveAttachments, cancellationToken);
+            if (!responseRemoveAttachments.IsSuccessStatusCode){
+                logger.LogError($"Response from Dialogporten when removing attachments for {dialogId} was not successful: {responseRemoveAttachments.StatusCode}: {await responseRemoveAttachments.Content.ReadAsStringAsync()}");
+                throw new Exception($"Response from Dialogporten when removing attachments was not successful: {responseRemoveAttachments.StatusCode}: {await responseRemoveAttachments.Content.ReadAsStringAsync()}");
+            }
+        }
+
+        logger.LogInformation("Trying to add download all attachments to correspondence: {correspondenceId}", correspondence.Id);
         var patchRequestBuilder = new DialogPatchRequestBuilder()
-            .WithAddDownloadAllAttachmentsOperation(baseUrl: generalSettings.Value.CorrespondenceBaseUrl, correspondence: correspondence);
+            .WithAddDownloadAllAttachmentsOperation(baseUrl: generalSettings.Value.CorrespondenceBaseUrl, correspondence: correspondence, attachments: attachments);
         var patchRequest = patchRequestBuilder.Build();
-        var response = await _httpClient.PatchAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}", patchRequest, cancellationToken);
+        var response = await _httpClient.PatchAsJsonAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}?isSilentUpdate=true", patchRequest, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
-            logger.LogError(($"Response from Dialogporten when adding download all attachments for {dialogId} was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}"));
-            return false;
+            logger.LogError($"Response from Dialogporten when adding download all attachments for {dialogId} was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+            throw new Exception($"Response from Dialogporten when adding download all attachments was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
         }
-        return true;
     }
 
     #region MigrationRelated

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Factories/PatchDialogRequestBuilder.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Factories/PatchDialogRequestBuilder.cs
@@ -74,17 +74,26 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
             return this;
         }
 
-        internal DialogPatchRequestBuilder WithAddDownloadAllAttachmentsOperation(string baseUrl, CorrespondenceEntity correspondence)
+        internal DialogPatchRequestBuilder WithRemoveAttachmentsOperation()
         {
-            var baseTimestamp = DateTimeOffset.UtcNow;
             _PatchDialogRequest.Add(
                 new
                 {
-                    op = "add",
-                    path = "/attachments/0",
-                    value = new Attachment
+                    op = "remove",
+                    path = "/attachments"
+                }
+            );
+            return this;
+        }
+
+        internal DialogPatchRequestBuilder WithAddDownloadAllAttachmentsOperation(string baseUrl, CorrespondenceEntity correspondence, List<Attachment> attachments)
+        {
+            var baseTimestamp = DateTimeOffset.UtcNow;
+            var dialogAttachments = attachments;
+            var downloadAllAttachment = 
+                new Attachment
                     {
-                        Id = Guid.CreateVersion7(baseTimestamp).ToString(),
+                        Id = Guid.CreateVersion7(DateTimeOffset.UnixEpoch).ToString(),
                         DisplayName = new List<DisplayName>
                     {
                         new DisplayName { LanguageCode = "nb", Value = "Alle vedlegg" },
@@ -100,8 +109,26 @@ namespace Altinn.Correspondence.Integrations.Dialogporten
                             Url = GetDownloadAllAttachmentsEndpoint(baseUrl, correspondence.Id)
                         }
                     }
+                    };
+            dialogAttachments.Insert(0, downloadAllAttachment);
+                _PatchDialogRequest.Add(
+                    new
+                    {
+                        op = "add",
+                        path = "/attachments",
+                        value = dialogAttachments.Select(a => new
+                        {
+                            id = a.Id,
+                            displayName = a.DisplayName,
+                            urls = a.Urls?.Select(u => new
+                            {
+                                consumerType = u.ConsumerType,
+                                mediaType = u.MediaType,
+                                url = u.Url
+                            })
+                        })
                     }
-                });
+                );
             return this;
         }
 

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Mappers/CreateDialogRequestMapper.cs
@@ -692,5 +692,11 @@ namespace Altinn.Correspondence.Integrations.Dialogporten.Mappers
                 }
             };
         }
+
+        internal static List<Attachment> GetAttachmentsForDialogPatchRequest(CorrespondenceEntity correspondence, string baseUrl)
+        {
+            var attachments = GetAttachmentsForCorrespondence(baseUrl, correspondence);
+            return attachments;
+        }
     }
 }


### PR DESCRIPTION
## Description
When running the job the indexing of the download all attachments button was wrong. This PR improves the patch logic through queueing a background job with retries. The background job runs two patch methods responsible for removing the attachments of the dialog, and adding them back again with the download all inserted and indexed correctly.
If the patch method which is supposed to add the attachments back to the dialog fails, when retried the job will retrieve the attachments from the correspondence to ensure attachments arent lost. 

## Related Issue(s)
- #1969
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved resilience of the "Download All Attachments" operation with automatic retry logic.
  * Updated attachment handling in dialogs to support more robust patching workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->