### PR TITLE
Changed download all to stream directly to client instead of streaming to memory first

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingApplication/ZipContentLengthCalculatorTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingApplication/ZipContentLengthCalculatorTests.cs
@@ -1,0 +1,117 @@
+using System.IO.Compression;
+using Altinn.Correspondence.Application.DownloadAllCorrespondenceAttachments;
+using Altinn.Correspondence.Core.Models.Entities;
+
+namespace Altinn.Correspondence.Tests.TestingApplication;
+
+/// <summary>
+/// Guards <see cref="ZipContentLengthCalculator"/> against the framework: it builds a real stored zip via
+/// the same async ZipArchive path WriteZip uses and asserts the calculated length matches the actual bytes
+/// to the byte. If a future .NET version changes the zip writer's overhead, these tests fail in CI pipeline before a
+/// wrong Content-Length can corrupt downloads.
+/// </summary>
+public class ZipContentLengthCalculatorTests
+{
+    [Fact]
+    public async Task TryCalculate_MatchesActualStoredZipLength()
+    {
+        ZipAttachmentEntry[][] configs =
+        [
+            [Entry("a.txt", 0)],
+            [Entry("a.txt", 1000)],
+            [Entry("a.txt", 1000), Entry("b.bin", 500_000)],
+            [Entry("file with spaces.pdf", 12345), Entry("æøå-unicode-navn.txt", 67890), Entry("c", 1)],
+            [.. Enumerable.Range(0, 50).Select(i => Entry($"attachment_{i}.dat", 1000 + i))],
+        ];
+
+        foreach (var entries in configs)
+        {
+            long actual = await ActualStoredZipLength(entries);
+            long? computed = ZipContentLengthCalculator.TryCalculate(entries);
+            Assert.Equal(actual, computed);
+        }
+    }
+
+    [Fact]
+    public void TryCalculate_ReturnsNull_WhenEntryCountReachesZip64Boundary()
+    {
+        var entries = Enumerable.Range(0, 0xFFFF).Select(_ => Entry("f", 1)).ToArray();
+        Assert.Null(ZipContentLengthCalculator.TryCalculate(entries));
+    }
+
+    [Fact]
+    public void TryCalculate_ReturnsNull_WhenTotalSizeReachesZip64Boundary()
+    {
+        var entries = new[] { Entry("big.bin", 0xFFFFFFFF) };
+        Assert.Null(ZipContentLengthCalculator.TryCalculate(entries));
+    }
+
+    [Fact]
+    public void TryCalculate_ReturnsValue_JustBelowZip64Boundary()
+    {
+        var entries = new[] { Entry("f", 0xFFFFFFFFL - 1000) };
+        Assert.NotNull(ZipContentLengthCalculator.TryCalculate(entries));
+    }
+
+    private static ZipAttachmentEntry Entry(string name, long size) =>
+        new(new AttachmentEntity
+        {
+            ResourceId = "test",
+            SendersReference = "ref",
+            Sender = "0192:000000000",
+            Created = DateTimeOffset.UtcNow,
+            FileName = name,
+            AttachmentSize = size
+        }, name);
+
+    private static async Task<long> ActualStoredZipLength(IReadOnlyList<ZipAttachmentEntry> entries)
+    {
+        var counter = new CountingStream();
+        await using (var archive = await ZipArchive.CreateAsync(counter, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding: null))
+        {
+            foreach (var (attachment, entryName) in entries)
+            {
+                var entry = archive.CreateEntry(entryName, CompressionLevel.NoCompression);
+                await using var entryStream = await entry.OpenAsync();
+                var buffer = new byte[81920];
+                long written = 0;
+                while (written < attachment.AttachmentSize)
+                {
+                    int n = (int)Math.Min(buffer.Length, attachment.AttachmentSize - written);
+                    await entryStream.WriteAsync(buffer.AsMemory(0, n));
+                    written += n;
+                }
+            }
+        }
+        return counter.Count;
+    }
+
+    /// <summary>Non-seekable stream that just counts bytes written, mimicking the HTTP response body.</summary>
+    private sealed class CountingStream : Stream
+    {
+        public long Count { get; private set; }
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => Count; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override void Write(byte[] buffer, int offset, int count) => Count += count;
+        public override void Write(ReadOnlySpan<byte> buffer) => Count += buffer.Length;
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Count += buffer.Length;
+            return ValueTask.CompletedTask;
+        }
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            Count += count;
+            return Task.CompletedTask;
+        }
+        public override ValueTask DisposeAsync() => default;
+    }
+}

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -642,11 +642,8 @@ namespace Altinn.Correspondence.API.Controllers
                 CorrespondenceId = correspondenceId
             }, HttpContext.User, cancellationToken);
             return commandResult.Match(
-                result =>
-                {                 
-                    var zipFileName = result.zipFileName;
-                    return File(result.Stream, "application/zip", zipFileName);
-                },
+                result => new FileCallbackResult("application/zip", result.ZipFileName,
+                    (stream, ct) => handler.WriteZip(result.Entries, stream, ct)),
                 Problem
             );
         }

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -642,7 +642,7 @@ namespace Altinn.Correspondence.API.Controllers
                 CorrespondenceId = correspondenceId
             }, HttpContext.User, cancellationToken);
             return commandResult.Match(
-                result => new FileCallbackResult("application/zip", result.ZipFileName,
+                result => new FileCallbackResult("application/zip", result.ZipFileName, result.ContentLength,
                     (stream, ct) => handler.WriteZip(result.Entries, stream, ct)),
                 Problem
             );

--- a/src/Altinn.Correspondence.API/Helpers/FileCallbackResult.cs
+++ b/src/Altinn.Correspondence.API/Helpers/FileCallbackResult.cs
@@ -5,9 +5,8 @@ using Microsoft.Net.Http.Headers;
 namespace Altinn.Correspondence.API.Helpers;
 
 /// <summary>
-/// An <see cref="IActionResult"/> that streams content directly to the HTTP response body via a callback,
-/// without buffering the whole payload in memory first. Used for the
-/// "download all attachments" zip download, where buffering in a <see cref="MemoryStream"/> can exhaust memory.
+/// An <see cref="IActionResult"/> that streams content directly to the HTTP response body via a callback. Used for the
+/// "download all attachments" zip download.
 /// </summary>
 /// <remarks>
 /// Once the callback starts writing to the response body the status code and headers are already

--- a/src/Altinn.Correspondence.API/Helpers/FileCallbackResult.cs
+++ b/src/Altinn.Correspondence.API/Helpers/FileCallbackResult.cs
@@ -28,7 +28,8 @@ public sealed class FileCallbackResult(string contentType, string fileDownloadNa
         // The length is unknown up front; stream out as it is produced rather than buffering.
         context.HttpContext.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
 
-        // ZipArchive writes to the underlying stream synchronously, which Kestrel disallows by default.
+        //.NET 10's ZipArchive still flushes a small per-entry data descriptor (~16 bytes)
+        // synchronously when an entry is closed
         var bodyControl = context.HttpContext.Features.Get<IHttpBodyControlFeature>();
         if (bodyControl is not null)
         {

--- a/src/Altinn.Correspondence.API/Helpers/FileCallbackResult.cs
+++ b/src/Altinn.Correspondence.API/Helpers/FileCallbackResult.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+
+namespace Altinn.Correspondence.API.Helpers;
+
+/// <summary>
+/// An <see cref="IActionResult"/> that streams content directly to the HTTP response body via a callback,
+/// without buffering the whole payload in memory first. Used for the
+/// "download all attachments" zip download, where buffering in a <see cref="MemoryStream"/> can exhaust memory.
+/// </summary>
+/// <remarks>
+/// Once the callback starts writing to the response body the status code and headers are already
+/// committed, so the callback cannot signal an error via the response. All validation that can fail
+/// must happen before this result is returned.
+/// </remarks>
+public sealed class FileCallbackResult(string contentType, string fileDownloadName, Func<Stream, CancellationToken, Task> callback) : ActionResult
+{
+    public override async Task ExecuteResultAsync(ActionContext context)
+    {
+        var response = context.HttpContext.Response;
+        response.ContentType = contentType;
+        response.Headers[HeaderNames.ContentDisposition] = new ContentDispositionHeaderValue("attachment")
+        {
+            FileNameStar = fileDownloadName
+        }.ToString();
+
+        // The length is unknown up front; stream out as it is produced rather than buffering.
+        context.HttpContext.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
+        // ZipArchive writes to the underlying stream synchronously, which Kestrel disallows by default.
+        var bodyControl = context.HttpContext.Features.Get<IHttpBodyControlFeature>();
+        if (bodyControl is not null)
+        {
+            bodyControl.AllowSynchronousIO = true;
+        }
+
+        await callback(response.Body, context.HttpContext.RequestAborted);
+    }
+}

--- a/src/Altinn.Correspondence.API/Helpers/FileCallbackResult.cs
+++ b/src/Altinn.Correspondence.API/Helpers/FileCallbackResult.cs
@@ -13,7 +13,7 @@ namespace Altinn.Correspondence.API.Helpers;
 /// committed, so the callback cannot signal an error via the response. All validation that can fail
 /// must happen before this result is returned.
 /// </remarks>
-public sealed class FileCallbackResult(string contentType, string fileDownloadName, Func<Stream, CancellationToken, Task> callback) : ActionResult
+public sealed class FileCallbackResult(string contentType, string fileDownloadName, long? contentLength, Func<Stream, CancellationToken, Task> callback) : ActionResult
 {
     public override async Task ExecuteResultAsync(ActionContext context)
     {
@@ -24,7 +24,12 @@ public sealed class FileCallbackResult(string contentType, string fileDownloadNa
             FileNameStar = fileDownloadName
         }.ToString();
 
-        // The length is unknown up front; stream out as it is produced rather than buffering.
+        if (contentLength.HasValue)
+        {
+            response.ContentLength = contentLength.Value;
+        }
+
+        // Stream out as produced rather than buffering the whole payload.
         context.HttpContext.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
 
         //.NET 10's ZipArchive still flushes a small per-entry data descriptor (~16 bytes)

--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
@@ -99,41 +99,35 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
             _logger.LogError("Total size of attachments for correspondence {CorrespondenceId} exceeds the maximum allowed for zip download: {TotalSize} bytes", request.CorrespondenceId, totalSize);
             return AttachmentErrors.TotalAttachmentSizeExceedsLimit;
         }
-        var zipStream = new MemoryStream();
-        using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: true))
+        
+        var entries = new List<ZipAttachmentEntry>(attachments.Count);
+        var usedEntryNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var attachment in attachments)
         {
-            var usedEntryNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var attachment in attachments)
+            var originalFileName = attachment.FileName ?? attachment.Id.ToString();
+            var zipEntryName = originalFileName;
+            var fileNameBytes = Encoding.UTF8.GetByteCount(originalFileName);
+            if (fileNameBytes > 255)
             {
-                var originalFileName = attachment.FileName ?? attachment.Id.ToString();
-                var zipEntryName = originalFileName;
-                var fileNameBytes = Encoding.UTF8.GetByteCount(originalFileName);
-                if (fileNameBytes > 255)
-                {
-                    _logger.LogInformation("Attachment {AttachmentId} in correspondence {CorrespondenceId} has a filename that exceeds the maximum length for zip entries. It will be truncated to fit within the limit.", attachment.Id, request.CorrespondenceId);
-                    var ext = Path.GetExtension(originalFileName);
-                    var nameWithoutExt = Path.GetFileNameWithoutExtension(originalFileName);
-                    zipEntryName = TruncateToUtf8Bytes(nameWithoutExt, 255 - Encoding.UTF8.GetByteCount(ext)) + ext;
-                }
-                var baseName = zipEntryName;
-                var uniqueName = baseName;
-                var counter = 1;
-                while (!usedEntryNames.Add(uniqueName))
-                {
-                    var ext = Path.GetExtension(baseName);
-                    var nameWithoutExt = Path.GetFileNameWithoutExtension(baseName);
-                    var suffix = $"({counter})";
-                    var truncatedName = TruncateToUtf8Bytes(nameWithoutExt, 255 - Encoding.UTF8.GetByteCount(ext) - Encoding.UTF8.GetByteCount(suffix));
-                    uniqueName = $"{truncatedName}{suffix}{ext}";
-                    counter++;
-                }
-                var entry = archive.CreateEntry(uniqueName);
-                using var entryStream = entry.Open();
-                using var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, attachment.StorageProvider, cancellationToken);
-                await attachmentStream.CopyToAsync(entryStream, cancellationToken);
+                _logger.LogInformation("Attachment {AttachmentId} in correspondence {CorrespondenceId} has a filename that exceeds the maximum length for zip entries. It will be truncated to fit within the limit.", attachment.Id, request.CorrespondenceId);
+                var ext = Path.GetExtension(originalFileName);
+                var nameWithoutExt = Path.GetFileNameWithoutExtension(originalFileName);
+                zipEntryName = TruncateToUtf8Bytes(nameWithoutExt, 255 - Encoding.UTF8.GetByteCount(ext)) + ext;
             }
