### PR TITLE
remove external reference when purging a dialog

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
@@ -145,6 +145,50 @@ public class DialogportenServiceTests
         return (service, mockCorrespondenceForwardingEventRepository, mockAltinnRegisterService, () => capturedRequestBody);
     }
 
+    private static (DialogportenService service, Mock<ICorrespondenceRepository> repoMock) CreateServiceWithMockedDialogPurge(CorrespondenceEntity correspondence, string dialogId)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Post &&
+                    m.RequestUri != null &&
+                    m.RequestUri.AbsolutePath.EndsWith($"/dialogporten/api/v1/serviceowner/dialogs/{dialogId}/actions/purge")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var httpClient = new HttpClient(mockHandler.Object)
+        {
+            BaseAddress = new Uri("https://dialogporten.example/")
+        };
+
+        var mockRepo = new Mock<ICorrespondenceRepository>();
+        mockRepo
+            .Setup(r => r.GetCorrespondenceById(correspondence.Id, true, true, false, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(correspondence);
+        mockRepo
+            .Setup(r => r.RemoveExternalReference(correspondence, ReferenceType.DialogportenDialogId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var mockAltinnRegisterService = new Mock<IAltinnRegisterService>();
+        var mockPartyUrnHelper = new Mock<PartyUrnHelper>(mockAltinnRegisterService.Object, Mock.Of<ILogger<PartyUrnHelper>>());
+        var options = Options.Create(new GeneralSettings { CorrespondenceBaseUrl = "https://correspondence.example" });
+
+        var service = new DialogportenService(
+            httpClient,
+            mockRepo.Object,
+            Mock.Of<ICorrespondenceForwardingEventRepository>(),
+            mockAltinnRegisterService.Object,
+            options,
+            Mock.Of<ILogger<DialogportenService>>(),
+            Mock.Of<IIdempotencyKeyRepository>(),
+            Mock.Of<IResourceRegistryService>(),
+            mockPartyUrnHelper.Object);
+
+        return (service, mockRepo);
+    }
+
     [Fact]
     public async Task CreateCorrespondenceDialog_TruncatesSearchTags_ToMax63AndSucceeds()
     {
@@ -786,5 +830,28 @@ public class DialogportenServiceTests
 
         // Verify confirmed activity uses the person who confirmed
         Assert.Contains("urn:altinn:person:identifier-no:13076800124", confirmedActivity!.PerformedBy.ActorId);
+    }
+
+    [Fact]
+    public async Task PurgeCorrespondenceDialog_WhenCorrespondenceHasDialogReference_RemovesExternalReference()
+    {
+        // Arrange
+        var correspondenceId = Guid.NewGuid();
+        const string dialogId = "dialog-123";
+
+        var correspondence = new CorrespondenceEntityBuilder()
+            .WithId(correspondenceId)
+            .WithDialogId(dialogId)
+            .Build();
+
+        var (service, mockRepo) = CreateServiceWithMockedDialogPurge(correspondence, dialogId);
+
+        // Act
+        await service.PurgeCorrespondenceDialog(correspondenceId);
+
+        // Assert
+        mockRepo.Verify(
+            r => r.RemoveExternalReference(correspondence, ReferenceType.DialogportenDialogId, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/PublishCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/PublishCorrespondenceHandlerTests.cs
@@ -144,6 +144,14 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                     It.IsAny<IState>()),
                 Times.AtLeastOnce);
 
+            _backgroundJobClientMock.Verify(
+                x => x.Create(
+                    It.Is<Job>(job =>
+                        job.Type == typeof(IDialogportenService) &&
+                        job.Method.Name == nameof(IDialogportenService.PurgeCorrespondenceDialog)),
+                    It.IsAny<IState>()),
+                Times.Once);
+
             _idempotencyKeyRepositoryMock.Verify(x => x.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -117,5 +117,7 @@ namespace Altinn.Correspondence.Core.Repositories
             Guid? cursorId,
             int batchSize,
             CancellationToken cancellationToken);
+
+        Task<bool> RemoveExternalReference(CorrespondenceEntity correspondence, ReferenceType referenceType, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -612,9 +612,14 @@ public class DialogportenService(HttpClient _httpClient,
         }
 
         var response = await _httpClient.PostAsync($"dialogporten/api/v1/serviceowner/dialogs/{dialogId}/actions/purge", null, cancellationToken);
+        var statusCode = response.StatusCode;
         if (!response.IsSuccessStatusCode)
         {
-            throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+            if (statusCode != HttpStatusCode.NotFound)
+            {
+                throw new Exception($"Response from Dialogporten was not successful: {statusCode}: {await response.Content.ReadAsStringAsync()}");
+            }
+            logger.LogWarning("Dialog {dialogId} was already purged in Dialogporten; proceeding with local reference removal for correspondence {correspondenceId}", dialogId, correspondenceId);
         }
         var externalReferencesRemoved = await _correspondenceRepository.RemoveExternalReference(correspondence, ReferenceType.DialogportenDialogId, cancellationToken);
         if (!externalReferencesRemoved)

--- a/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/DialogportenService.cs
@@ -616,6 +616,11 @@ public class DialogportenService(HttpClient _httpClient,
         {
             throw new Exception($"Response from Dialogporten was not successful: {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
         }
+        var externalReferencesRemoved = await _correspondenceRepository.RemoveExternalReference(correspondence, ReferenceType.DialogportenDialogId, cancellationToken);
+        if (!externalReferencesRemoved)
+        {
+            logger.LogWarning("Failed to remove Dialogporten dialog reference for correspondence {correspondenceId} after purging dialog {dialogId}", correspondenceId, dialogId);
+        }
     }
 
     public async Task SoftDeleteDialog(string dialogId)

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -791,5 +791,22 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .Include(c => c.Notifications)
                 .ToListAsync(cancellationToken);
         }
+
+        public async Task<bool> RemoveExternalReference(CorrespondenceEntity correspondence, ReferenceType referenceType, CancellationToken cancellationToken = default)
+        {
+            var referencesToRemove = correspondence.ExternalReferences
+                .Where(er => er.ReferenceType == referenceType)
+                .ToList();
+
+            if (referencesToRemove.Count == 0)
+            {
+                logger.LogWarning("No external references of type {ReferenceType} found for correspondence {CorrespondenceId}", referenceType, correspondence.Id);
+                return false;
+            }
+
+            _context.ExternalReferences.RemoveRange(referencesToRemove);
+            await _context.SaveChangesAsync(cancellationToken);
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Description
If initializing a correspondence fails the dialog is purged however the externalReference which refers to the dialog still persists. This pr removes externalReferences of type 3 (DialogportenDialogId) if the publishing of the correspondence fails.

This PR does NOT clean up the existing occurances of this which were mentioned in the issue.

## Related Issue(s)
- #2014

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * When a dialog is purged, the related saved dialog reference is now also removed from the correspondence record.
  * Purge now treats “not found” as non-fatal, logging a warning and continuing.
  * If the purge succeeds but the reference can’t be cleared, a warning is logged so the issue is easier to detect.
  * Failed correspondence handling now also triggers dialog purging, alongside existing notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->