### PR TITLE
Permit transmission correspondences on Altinn App instances

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -713,6 +713,71 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
         }
 
         [Fact]
+        public async Task InitializeCorrespondence_WithAnAltinnApp_FailsWithBadRequest()
+        {
+            // Arrange
+            using var testFactory = new UnitWebApplicationFactory((IServiceCollection services) =>
+            {
+                var resourceRegistryService = new Mock<IResourceRegistryService>();
+                resourceRegistryService.Setup(x => x.GetServiceOwnerNameOfResource(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("altinn-app-test-resource");
+                resourceRegistryService.Setup(x => x.GetResourceType(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("AltinnApp");
+                resourceRegistryService.Setup(x => x.GetServiceOwnerOrganizationNumber(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("991825827");
+                resourceRegistryService.Setup(x => x.GetResourceTitle(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync("altinn-app-test-resource");
+                services.AddScoped(_ => resourceRegistryService.Object);
+            });
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .Build();
+
+            // Act
+            var unitSenderClient = testFactory.CreateSenderClient();
+            var initializeCorrespondenceResponse = await unitSenderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, initializeCorrespondenceResponse.StatusCode);
+            var responseObject = await initializeCorrespondenceResponse.Content.ReadFromJsonAsync<ProblemDetails>(_responseSerializerOptions);
+            Assert.NotNull(responseObject);
+        }
+
+        [Fact]
+        public async Task InitializeCorrespondence_WithAnAltinnApp_AsTransmission_Succeeds()
+        {
+            // Arrange
+            using var testFactory = new UnitWebApplicationFactory((IServiceCollection services) =>
+            {
+                var resourceRegistryService = new Mock<IResourceRegistryService>();
+                resourceRegistryService.Setup(x => x.GetServiceOwnerNameOfResource(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("altinn-app-test-resource");
+                resourceRegistryService.Setup(x => x.GetResourceType(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("AltinnApp");
+                resourceRegistryService.Setup(x => x.GetServiceOwnerOrganizationNumber(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("991825827");
+                resourceRegistryService.Setup(x => x.GetResourceTitle(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync("altinn-app-test-resource");
+                resourceRegistryService.Setup(x => x.GetConfidentialType(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Core.Models.Enums.ConfidentialTypeEnum.NotConfidential);
+                services.AddScoped(_ => resourceRegistryService.Object);
+
+                var mockDialogporten = new Mock<IDialogportenService>();
+                mockDialogporten
+                    .Setup(x => x.DialogValidForTransmission(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+                mockDialogporten
+                    .Setup(x => x.ValidateDialogRecipientMatch(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+                var existingDialogporten = services.FirstOrDefault(d => d.ServiceType == typeof(IDialogportenService));
+                if (existingDialogporten != null) services.Remove(existingDialogporten);
+                services.AddScoped(_ => mockDialogporten.Object);
+            });
+            var payload = new CorrespondenceBuilder()
+                .CreateCorrespondence()
+                .WithExternalReferencesDialogId("019abaa7-6dfd-7b82-9232-a34ba1e87fbd")
+                .Build();
+
+            // Act
+            var unitSenderClient = testFactory.CreateSenderClient();
+            var initializeCorrespondenceResponse = await unitSenderClient.PostAsJsonAsync("correspondence/api/v1/correspondence", payload);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, initializeCorrespondenceResponse.StatusCode);
+        }
+
+        [Fact]
         public async Task InitializeCorrespondence_WithoutAttachments_SchedulesPublish()
         {
             // Arrange

--- a/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/AttachmentController.cs
@@ -40,7 +40,7 @@ public class AttachmentController(ILogger<CorrespondenceController> logger) : Co
     /// <li>2013: Filetype not allowed</li>
     /// <li>2017: Attachment expirationTime must be at least 14 days from now (1 day in non-production environments)</li>
     /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register </li>
-    /// <li>4009: Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService. </li>
+    /// <li>4009: Resource type is not supported. Resource must be of type CorrespondenceService. </li>
     /// </ul></response>
     /// <response code="401">4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and organization in Altinn Authorization</response>
     [HttpPost]

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -101,7 +101,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>3024: Email body, subject and SMS body must be provided when sending email and SMS notifications</li>
         /// <li>3025: Reminder email body, subject and SMS body must be provided when sending reminder email and SMS notifications</li>
         /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li>
-        /// <li>4009: Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService</li>
+        /// <li>4009: Resource type is not supported. Resource must be of type CorrespondenceService</li>
         /// </ul></response>
         /// <response code="401"><ul>
         /// <li>4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and organization in Altinn Authorization</li>
@@ -216,7 +216,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// <li>3024: Email body, subject and SMS body must be provided when sending email and SMS notifications</li>
         /// <li>3025: Reminder email body, subject and SMS body must be provided when sending reminder email and SMS notifications</li>
         /// <li>4002: Could not retrieve party uuid from lookup in Altinn Register</li>
-        /// <li>4009: Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService</li>
+        /// <li>4009: Resource type is not supported. Resource must be of type CorrespondenceService</li>
         /// </ul></response>
         /// <response code="401"><ul>
         /// <li>4001: You must use an Altinn token, DialogToken or log in to IDPorten as someone with access to the resource and organization in Altinn Authorization</li>

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -124,7 +124,8 @@ public static class AuthorizationErrors
     public static Error LegacyNotAccessToOwner(int partyId) { return new Error(4005, $"User does not have access to party with partyId {partyId}", HttpStatusCode.Unauthorized); }
     public static Error CouldNotDetermineCaller = new Error(4006, "Could not determine caller", HttpStatusCode.Unauthorized);
     public static Error CouldNotFindOrgNo = new Error(4007, "Could not identify orgnumber from user", HttpStatusCode.Unauthorized);
-    public static Error IncorrectResourceType = new Error(4009, "Resource type is not supported. Resource must be of type CorrespondenceService.", HttpStatusCode.BadRequest);
+    public static Error IncorrectResourceType = new Error(4009, "Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService.", HttpStatusCode.BadRequest);
+    public static Error IncorrectCorrespondenceResourceType = new Error(4009, "Resource type is not supported. Resource must be of type CorrespondenceService or AltinnApp (AltinnApp allowed for Correspondence transmissions).", HttpStatusCode.BadRequest);
 }
 
 public static class SyncErrors

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -124,7 +124,7 @@ public static class AuthorizationErrors
     public static Error LegacyNotAccessToOwner(int partyId) { return new Error(4005, $"User does not have access to party with partyId {partyId}", HttpStatusCode.Unauthorized); }
     public static Error CouldNotDetermineCaller = new Error(4006, "Could not determine caller", HttpStatusCode.Unauthorized);
     public static Error CouldNotFindOrgNo = new Error(4007, "Could not identify orgnumber from user", HttpStatusCode.Unauthorized);
-    public static Error IncorrectResourceType = new Error(4009, "Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService.", HttpStatusCode.BadRequest);
+    public static Error IncorrectResourceType = new Error(4009, "Resource type is not supported. Resource must be of type CorrespondenceService.", HttpStatusCode.BadRequest);
     public static Error IncorrectCorrespondenceResourceType = new Error(4009, "Resource type is not supported. Resource must be of type CorrespondenceService. If creating a Correspondence as a transmission with reference to an existing DialogId AltinnApp is also allowed.", HttpStatusCode.BadRequest);
 }
 

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -125,7 +125,7 @@ public static class AuthorizationErrors
     public static Error CouldNotDetermineCaller = new Error(4006, "Could not determine caller", HttpStatusCode.Unauthorized);
     public static Error CouldNotFindOrgNo = new Error(4007, "Could not identify orgnumber from user", HttpStatusCode.Unauthorized);
     public static Error IncorrectResourceType = new Error(4009, "Resource type is not supported. Resource must be of type GenericAccessResource or CorrespondenceService.", HttpStatusCode.BadRequest);
-    public static Error IncorrectCorrespondenceResourceType = new Error(4009, "Resource type is not supported. Resource must be of type CorrespondenceService or AltinnApp (AltinnApp allowed for Correspondence transmissions).", HttpStatusCode.BadRequest);
+    public static Error IncorrectCorrespondenceResourceType = new Error(4009, "Resource type is not supported. Resource must be of type CorrespondenceService. If creating a Correspondence as a transmission with reference to an existing DialogId AltinnApp is also allowed.", HttpStatusCode.BadRequest);
 }
 
 public static class SyncErrors

--- a/src/Altinn.Correspondence.Application/Errors.cs
+++ b/src/Altinn.Correspondence.Application/Errors.cs
@@ -125,7 +125,7 @@ public static class AuthorizationErrors
     public static Error CouldNotDetermineCaller = new Error(4006, "Could not determine caller", HttpStatusCode.Unauthorized);
     public static Error CouldNotFindOrgNo = new Error(4007, "Could not identify orgnumber from user", HttpStatusCode.Unauthorized);
     public static Error IncorrectResourceType = new Error(4009, "Resource type is not supported. Resource must be of type CorrespondenceService.", HttpStatusCode.BadRequest);
-    public static Error IncorrectCorrespondenceResourceType = new Error(4009, "Resource type is not supported. Resource must be of type CorrespondenceService. If creating a Correspondence as a transmission with reference to an existing DialogId AltinnApp is also allowed.", HttpStatusCode.BadRequest);
+    public static Error IncorrectCorrespondenceResourceType = new Error(4010, "Resource type is not supported. Resource must be of type CorrespondenceService. If creating a Correspondence as a transmission with reference to an existing DialogId AltinnApp is also allowed.", HttpStatusCode.BadRequest);
 }
 
 public static class SyncErrors

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceValidationHelper.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceValidationHelper.cs
@@ -70,7 +70,11 @@ namespace Altinn.Correspondence.Application.InitializeCorrespondences
                 logger.LogError("Resource type not found for {ResourceId} despite successful authorization", request.Correspondence.ResourceId);
                 throw new Exception($"Resource type not found for {request.Correspondence.ResourceId}. This should be impossible as authorization worked.");
             }
-            if (resourceType != "CorrespondenceService")
+            var isTransmissionCorrespondence = request.Correspondence.ExternalReferences?
+                .Any(er => er.ReferenceType == ReferenceType.DialogportenDialogId) == true;
+            var resourceTypeAllowed = resourceType == "CorrespondenceService"
+                || (resourceType == "AltinnApp" && isTransmissionCorrespondence);
+            if (!resourceTypeAllowed)
             {
                 logger.LogError("Incorrect resource type {ResourceType} for {ResourceId}", resourceType, request.Correspondence.ResourceId);
                 return AuthorizationErrors.IncorrectResourceType;

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceValidationHelper.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondenceValidationHelper.cs
@@ -76,8 +76,11 @@ namespace Altinn.Correspondence.Application.InitializeCorrespondences
                 || (resourceType == "AltinnApp" && isTransmissionCorrespondence);
             if (!resourceTypeAllowed)
             {
-                logger.LogError("Incorrect resource type {ResourceType} for {ResourceId}", resourceType, request.Correspondence.ResourceId);
-                return AuthorizationErrors.IncorrectResourceType;
+                logger.LogError(
+                    "Incorrect resource type {ResourceType} for {ResourceId}. Resource must be of type CorrespondenceService or AltinnApp (AltinnApp allowed for Dialogporten transmissions)",
+                    resourceType,
+                    request.Correspondence.ResourceId);
+                return AuthorizationErrors.IncorrectCorrespondenceResourceType;
             }
 
             var caller = user?.GetCallerPartyUrn();


### PR DESCRIPTION
## Description
Altinn Studio users want to use Correspondence to provide updates on their app instances with transmissions.

## Related Issue(s)
- #2004

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Updated correspondence initialization validation to support **AltinnApp** when creating **Dialogporten transmission** workflows, with a more specific **4009** error when the resource type is invalid.

## Documentation
- Refreshed API/Swagger error documentation for **4009** to reflect the stricter **CorrespondenceService-only** guidance.

## Tests
- Added coverage for AltinnApp resource scenarios, including successful initialization for Dialogporten transmission and failure when initialized with unsupported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->