+            var baseName = zipEntryName;
+            var uniqueName = baseName;
+            var counter = 1;
+            while (!usedEntryNames.Add(uniqueName))
+            {
+                var ext = Path.GetExtension(baseName);
+                var nameWithoutExt = Path.GetFileNameWithoutExtension(baseName);
+                var suffix = $"({counter})";
+                var truncatedName = TruncateToUtf8Bytes(nameWithoutExt, 255 - Encoding.UTF8.GetByteCount(ext) - Encoding.UTF8.GetByteCount(suffix));
+                uniqueName = $"{truncatedName}{suffix}{ext}";
+                counter++;
+            }
+            entries.Add(new ZipAttachmentEntry(attachment, uniqueName));
         }
-        zipStream.Position = 0;
 
         await TransactionWithRetriesPolicy.Execute<bool>(async (cancellationToken) =>
         {
@@ -167,7 +161,33 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
         }
 
         _logger.LogInformation("Successfully processed download of all attachments for correspondence {CorrespondenceId}", request.CorrespondenceId);
-        return new DownloadAllCorrespondenceAttachmentsResponse { Stream = zipStream, zipFileName = attachmentHelper.GetZipFileNameForCorrespondence(correspondence) };
+        return new DownloadAllCorrespondenceAttachmentsResponse
+        {
+            Entries = entries,
+            ZipFileName = attachmentHelper.GetZipFileNameForCorrespondence(correspondence)
+        };
+    }
+
+    /// <summary>
+    /// Streams the attachments as a zip archive directly to <paramref name="output"/>, downloading each
+    /// attachment from storage and copying it into the archive one at a time. Memory use stays small and
+    /// constant regardless of total size.
+    /// </summary>
+    /// <remarks>
+    /// Call only after <see cref="Process"/> has succeeded. Once writing begins the HTTP response is
+    /// already committed, so a failure here (e.g. a storage error) cannot be turned into an error
+    /// response — it surfaces as an aborted/truncated download.
+    /// </remarks>
+    public async Task WriteZip(IReadOnlyList<ZipAttachmentEntry> entries, Stream output, CancellationToken cancellationToken)
+    {
+        using var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true);
+        foreach (var (attachment, entryName) in entries)
+        {
+            var entry = archive.CreateEntry(entryName);
+            using var entryStream = entry.Open();
+            using var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, attachment.StorageProvider, cancellationToken);
+            await attachmentStream.CopyToAsync(entryStream, cancellationToken);
+        }
     }
 
     private static string TruncateToUtf8Bytes(string text, int maxBytes)

