### PR TITLE
Added read field to overview and detail endpoint responses

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceStatusTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceStatusTests.cs
@@ -75,6 +75,51 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
+        public async Task GetCorrespondence_ReadTimestamp_IsNullBeforeRead()
+        {
+            // Arrange
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .Build();
+            var initializedCorrespondence = await CorrespondenceHelper.GetInitializedCorrespondence(_senderClient, _responseSerializerOptions, payload);
+            var correspondenceId = initializedCorrespondence.CorrespondenceId;
+            await CorrespondenceHelper.WaitForCorrespondenceStatusUpdate(_senderClient, _responseSerializerOptions, correspondenceId, CorrespondenceStatusExt.Published);
+
+            // Act
+            var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{correspondenceId}", _responseSerializerOptions);
+            var details = await _senderClient.GetFromJsonAsync<CorrespondenceDetailsExt>($"correspondence/api/v1/correspondence/{correspondenceId}/details", _responseSerializerOptions);
+
+            // Assert
+            Assert.Null(overview?.Read);
+            Assert.Null(details?.Read);
+        }
+
+        [Fact]
+        public async Task GetCorrespondence_ReadTimestamp_IsPopulatedOnOverviewAndDetailsAfterRead()
+        {
+            // Arrange
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .Build();
+            var initializedCorrespondence = await CorrespondenceHelper.GetInitializedCorrespondence(_senderClient, _responseSerializerOptions, payload);
+            var correspondenceId = initializedCorrespondence.CorrespondenceId;
+            await CorrespondenceHelper.WaitForCorrespondenceStatusUpdate(_senderClient, _responseSerializerOptions, correspondenceId, CorrespondenceStatusExt.Published);
+
+            // Act
+            var fetchResponse = await _recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}"); // Fetch in order to be able to Read
+            Assert.Equal(HttpStatusCode.OK, fetchResponse.StatusCode);
+            var readResponse = await _recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/markasread", null);
+            readResponse.EnsureSuccessStatusCode();
+
+            // Assert
+            var overview = await _senderClient.GetFromJsonAsync<CorrespondenceOverviewExt>($"correspondence/api/v1/correspondence/{correspondenceId}", _responseSerializerOptions);
+            var details = await _senderClient.GetFromJsonAsync<CorrespondenceDetailsExt>($"correspondence/api/v1/correspondence/{correspondenceId}/details", _responseSerializerOptions);
+            Assert.NotNull(overview?.Read);
+            Assert.NotNull(details?.Read);
+            Assert.Equal(overview?.Read, details?.Read);
+        }
+
+        [Fact]
         public async Task UpdateCorrespondenceStatus_MarkAsRead_WithoutFetched_ReturnsBadRequest()
         {
             //  Arrange

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceDetailsMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceDetailsMapper.cs
@@ -31,6 +31,7 @@ internal static class CorrespondenceDetailsMapper
             DueDateTime = correspondenceDetails.DueDateTime,
             PropertyList = correspondenceDetails.PropertyList,
             Published = correspondenceDetails.Published,
+            Read = correspondenceDetails.Read,
             IsConfirmationNeeded = correspondenceDetails.IsConfirmationNeeded,
             IsConfidential = correspondenceDetails.IsConfidential,
             Altinn2CorrespondenceId = correspondenceDetails.Altinn2CorrespondenceId,

--- a/src/Altinn.Correspondence.API/Mappers/CorrespondenceOverviewMapper.cs
+++ b/src/Altinn.Correspondence.API/Mappers/CorrespondenceOverviewMapper.cs
@@ -35,6 +35,7 @@ internal static class CorrespondenceOverviewMapper
             PropertyList = correspondenceOverview.PropertyList,
             IgnoreReservation = correspondenceOverview.IgnoreReservation,
             Published = correspondenceOverview.Published,
+            Read = correspondenceOverview.Read,
             IsConfirmationNeeded = correspondenceOverview.IsConfirmationNeeded,
             IsConfidential = correspondenceOverview.IsConfidential,
             Altinn2CorrespondenceId = correspondenceOverview.Altinn2CorrespondenceId

--- a/src/Altinn.Correspondence.API/Models/CorrespondenceOverviewExt.cs
+++ b/src/Altinn.Correspondence.API/Models/CorrespondenceOverviewExt.cs
@@ -67,5 +67,11 @@ namespace Altinn.Correspondence.API.Models
         /// </summary>
         [JsonPropertyName("published")]
         public DateTimeOffset? Published { get; set; }
+
+        /// <summary>
+        /// Timestamp for when the correspondence was first read by the recipient. Is null until the correspondence has been read.
+        /// </summary>
+        [JsonPropertyName("read")]
+        public DateTimeOffset? Read { get; set; }
     }
 }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsHandler.cs
