### PR TITLE
Disallow colon in legacy si user username

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingUtility/RecipientListAttributeTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/RecipientListAttributeTests.cs
@@ -31,4 +31,24 @@ public class RecipientListAttributeTests
         Assert.NotEqual(ValidationResult.Success, result);
         Assert.Equal("The given Recipient email address is not valid", result?.ErrorMessage);
     }
+
+    [Fact]
+    public void IsValid_ReturnsSuccess_For_Valid_Legacy_SelfIdentified_Urn()
+    {
+        var result = _attribute.GetValidationResult(
+            new List<string> { "urn:altinn:person:legacy-selfidentified:axely123" },
+            _validationContext);
+
+        Assert.Equal(ValidationResult.Success, result);
+    }
+
+    [Fact]
+    public void IsValid_ReturnsSuccess_For_Legacy_SelfIdentified_Urn_With_Colon_In_Username()
+    {
+        var result = _attribute.GetValidationResult(
+            new List<string> { "urn:altinn:person:legacy-selfidentified:email:test@example.com" },
+            _validationContext);
+
+        Assert.Equal(ValidationResult.Success, result);
+    }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingUtility/RecipientListAttributeTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingUtility/RecipientListAttributeTests.cs
@@ -43,12 +43,12 @@ public class RecipientListAttributeTests
     }
 
     [Fact]
-    public void IsValid_ReturnsSuccess_For_Legacy_SelfIdentified_Urn_With_Colon_In_Username()
+    public void IsValid_ReturnsError_For_Legacy_SelfIdentified_Urn_With_Colon_In_Username()
     {
         var result = _attribute.GetValidationResult(
             new List<string> { "urn:altinn:person:legacy-selfidentified:email:test@example.com" },
             _validationContext);
 
-        Assert.Equal(ValidationResult.Success, result);
+        Assert.NotEqual(ValidationResult.Success, result);
     }
 }

--- a/src/Altinn.Correspondence.API/ValidationAttributes/RecipientListAttribute.cs
+++ b/src/Altinn.Correspondence.API/ValidationAttributes/RecipientListAttribute.cs
@@ -40,7 +40,7 @@ internal class RecipientListAttribute : ValidationAttribute
             var orgRegex = new Regex($@"^(?:0192:|{UrnConstants.OrganizationNumberAttribute}:)\d{{9}}$");
             var personRegex = new Regex($@"^(?:{UrnConstants.PersonIdAttribute}:)?\d{{11}}$");
             var emailUrnRegex = new Regex($@"^{Regex.Escape(UrnConstants.PersonIdPortenEmailAttribute)}:.+$");
-            var legacySelfIdentifiedUrnRegex = new Regex($@"^{Regex.Escape(UrnConstants.PersonLegacySelfIdentifiedAttribute)}:.+$");
+            var legacySelfIdentifiedUrnRegex = new Regex($@"^{Regex.Escape(UrnConstants.PersonLegacySelfIdentifiedAttribute)}:[^:]+$");
             
             if (!orgRegex.IsMatch(recipient) && !personRegex.IsMatch(recipient) && !emailUrnRegex.IsMatch(recipient) && !legacySelfIdentifiedUrnRegex.IsMatch(recipient))
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A couple correspondences have failed on dialog creation in production because the recipient is on a format not accepted by dialogporten. Dialogporten does not permit colon in legacy si-user usernames and so we cannot allow it either. This PR updates the legacy si-user validation to not allow colon in the username.

## Related Issue(s)
- #2026 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for legacy self-identified recipient URNs, allowing valid recipient entries that were previously rejected.
  * Added coverage for legacy URNs with and without a colon in the username portion to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->