--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
@@ -99,7 +99,7 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
             _logger.LogError("Total size of attachments for correspondence {CorrespondenceId} exceeds the maximum allowed for zip download: {TotalSize} bytes", request.CorrespondenceId, totalSize);
             return AttachmentErrors.TotalAttachmentSizeExceedsLimit;
         }
-        
+
         var entries = new List<ZipAttachmentEntry>(attachments.Count);
         var usedEntryNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var attachment in attachments)
@@ -168,24 +168,14 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
         };
     }
 
-    /// <summary>
-    /// Streams the attachments as a zip archive directly to <paramref name="output"/>, downloading each
-    /// attachment from storage and copying it into the archive one at a time. Memory use stays small and
-    /// constant regardless of total size.
-    /// </summary>
-    /// <remarks>
-    /// Call only after <see cref="Process"/> has succeeded. Once writing begins the HTTP response is
-    /// already committed, so a failure here (e.g. a storage error) cannot be turned into an error
-    /// response — it surfaces as an aborted/truncated download.
-    /// </remarks>
     public async Task WriteZip(IReadOnlyList<ZipAttachmentEntry> entries, Stream output, CancellationToken cancellationToken)
     {
-        using var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true);
+        await using var archive = await ZipArchive.CreateAsync(output, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding: null);
         foreach (var (attachment, entryName) in entries)
         {
             var entry = archive.CreateEntry(entryName);
-            using var entryStream = entry.Open();
-            using var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, attachment.StorageProvider, cancellationToken);
+            await using var entryStream = await entry.OpenAsync(cancellationToken);
+            await using var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, attachment.StorageProvider, cancellationToken);
             await attachmentStream.CopyToAsync(entryStream, cancellationToken);
         }
     }

