### PR TITLE
⚠️ Added index to make confidential correspondences for recipient lookup quick and cheap

### DIFF
--- a/src/Altinn.Correspondence.Persistence/Data/ApplicationDbContext.cs
+++ b/src/Altinn.Correspondence.Persistence/Data/ApplicationDbContext.cs
@@ -57,6 +57,12 @@ public class ApplicationDbContext : DbContext
             .IsDescending(false, false, true, false)
             .HasDatabaseName("IX_Correspondences_Sender_ResourceId_RequestedPublishTime");
 
+        // Partial index for the unopened-confidential-correspondence reminder query.
+        modelBuilder.Entity<CorrespondenceEntity>()
+            .HasIndex(c => new { c.Recipient, c.RequestedPublishTime })
+            .HasFilter("\"IsConfidential\" = true")
+            .HasDatabaseName("IX_Correspondences_Confidential_Recipient_PublishTime");
+
         // Ensure simple FK indexes exist for query performance (these are separate from the unique expression indexes)
         modelBuilder.Entity<CorrespondenceDeleteEventEntity>()
             .HasIndex(e => e.CorrespondenceId);

--- a/src/Altinn.Correspondence.Persistence/Migrations/20260615121718_AddConfidentialRecipientPublishTimeIndex.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20260615121718_AddConfidentialRecipientPublishTimeIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Altinn.Correspondence.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615121718_AddConfidentialRecipientPublishTimeIndex")]
+    partial class AddConfidentialRecipientPublishTimeIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20260615121718_AddConfidentialRecipientPublishTimeIndex.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20260615121718_AddConfidentialRecipientPublishTimeIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfidentialRecipientPublishTimeIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Partial index for GetUnopenedConfidentialCorrespondencesForParty
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_Correspondences_Confidential_Recipient_PublishTime\" " +
+                "ON correspondence.\"Correspondences\" (\"Recipient\", \"RequestedPublishTime\") " +
+                "WHERE \"IsConfidential\" = true;",
+                suppressTransaction: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS correspondence.\"IX_Correspondences_Confidential_Recipient_PublishTime\";",
+                suppressTransaction: true);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There has occured a couple timeouts on calls to get unread confidential corrrespondences in production. The slow query seems to be due to missing index to make the confidential correspondence lookup for a recipient cheap and quick. This PR adds an index to make the lookup quick and cheap and should prevent further timeouts. 

⚠️ This PR contains a migration to add one index

## Related Issue(s)
- #1997 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a database index to optimize performance for confidential correspondence queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->