### PR TITLE
Exclude malwarescan from audit

### DIFF
--- a/.azure/applications/api/main.bicep
+++ b/.azure/applications/api/main.bicep
@@ -69,8 +69,6 @@ module auditStorageBlobLogsTransform '../../modules/logAnalytics/workspaceStorag
   scope: resourceGroup
   params: {
     location: location
-    appObjectId: appIdentity.outputs.principalId
-    appClientId: appIdentity.outputs.clientId
     namePrefix: namePrefix
   }
 }

--- a/.azure/applications/api/main.bicep
+++ b/.azure/applications/api/main.bicep
@@ -70,6 +70,7 @@ module auditStorageBlobLogsTransform '../../modules/logAnalytics/workspaceStorag
   params: {
     location: location
     appObjectId: appIdentity.outputs.principalId
+    appClientId: appIdentity.outputs.clientId
     namePrefix: namePrefix
   }
 }

--- a/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
+++ b/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
@@ -4,6 +4,9 @@ param location string = resourceGroup().location
 @description('Object ID of the app managed identity to exclude from StorageBlobLogs.')
 param appObjectId string
 
+@description('Application (client) ID of the app managed identity to exclude from StorageBlobLogs.')
+param appClientId string
+
 @description('Prefix used for uniquely named DCR resources in this environment.')
 param namePrefix string
 
@@ -11,7 +14,13 @@ var workspaceName = '${namePrefix}-audit-logs'
 var transformDcrName = '${namePrefix}-storageblob-logs-transform-dcr'
 var dcrAssociationName = '${namePrefix}-storageblob-logs-transform-assoc'
 var logAnalyticsDestinationName = 'audit-logs'
-var blobLogsTransformKql = 'source | where RequesterObjectId != "${appObjectId}"'
+var defenderScannerObjectId = storageDataScanner.identity.principalId
+var blobLogsTransformKql = 'source | where AuthenticationType !~ \'TrustedAccess\' | where tolower(tostring(RequesterObjectId)) !in~ (tolower(\'${appObjectId}\'), tolower(\'${defenderScannerObjectId}\')) | where tolower(tostring(RequesterAppId)) != tolower(\'${appClientId}\')'
+
+resource storageDataScanner 'Microsoft.Security/datascanners@2025-06-01' existing = {
+  scope: subscription()
+  name: 'StorageDataScanner'
+}
 
 resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
   name: workspaceName
@@ -50,8 +59,9 @@ resource dcrAssociation 'Microsoft.Insights/dataCollectionRuleAssociations@2023-
   name: dcrAssociationName
   properties: {
     dataCollectionRuleId: transformDcr.id
-    description: 'Exclude app managed identity from StorageBlobLogs in the audit workspace'
+    description: 'Exclude app managed identity, Defender StorageDataScanner, and platform TrustedAccess calls from StorageBlobLogs'
   }
 }
 
 output dataCollectionRuleId string = transformDcr.id
+output transformKql string = blobLogsTransformKql

--- a/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
+++ b/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
@@ -12,18 +12,13 @@ param namePrefix string
 
 var workspaceName = '${namePrefix}-audit-logs'
 var transformDcrName = '${namePrefix}-storageblob-logs-transform-dcr'
-var dcrAssociationName = '${namePrefix}-storageblob-logs-transform-assoc'
 var logAnalyticsDestinationName = 'audit-logs'
 var defenderScannerObjectId = storageDataScanner.identity.principalId
-var blobLogsTransformKql = 'source | where AuthenticationType !~ \'TrustedAccess\' | where tolower(tostring(RequesterObjectId)) !in~ (tolower(\'${appObjectId}\'), tolower(\'${defenderScannerObjectId}\')) | where tolower(tostring(RequesterAppId)) != tolower(\'${appClientId}\')'
+var blobLogsTransformKql = 'source | where AuthenticationType !~ \'TrustedAccess\' and AuthenticationType !~ \'AnonymousPreflight\' | where tostring(RequesterObjectId) !~ \'${appObjectId}\' and tostring(RequesterObjectId) !~ \'${defenderScannerObjectId}\' | where tostring(RequesterAppId) !~ \'${appClientId}\''
 
 resource storageDataScanner 'Microsoft.Security/datascanners@2021-12-01-preview' existing = {
   scope: subscription()
   name: 'StorageDataScanner'
-}
-
-resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
-  name: workspaceName
 }
 
 resource transformDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
@@ -46,7 +41,7 @@ resource transformDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
     destinations: {
       logAnalytics: [
         {
-          workspaceResourceId: workspace.id
+          workspaceResourceId: resourceId('Microsoft.OperationalInsights/workspaces', workspaceName)
           name: logAnalyticsDestinationName
         }
       ]
@@ -54,14 +49,17 @@ resource transformDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
   }
 }
 
-resource dcrAssociation 'Microsoft.Insights/dataCollectionRuleAssociations@2023-03-11' = {
-  scope: workspace
-  name: dcrAssociationName
+// Workspace transform DCRs must be linked on the workspace itself (not via dataCollectionRuleAssociations).
+resource auditLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: workspaceName
   properties: {
-    dataCollectionRuleId: transformDcr.id
-    description: 'Exclude app managed identity, Defender StorageDataScanner, and platform TrustedAccess calls from StorageBlobLogs'
+    defaultDataCollectionRuleResourceId: transformDcr.id
   }
+  dependsOn: [
+    transformDcr
+  ]
 }
 
 output dataCollectionRuleId string = transformDcr.id
 output transformKql string = blobLogsTransformKql