--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsHandler.cs
@@ -164,16 +164,17 @@ public class DownloadAllCorrespondenceAttachmentsHandler(
         return new DownloadAllCorrespondenceAttachmentsResponse
         {
             Entries = entries,
-            ZipFileName = attachmentHelper.GetZipFileNameForCorrespondence(correspondence)
+            ZipFileName = attachmentHelper.GetZipFileNameForCorrespondence(correspondence),
+            ContentLength = ZipContentLengthCalculator.TryCalculate(entries)
         };
     }
 
     public async Task WriteZip(IReadOnlyList<ZipAttachmentEntry> entries, Stream output, CancellationToken cancellationToken)
     {
-        await using var archive = await ZipArchive.CreateAsync(output, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding: null);
+        await using var archive = await ZipArchive.CreateAsync(output, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding: null, cancellationToken);
         foreach (var (attachment, entryName) in entries)
         {
-            var entry = archive.CreateEntry(entryName);
+            var entry = archive.CreateEntry(entryName, CompressionLevel.NoCompression);
             await using var entryStream = await entry.OpenAsync(cancellationToken);
             await using var attachmentStream = await storageRepository.DownloadAttachment(attachment.Id, attachment.StorageProvider, cancellationToken);
             await attachmentStream.CopyToAsync(entryStream, cancellationToken);

--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsResponse.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsResponse.cs
@@ -1,7 +1,15 @@
+using Altinn.Correspondence.Core.Models.Entities;
+
 namespace Altinn.Correspondence.Application.DownloadAllCorrespondenceAttachments;
 
 public class DownloadAllCorrespondenceAttachmentsResponse
 {
-    public required Stream Stream { get; set; }
-    public required string zipFileName { get; set; }
+    /// <summary>
+    /// The attachments to include in the zip, paired with the (deduplicated, length-bounded) entry name to use.
+    /// Resolved during validation so the zip can be streamed straight to the response without buffering.
+    /// </summary>
+    public required IReadOnlyList<ZipAttachmentEntry> Entries { get; set; }
+    public required string ZipFileName { get; set; }
 }
+
+public record ZipAttachmentEntry(AttachmentEntity Attachment, string EntryName);

--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsResponse.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/DownloadAllCorrespondenceAttachmentsResponse.cs
@@ -10,6 +10,12 @@ public class DownloadAllCorrespondenceAttachmentsResponse
     /// </summary>
     public required IReadOnlyList<ZipAttachmentEntry> Entries { get; set; }
     public required string ZipFileName { get; set; }
+
+    /// <summary>
+    /// Exact byte length of the (uncompressed) zip, when it can be computed below the zip64 boundary.
+    /// Null means it could not be determined and the response should be streamed chunked instead.
+    /// </summary>
+    public long? ContentLength { get; set; }
 }
 
 public record ZipAttachmentEntry(AttachmentEntity Attachment, string EntryName);

--- a/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/ZipContentLengthCalculator.cs
+++ b/src/Altinn.Correspondence.Application/DownloadAllCorrespondenceAttachments/ZipContentLengthCalculator.cs
@@ -1,0 +1,49 @@
+using System.Text;
+
+namespace Altinn.Correspondence.Application.DownloadAllCorrespondenceAttachments;
+
+/// <summary>
+/// Computes the exact byte length of the uncompressed (stored) zip produced by
+/// <see cref="DownloadAllCorrespondenceAttachmentsHandler.WriteZip"/>, so a Content-Length can be set on
+/// the streamed response.
+/// </summary>
+/// <remarks>
+/// The overhead constants are the ZIP format's fixed structure for a STORED entry written to a
+/// non-seekable stream. The formula is only valid below the zip64 boundary (4 GiB); above it the archive switches format and
+/// the overhead changes, so the caller must fall back to chunked transfer (no Content-Length).
+/// It also assumes each attachment's recorded size matches its actual stored bytes.
+/// </remarks>
+public static class ZipContentLengthCalculator
+{
+    private const long PerEntryOverhead = 76;       // local file header (30) + central directory header (46)
+    private const long DataDescriptorOverhead = 16; // trailing data descriptor, only emitted for entries with content
+    private const long PerNameByteOverhead = 2;     // the file name is stored in both the local header and the central directory
+    private const long EndOfCentralDirectory = 22;
+
+    // At or above these values a field no longer fits in 32 bits and ZipArchive emits zip64, invalidating the formula.
+    private const long Zip64SizeThreshold = 0xFFFFFFFF;   // 4 GiB - 1 (covers per-entry size, header offsets and total size)
+    private const int Zip64EntryCountThreshold = 0xFFFF;  // 65535
+
+    /// <summary>
+    /// Returns the exact length of the stored zip, or null if it would cross the zip64 boundary
+    /// </summary>
+    public static long? TryCalculate(IReadOnlyList<ZipAttachmentEntry> entries)
+    {
+        if (entries.Count >= Zip64EntryCountThreshold)
+        {
+            return null;
+        }
+
+        long total = EndOfCentralDirectory;
+        foreach (var entry in entries)
+        {
+            var size = entry.Attachment.AttachmentSize;
+            total += size
+                   + PerEntryOverhead
+                   + (size > 0 ? DataDescriptorOverhead : 0)
+                   + PerNameByteOverhead * Encoding.UTF8.GetByteCount(entry.EntryName);
+        }
+
+        return total >= Zip64SizeThreshold ? null : total;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We have gotten a couple system.OutOfMemory exceptions that has occured during calls to DownloadAllCorrespondenceAttachments. The exception occurs because the system temporarily stores the zip file in memory before serving the recipient, which can lead to system.OutOfMemory if the zip file is big. After having tested in staging 1 GB zip file download might work fine temporarily stored in memory, but when approahing 2 GB the zip file download consistently fails and the system throws a system.OutOfMemory exception.

This PR refactors the download all logic a bit to stream the zip file directly to client instead of storing it in memory before serving the client. The zip file is written async. This does not have these memory issues and could possibly allow us to support the download all operation for files that total even more than 2 GB.

This PR calculates the content length based on the recorded attachment sizes and uses it when serving the zip to the client, so that download progress in the ux is kept. Without content length the client won't know when the download is finished, it could see a failed download as succeeded with the resulting downloaded file being corrupted.

Before (Download ux for a 1GB zip file download in microsoft edge (2 GB download failed before file transfer started)):
<img width="446" height="129" alt="image" src="https://github.com/user-attachments/assets/f8772d80-c1b1-4073-b475-bab933b43f29" />
After (Download ux for a 1 GB zip file download in microsoft edge):
<img width="340" height="63" alt="image" src="https://github.com/user-attachments/assets/21198f71-e6be-434d-ad61-d4ff0dd4b52a" />

Previously it would load the zip file to memory before serving the client, which for the larger zip-files could take a couple seconds. So for the user, download would not start immediately after clicking the download all zip file. This is not an issue with this change as it now starts downloading immediately, because the zip is streamed as its read and created. This feels more responsive and is a bit more user friendly. But this is only really a relevant improvement for when the zip file size is large (for example 1 GB) and is not that significant of an issue.

However to calculate a correct content-length for the zip file before producing it, the zip file can not be compressed. This affects file types that are not already compressed and are compressible like text files (.txt, .xml, .json, .csv, .html) and .doc, .xls, .ppt and .pps. File types like .docx, .xlsx, .zip, .pdf, .jpg, .jpeg, .png and .gif are already compressed and wouldn't be further compressed anyway by zip file compression. For Dicom files it depends wether they are compressible or not depending on the transfer syntax for the file.

If we want to keep the compression, and also have content-length and support file sizes larger than 1 GB without memory issues. We could measure the content length, instead of caluculating the zip size, by compressing everything once to a counting stream just to measure the file size without storing the file and then compress again while streaming to the client with a content length set to the measured length. This is correct but adds double compression processing which could be considered wastefull. Alternatively we could store the zip file to blob before serving the client. Both of these solutions would add a small delay before the file is streamed to the client depending on file size, just like streaming to memory had.

## Related Issue(s)
- #2002 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Attachment ZIPs are now streamed and generated during the download request, avoiding pre-buffering of the entire archive.

* **User Experience Improvements**
  * Download and archive filenames are applied consistently.
  * ZIP entry names are normalized with UTF-8 length limits and duplicates are deduplicated for stable, predictable contents.

* **Reliability Improvements**
  * Response streaming is improved and may include an accurate `Content-Length` when it can be determined.
  * Added automated coverage to verify computed ZIP sizing against real generated ZIP output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->