@@ -178,6 +178,7 @@ public class GetCorrespondenceDetailsHandler(
                 DueDateTime = correspondence.DueDateTime,
                 PropertyList = correspondence.PropertyList,
                 Published = correspondence.Published,
+                Read = correspondence.GetReadTimestamp(),
                 IsConfirmationNeeded = correspondence.IsConfirmationNeeded,
                 IsConfidential = correspondence.IsConfidential,
                 SystemLabel = systemLabel

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceDetails/GetCorrespondenceDetailsResponse.cs
@@ -46,6 +46,8 @@ public class GetCorrespondenceDetailsResponse
     
     public DateTimeOffset? Published { get; internal set; }
 
+    public DateTimeOffset? Read { get; set; }
+
     public bool IsConfirmationNeeded { get; set; }
     
     public bool IsConfidential { get; set; }

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -194,6 +194,7 @@ public class GetCorrespondenceOverviewHandler(
                 RequestedPublishTime = correspondence.RequestedPublishTime,
                 IgnoreReservation = correspondence.IgnoreReservation ?? false,
                 Published = correspondence.Published,
+                Read = correspondence.GetReadTimestamp(),
                 IsConfirmationNeeded = correspondence.IsConfirmationNeeded,
                 IsConfidential = correspondence.IsConfidential,
                 Altinn2CorrespondenceId = correspondence.Altinn2CorrespondenceId

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewHandler.cs
@@ -83,6 +83,7 @@ public class GetCorrespondenceOverviewHandler(
 
         return await TransactionWithRetriesPolicy.Execute<OneOf<GetCorrespondenceOverviewResponse, Error>>(async (cancellationToken) =>
         {
+            DateTimeOffset? readTimestamp = null;
             if (hasAccessAsRecipient && !user.CallingAsSender())
             {
                 if (!latestStatus.Status.IsAvailableForRecipient())
@@ -110,7 +111,7 @@ public class GetCorrespondenceOverviewHandler(
                     cancellationToken);
                 if (request.OnlyGettingContent)
                 {
-                    if (!correspondence.StatusHasBeen(CorrespondenceStatus.Read)) { 
+                    if (!correspondence.StatusHasBeen(CorrespondenceStatus.Read)) {
                         await correspondenceStatusRepository.AddCorrespondenceStatus(new CorrespondenceStatusEntity
                         {
                             CorrespondenceId = correspondence.Id,
@@ -119,6 +120,7 @@ public class GetCorrespondenceOverviewHandler(
                             StatusChanged = operationTimestamp,
                             PartyUuid = partyUuid
                         }, cancellationToken);
+                        readTimestamp = operationTimestamp;
                         backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(
                             AltinnEventType.CorrespondenceReceiverRead,
                             correspondence.ResourceId,
@@ -194,7 +196,7 @@ public class GetCorrespondenceOverviewHandler(
                 RequestedPublishTime = correspondence.RequestedPublishTime,
                 IgnoreReservation = correspondence.IgnoreReservation ?? false,
                 Published = correspondence.Published,
-                Read = correspondence.GetReadTimestamp(),
+                Read = readTimestamp ?? correspondence.GetReadTimestamp(),
                 IsConfirmationNeeded = correspondence.IsConfirmationNeeded,
                 IsConfidential = correspondence.IsConfidential,
                 Altinn2CorrespondenceId = correspondence.Altinn2CorrespondenceId

--- a/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
+++ b/src/Altinn.Correspondence.Application/GetCorrespondenceOverview/GetCorrespondenceOverviewResponse.cs
@@ -45,6 +45,8 @@ public class GetCorrespondenceOverviewResponse
     
     public DateTimeOffset? Published { get; set; }
 
+    public DateTimeOffset? Read { get; set; }
+
     public bool IsConfirmationNeeded { get; set; }
     
     public bool IsConfidential { get; set; }

--- a/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
+++ b/src/Altinn.Correspondence.Application/Helpers/CorrespondenceExtensions.cs
@@ -85,4 +85,15 @@ public static class CorrespondenceStatusExtensions
     {
         return correspondence.Statuses.Any(s => s.Status == status) || correspondence.StatusFetched.Any(s => s.Status == status);
     }
+
+    /// <summary>
+    /// Returns the timestamp of the first time the correspondence was marked as Read, or null if it has not been read.
+    /// </summary>
+    public static DateTimeOffset? GetReadTimestamp(this CorrespondenceEntity correspondence)
+    {
+        return correspondence.Statuses
+            .Where(s => s.Status == CorrespondenceStatus.Read)
+            .OrderBy(s => s.StatusChanged)
+            .FirstOrDefault()?.StatusChanged;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a read field to both the overview and detail endpoints. The field is the timestamp for when the correspondence was first read and null if not yet read, similar to the existing published field present on both the endpoints. This allows an API-user to check if the correspondence has been read from the overview endpoint.

## Related Issue(s)
- #1989 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Correspondence now displays read timestamps, indicating when items were marked as read in both overview and detailed views.

* **Tests**
  * Added test cases to validate read timestamp behavior before and after marking correspondence as read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->