+output defenderScannerObjectId string = defenderScannerObjectId

--- a/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
+++ b/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
@@ -39,11 +39,16 @@ resource transformDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
   }
 }
 
-// Workspace transform DCRs must be linked on the workspace itself (not via dataCollectionRuleAssociations).
+// Link the transform DCR on the workspace. Keep sku/retention/tags aligned with containerAppEnvironment/main.bicep.
 resource auditLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: workspaceName
   location: location
+  tags: resourceGroup().tags
   properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 90
     defaultDataCollectionRuleResourceId: transformDcr.id
   }
   dependsOn: [

--- a/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
+++ b/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
@@ -1,5 +1,5 @@
-@description('Azure region for the workspace transformation DCR.')
-param location string = resourceGroup().location
+@description('Azure region for the audit workspace and transformation DCR. Must match the existing workspace location.')
+param location string
 
 @description('Object ID of the app managed identity to exclude from StorageBlobLogs.')
 param appObjectId string
@@ -11,6 +11,7 @@ param appClientId string
 param namePrefix string
 
 var workspaceName = '${namePrefix}-audit-logs'
+var workspaceResourceId = resourceId('Microsoft.OperationalInsights/workspaces', workspaceName)
 var transformDcrName = '${namePrefix}-storageblob-logs-transform-dcr'
 var logAnalyticsDestinationName = 'audit-logs'
 var defenderScannerObjectId = storageDataScanner.identity.principalId
@@ -41,7 +42,7 @@ resource transformDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
     destinations: {
       logAnalytics: [
         {
-          workspaceResourceId: resourceId('Microsoft.OperationalInsights/workspaces', workspaceName)
+          workspaceResourceId: workspaceResourceId
           name: logAnalyticsDestinationName
         }
       ]
@@ -52,6 +53,7 @@ resource transformDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
 // Workspace transform DCRs must be linked on the workspace itself (not via dataCollectionRuleAssociations).
 resource auditLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: workspaceName
+  location: location
   properties: {
     defaultDataCollectionRuleResourceId: transformDcr.id
   }

--- a/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
+++ b/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
@@ -17,7 +17,7 @@ var logAnalyticsDestinationName = 'audit-logs'
 var defenderScannerObjectId = storageDataScanner.identity.principalId
 var blobLogsTransformKql = 'source | where AuthenticationType !~ \'TrustedAccess\' | where tolower(tostring(RequesterObjectId)) !in~ (tolower(\'${appObjectId}\'), tolower(\'${defenderScannerObjectId}\')) | where tolower(tostring(RequesterAppId)) != tolower(\'${appClientId}\')'
 
-resource storageDataScanner 'Microsoft.Security/datascanners@2025-06-01' existing = {
+resource storageDataScanner 'Microsoft.Security/datascanners@2021-12-01-preview' existing = {
   scope: subscription()
   name: 'StorageDataScanner'
 }

--- a/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
+++ b/.azure/modules/logAnalytics/workspaceStorageBlobLogsTransform.bicep
@@ -1,12 +1,6 @@
 @description('Azure region for the audit workspace and transformation DCR. Must match the existing workspace location.')
 param location string
 
-@description('Object ID of the app managed identity to exclude from StorageBlobLogs.')
-param appObjectId string
-
-@description('Application (client) ID of the app managed identity to exclude from StorageBlobLogs.')
-param appClientId string
-
 @description('Prefix used for uniquely named DCR resources in this environment.')
 param namePrefix string
 
@@ -14,13 +8,8 @@ var workspaceName = '${namePrefix}-audit-logs'
 var workspaceResourceId = resourceId('Microsoft.OperationalInsights/workspaces', workspaceName)
 var transformDcrName = '${namePrefix}-storageblob-logs-transform-dcr'
 var logAnalyticsDestinationName = 'audit-logs'
-var defenderScannerObjectId = storageDataScanner.identity.principalId
-var blobLogsTransformKql = 'source | where AuthenticationType !~ \'TrustedAccess\' and AuthenticationType !~ \'AnonymousPreflight\' | where tostring(RequesterObjectId) !~ \'${appObjectId}\' and tostring(RequesterObjectId) !~ \'${defenderScannerObjectId}\' | where tostring(RequesterAppId) !~ \'${appClientId}\''
-
-resource storageDataScanner 'Microsoft.Security/datascanners@2021-12-01-preview' existing = {
-  scope: subscription()
-  name: 'StorageDataScanner'
-}
+// Keep interactive user access only: app MI, Defender scanner, and platform calls have no RequesterUpn.
+var blobLogsTransformKql = 'source | where AuthenticationType =~ \'OAuth\' | where isnotempty(RequesterUpn)'
 
 resource transformDcr 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
   name: transformDcrName
@@ -64,4 +53,3 @@ resource auditLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@20
 
 output dataCollectionRuleId string = transformDcr.id
 output transformKql string = blobLogsTransformKql
-output defenderScannerObjectId string = defenderScannerObjectId


### PR DESCRIPTION
## Description
Malwarescan performs a bunch of operations. Also added filter to get rid of some other platform noise.

## Related Issue(s)
- #1121 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced audit logging to better exclude application-initiated storage operations by using both application object and client identifiers.
  * Updated how the log transformation is associated with the workspace for more reliable delivery.

* **New Features**
  * Improved transformation filtering to retain interactive user access and reduce noisy events; the transformation query is now exposed for inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->