### PR TITLE
Refactored check notification delivery to use self recursion for polling

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CheckNotificationDeliveryHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CheckNotificationDeliveryHandlerTests.cs
@@ -1,4 +1,5 @@
 using Altinn.Correspondence.Application.CheckNotificationDelivery;
+using Altinn.Correspondence.Application.SendSlackNotification;
 using Altinn.Correspondence.Core.Models.Entities;
 using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Models.Notifications;
@@ -9,6 +10,7 @@ using Altinn.Correspondence.Tests.Helpers;
 using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Text.Json;
@@ -19,6 +21,7 @@ public class CheckNotificationDeliveryHandlerTests
 {
     private readonly Mock<ICorrespondenceRepository> _correspondenceRepositoryMock;
     private readonly Mock<ICorrespondenceNotificationRepository> _notificationRepositoryMock;
+    private readonly Mock<IIdempotencyKeyRepository> _idempotencyKeyRepositoryMock;
     private readonly Mock<IAltinnNotificationService> _notificationServiceMock;
     private readonly Mock<IBackgroundJobClient> _backgroundJobClientMock;
     private readonly Mock<ILogger<CheckNotificationDeliveryHandler>> _loggerMock;
@@ -28,6 +31,7 @@ public class CheckNotificationDeliveryHandlerTests
     {
         _correspondenceRepositoryMock = new Mock<ICorrespondenceRepository>();
         _notificationRepositoryMock = new Mock<ICorrespondenceNotificationRepository>();
+        _idempotencyKeyRepositoryMock = new Mock<IIdempotencyKeyRepository>();
         _notificationServiceMock = new Mock<IAltinnNotificationService>();
         _backgroundJobClientMock = new Mock<IBackgroundJobClient>();
         _loggerMock = new Mock<ILogger<CheckNotificationDeliveryHandler>>();
@@ -35,6 +39,7 @@ public class CheckNotificationDeliveryHandlerTests
         _handler = new CheckNotificationDeliveryHandler(
             _correspondenceRepositoryMock.Object,
             _notificationRepositoryMock.Object,
+            _idempotencyKeyRepositoryMock.Object,
             _notificationServiceMock.Object,
             _backgroundJobClientMock.Object,
             _loggerMock.Object,
@@ -96,18 +101,67 @@ public class CheckNotificationDeliveryHandlerTests
     }
 
     [Fact]
-    public async Task Process_WhenNotificationNotDelivered_ThrowsException()
+    public async Task Process_WhenResolvedConcurrently_SkipsDuplicateSideEffects()
+    {
+        var (notification, correspondence, shipmentId) = BuildScenario();
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId));
+        _idempotencyKeyRepositoryMock
+            .Setup(x => x.CreateAsync(It.IsAny<IdempotencyKeyEntity>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(BuildUniqueViolation());
+
+        var result = await _handler.Process(notification.Id, CancellationToken.None);
+
+        Assert.True(result.IsT0);
+        Assert.True(result.AsT0);
+        _notificationRepositoryMock.Verify(x => x.UpdateNotificationSent(
+            It.IsAny<Guid>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        VerifyEventPublished(AltinnEventType.CorrespondenceNotificationDelivered, Times.Never());
+        _backgroundJobClientMock.Verify(x => x.Create(
+            It.Is<Job>(job => job.Type == typeof(IDialogportenService) && job.Method.Name == nameof(IDialogportenService.CreateInformationActivity)),
+            It.IsAny<IState>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenNotificationNotDelivered_SchedulesNextCheckWithoutSideEffects()
     {
         var (notification, correspondence, shipmentId) = BuildScenario();
         SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_New, orderStatus: "Order_Processing"));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Process(notification.Id, CancellationToken.None));
+        var result = await _handler.Process(notification.Id, CancellationToken.None);
 
+        Assert.True(result.IsT0);
         _notificationRepositoryMock.Verify(x => x.UpdateNotificationSent(
             It.IsAny<Guid>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         _backgroundJobClientMock.Verify(x => x.Create(
             It.Is<Job>(job => job.Type == typeof(IDialogportenService) && job.Method.Name == nameof(IDialogportenService.CreateInformationActivity)),
             It.IsAny<IState>()), Times.Never);
+        VerifyDeliveryCheckRescheduled(Times.Once());
+    }
+
+    [Fact]
+    public async Task Process_WhenNotDeliveredOnFinalAttempt_GivesUpAndAlertsSlack()
+    {
+        var (notification, correspondence, shipmentId) = BuildScenario();
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_New, orderStatus: "Order_Processing"));
+
+        var result = await _handler.Process(notification.Id, CancellationToken.None, publishFailedEvent: true, attempt: CheckNotificationDeliveryHandler.MaxAttempts);
+
+        Assert.True(result.IsT0);
+        VerifyDeliveryCheckRescheduled(Times.Never());
+        VerifySlackNotificationEnqueued(Times.Once());
+    }
+
+    [Fact]
+    public async Task Process_WhenNotDeliveredOnAttemptBeforeFinal_ReschedulesWithoutAlertingSlack()
+    {
+        var (notification, correspondence, shipmentId) = BuildScenario();
+        SetupMocks(notification, correspondence, shipmentId, BuildStatus(shipmentId, NotificationStatusV2.Email_New, orderStatus: "Order_Processing"));
+
+        var result = await _handler.Process(notification.Id, CancellationToken.None, publishFailedEvent: true, attempt: CheckNotificationDeliveryHandler.MaxAttempts - 1);
+
+        Assert.True(result.IsT0);
+        VerifyDeliveryCheckRescheduled(Times.Once());
+        VerifySlackNotificationEnqueued(Times.Never());
     }
 
     [Theory]
@@ -444,6 +498,31 @@ public class CheckNotificationDeliveryHandlerTests
                 job.Args.Count > 2 &&
                 job.Args[2] is DialogportenTextType &&
                 (DialogportenTextType)job.Args[2] == textType),
+            It.Is<IState>(state => state is EnqueuedState)), times);
+    }
+
+    private void VerifyDeliveryCheckRescheduled(Times times)
+    {
+        _backgroundJobClientMock.Verify(x => x.Create(
+            It.Is<Job>(job =>
+                job.Type == typeof(CheckNotificationDeliveryHandler) &&
+                job.Method.Name == nameof(CheckNotificationDeliveryHandler.Process)),
+            It.Is<IState>(state => state is ScheduledState)), times);
+    }
+
+    private static DbUpdateException BuildUniqueViolation()
+    {
+        var inner = new Exception("duplicate key value violates unique constraint");
+        inner.Data["SqlState"] = "23505";
+        return new DbUpdateException("unique violation", inner);
+    }
+
+    private void VerifySlackNotificationEnqueued(Times times)
+    {
+        _backgroundJobClientMock.Verify(x => x.Create(
+            It.Is<Job>(job =>
+                job.Type == typeof(SendSlackNotificationHandler) &&
+                job.Method.Name == nameof(SendSlackNotificationHandler.Process)),
             It.Is<IState>(state => state is EnqueuedState)), times);
     }
 

--- a/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
+++ b/src/Altinn.Correspondence.Application/CheckNotificationDelivery/CheckNotificationDeliveryHandler.cs
@@ -1,12 +1,17 @@
 using Altinn.Correspondence.Application.Helpers;
+using Altinn.Correspondence.Application.SendSlackNotification;
 using Altinn.Correspondence.Common.Helpers;
 using Altinn.Correspondence.Core.Models.Entities;
+using Altinn.Correspondence.Core.Models.Enums;
 using Altinn.Correspondence.Core.Models.Notifications;
 using Altinn.Correspondence.Core.Repositories;
 using Altinn.Correspondence.Core.Services;
 using Altinn.Correspondence.Core.Services.Enums;
 using Altinn.Correspondence.Persistence;
+using Altinn.Correspondence.Persistence.Helpers;
+using Altinn.Correspondence.Integrations.Hangfire;
 using Hangfire;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using OneOf;
 using System.Text.Json;
@@ -16,32 +21,38 @@ namespace Altinn.Correspondence.Application.CheckNotificationDelivery;
 public class CheckNotificationDeliveryHandler(
     ICorrespondenceRepository correspondenceRepository,
     ICorrespondenceNotificationRepository correspondenceNotificationRepository,
+    IIdempotencyKeyRepository idempotencyKeyRepository,
     IAltinnNotificationService altinnNotificationService,
     IBackgroundJobClient backgroundJobClient,
     ILogger<CheckNotificationDeliveryHandler> logger,
     ApplicationDbContext dbContext)
 {
-    [AutomaticRetry(
-        Attempts = 10,
-        DelaysInSeconds = new[] 
-        {
-            60,
-            15 * 60,
-            4 * 60 * 60,
-            8 * 60 * 60,
-            12 * 60 * 60,
-            16 * 60 * 60,
-            36 * 60 * 60,
-            48 * 60 * 60,
-            72 * 60 * 60
-        }
-    )]
+    private static readonly int[] PollBackoffSeconds =
+    [
+        60,
+        15 * 60,
+        4 * 60 * 60,
+        8 * 60 * 60,
+        12 * 60 * 60,
+        16 * 60 * 60,
+        36 * 60 * 60,
+        48 * 60 * 60,
+        72 * 60 * 60
+    ];
+
+    public static readonly int MaxAttempts = PollBackoffSeconds.Length + 1;
+
     public async Task<OneOf<bool, Error>> Process(Guid notificationId, CancellationToken cancellationToken)
     {
-        return await Process(notificationId, cancellationToken, publishFailedEvent: true);
+        return await Process(notificationId, cancellationToken, publishFailedEvent: true, attempt: 1);
     }
 
     public async Task<OneOf<bool, Error>> Process(Guid notificationId, CancellationToken cancellationToken, bool publishFailedEvent)
+    {
+        return await Process(notificationId, cancellationToken, publishFailedEvent, attempt: 1);
+    }
+
+    public async Task<OneOf<bool, Error>> Process(Guid notificationId, CancellationToken cancellationToken, bool publishFailedEvent, int attempt)
     {
         logger.LogInformation("Checking delivery status for notification {NotificationId}", notificationId);
         
@@ -92,8 +103,8 @@ public class CheckNotificationDeliveryHandler(
             
             if (notificationDetailsV2 == null)
             {
-                logger.LogError("Failed to get notification details for shipment {ShipmentId}", notification.ShipmentId);
-                return NotificationErrors.NotificationDetailsNotFound;
+                logger.LogWarning("Delivery details not yet available for shipment {ShipmentId}", notification.ShipmentId);
+                return ScheduleNextPollOrGiveUp(notification, publishFailedEvent, attempt, "delivery details not yet available");
             }
 
             if (IsFinalOrderStatus(notificationDetailsV2.Status))
@@ -103,81 +114,97 @@ public class CheckNotificationDeliveryHandler(
                 var allFailed = failedRecipients.Any() && notificationDetailsV2.Recipients.All(r => r.Status.IsFailed());
                 var isMainOrder = IsMainOrder(notification, correspondence.Recipient);
 
-                await DatabaseTransactionHelper.ExecuteAsync(dbContext, async (transactionToken) =>
+                try
                 {
-                    await correspondenceNotificationRepository.UpdateNotificationStatus(notificationId, notificationDetailsV2.Status, transactionToken);
-
-                    if (failedRecipients.Any())
+                    await DatabaseTransactionHelper.ExecuteAsync(dbContext, async (transactionToken) =>
                     {
-                        logger.LogError("Notification {NotificationId} has failed status (allFailed: {AllFailed}, isMainOrder: {IsMainOrder})", notificationId, allFailed, isMainOrder);
-                        if (publishFailedEvent)
+                        await idempotencyKeyRepository.CreateAsync(new IdempotencyKeyEntity
                         {
-                            if (allFailed && isMainOrder)
+                            Id = notification.Id,
+                            CorrespondenceId = notification.CorrespondenceId,
+                            IdempotencyType = IdempotencyType.NotificationDeliveryResolution
+                        }, transactionToken);
+
+                        await correspondenceNotificationRepository.UpdateNotificationStatus(notificationId, notificationDetailsV2.Status, transactionToken);
+
+                        if (failedRecipients.Any())
+                        {
+                            logger.LogError("Notification {NotificationId} has failed status (allFailed: {AllFailed}, isMainOrder: {IsMainOrder})", notificationId, allFailed, isMainOrder);
+                            if (publishFailedEvent)
                             {
-                                SendAllFailedEvent(correspondence.ResourceId, correspondence.Id.ToString(), correspondence.Sender);
+                                if (allFailed && isMainOrder)
+                                {
+                                    SendAllFailedEvent(correspondence.ResourceId, correspondence.Id.ToString(), correspondence.Sender);
+                                }
+                                else
+                                {
+                                    SendFailedEvent(correspondence.ResourceId, correspondence.Id.ToString(), correspondence.Sender);
+                                }
                             }
-                            else
+
+                            foreach (var recipient in failedRecipients)
                             {
-                                SendFailedEvent(correspondence.ResourceId, correspondence.Id.ToString(), correspondence.Sender);
+                                var failureTextType = recipient.Status.IsTtlFailure()
+                                    ? (notification.IsReminder ? DialogportenTextType.NotificationReminderDeliveryUnconfirmed : DialogportenTextType.NotificationDeliveryUnconfirmed)
+                                    : (notification.IsReminder ? DialogportenTextType.NotificationReminderFailed : DialogportenTextType.NotificationFailed);
+                                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) =>
+                                    dialogportenService.CreateInformationActivity(
+                                        correspondence.Id,
+                                        DialogportenActorType.ServiceOwner,
+                                        failureTextType,
+                                        recipient.LastUpdate,
+                                        recipient.Destination,
+                                        recipient.Type.ToString()));
                             }
                         }
 
-                        foreach (var recipient in failedRecipients)
+                        if (sentRecipients.Any())
                         {
-                            var failureTextType = recipient.Status.IsTtlFailure()
-                                ? (notification.IsReminder ? DialogportenTextType.NotificationReminderDeliveryUnconfirmed : DialogportenTextType.NotificationDeliveryUnconfirmed)
-                                : (notification.IsReminder ? DialogportenTextType.NotificationReminderFailed : DialogportenTextType.NotificationFailed);
-                            backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) =>
-                                dialogportenService.CreateInformationActivity(
-                                    correspondence.Id,
-                                    DialogportenActorType.ServiceOwner,
-                                    failureTextType,
-                                    recipient.LastUpdate,
-                                    recipient.Destination,
-                                    recipient.Type.ToString()));
-                        }
-                    }
+                            var deliveryDestination = string.Join(", ", sentRecipients.Select(r => r.Destination));
+                            var sentTime = sentRecipients.Min(r => r.LastUpdate);
+                            await correspondenceNotificationRepository.UpdateNotificationSent(notificationId, sentTime, deliveryDestination, transactionToken);
 
-                    if (sentRecipients.Any())
-                    {
-                        var deliveryDestination = string.Join(", ", sentRecipients.Select(r => r.Destination));
-                        var sentTime = sentRecipients.Min(r => r.LastUpdate);
-                        await correspondenceNotificationRepository.UpdateNotificationSent(notificationId, sentTime, deliveryDestination, transactionToken);
+                            var sentTextType = notification.IsReminder ? DialogportenTextType.NotificationReminderSent : DialogportenTextType.NotificationSent;
+                            foreach (var recipient in sentRecipients)
+                            {
+                                backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) =>
+                                    dialogportenService.CreateInformationActivity(
+                                        correspondence.Id,
+                                        DialogportenActorType.ServiceOwner,
+                                        sentTextType,
+                                        recipient.LastUpdate,
+                                        recipient.Destination,
+                                        recipient.Type.ToString()));
+                            }
 
-                        var sentTextType = notification.IsReminder ? DialogportenTextType.NotificationReminderSent : DialogportenTextType.NotificationSent;
-                        foreach (var recipient in sentRecipients)
-                        {
-                            backgroundJobClient.Enqueue<IDialogportenService>((dialogportenService) =>
-                                dialogportenService.CreateInformationActivity(
-                                    correspondence.Id,
-                                    DialogportenActorType.ServiceOwner,
-                                    sentTextType,
-                                    recipient.LastUpdate,
-                                    recipient.Destination,
-                                    recipient.Type.ToString()));
+                            var sentEventType = notification.IsReminder
+                                ? AltinnEventType.CorrespondenceNotificationReminderDelivered
+                                : AltinnEventType.CorrespondenceNotificationDelivered;
+                            backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(
+                                sentEventType, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, CancellationToken.None));
                         }
 
-                        var sentEventType = notification.IsReminder
-                            ? AltinnEventType.CorrespondenceNotificationReminderDelivered
-                            : AltinnEventType.CorrespondenceNotificationDelivered;
-                        backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(
-                            sentEventType, correspondence.ResourceId, correspondence.Id.ToString(), "correspondence", correspondence.Sender, CancellationToken.None));
-                    }
-
-                    return true;
-                }, cancellationToken);
+                        return true;
+                    }, cancellationToken);
+                }
+                catch (DbUpdateException e) when (e.IsPostgresUniqueViolation())
+                {
+                    logger.LogInformation(
+                        "Notification {NotificationId} delivery was already resolved by a concurrent run; skipping duplicate side effects.",
+                        notificationId);
+                }
 
                 return true;
             }
             else
             {
-                throw new InvalidOperationException($"Notification {notificationId} not yet finished (order status: {notificationDetailsV2.Status}). Throwing to retry.");
+                return ScheduleNextPollOrGiveUp(notification, publishFailedEvent, attempt, $"order status {notificationDetailsV2.Status}");
             }
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error checking delivery status for notification {NotificationId}", notificationId);
-                throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error checking delivery status for notification {NotificationId}", notificationId);
+            throw;
         }
     }
 
@@ -196,6 +223,31 @@ public class CheckNotificationDeliveryHandler(
         if (r.RecipientPerson != null) return r.RecipientPerson.NationalIdentityNumber == recipientWithoutPrefix;
         if (r.RecipientExternalIdentity != null) return r.RecipientExternalIdentity.ExternalIdentity == correspondenceRecipient;
         return false;
+    }
+
+    private OneOf<bool, Error> ScheduleNextPollOrGiveUp(CorrespondenceNotificationEntity notification, bool publishFailedEvent, int attempt, string reason)
+    {
+        if (attempt >= MaxAttempts)
+        {
+            logger.LogError(
+                "Delivery for notification {NotificationId} (correspondence {CorrespondenceId}) was not confirmed after {MaxAttempts} attempts ({Reason}). Giving up polling.",
+                notification.Id, notification.CorrespondenceId, MaxAttempts, reason);
+            var slackMessage =
+                $"Notification {notification.Id} for correspondence {notification.CorrespondenceId} did not reach a final order status after {MaxAttempts} delivery checks ({reason}). Delivery polling has been stopped.";
+            backgroundJobClient.Enqueue<SendSlackNotificationHandler>(handler =>
+                handler.Process("Notification delivery not confirmed", slackMessage, ":warning:"));
+            return true;
+        }
+
+        var nextAttempt = attempt + 1;
+        var nextPollTime = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(PollBackoffSeconds[attempt - 1]);
+        backgroundJobClient.Schedule<CheckNotificationDeliveryHandler>(HangfireQueues.Default,
+            handler => handler.Process(notification.Id, CancellationToken.None, publishFailedEvent, nextAttempt),
+            nextPollTime);
+        logger.LogInformation(
+            "Notification {NotificationId} delivery not yet confirmed on attempt {Attempt} of {MaxAttempts} ({Reason}). Scheduled attempt {NextAttempt} at {NextPollTime}.",
+            notification.Id, attempt, MaxAttempts, reason, nextAttempt, nextPollTime);
+        return true;
     }
 
     private void SendFailedEvent(string resourceId, string correspondenceId, string sender)

--- a/src/Altinn.Correspondence.Core/Models/Enums/IdempotencyType.cs
+++ b/src/Altinn.Correspondence.Core/Models/Enums/IdempotencyType.cs
@@ -37,7 +37,7 @@ public enum IdempotencyType
     PurgeCorrespondence = 5,
 
     /// <summary>
-    /// Indicates that this is an idempotency key for resolving a notification's delivery status
+    /// Indicates that this is an idempotency key for resolving a notification's final delivery status
     /// </summary>
     NotificationDeliveryResolution = 6,
 }

--- a/src/Altinn.Correspondence.Core/Models/Enums/IdempotencyType.cs
+++ b/src/Altinn.Correspondence.Core/Models/Enums/IdempotencyType.cs
@@ -35,4 +35,9 @@ public enum IdempotencyType
     /// Indicates that this is an idempotency key for purging a correspondence
     /// </summary>
     PurgeCorrespondence = 5,
-} 
+
+    /// <summary>
+    /// Indicates that this is an idempotency key for resolving a notification's delivery status
+    /// </summary>
+    NotificationDeliveryResolution = 6,
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the check notification delivery polls notification delivery by throwing exceptions. This is not optimal since it creates many false positive failed hangfire jobs and is an anti-pattern. This PR refactors the check notification delivery to use self-recursion to poll instead using the same max poll count and backoff. If the notification is not marked as delivered within 10 polls over about a week, the handler sends a slack notification and logs an error.

Also added an idempotencykey to guarantee no duplicate events and dialogporten activites from the job.

## Related Issue(s)
- #2029

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification delivery polling now uses scheduled retries with backoff, up to a maximum attempt count.
  * If delivery fails on the final attempt, the system sends an alert.

* **Bug Fixes**
  * Prevents duplicate delivery side effects when concurrent checks resolve the same notification.
  * Improved behavior when delivery details aren’t available yet and when notifications haven’t been delivered.

* **Tests**
  * Added scenarios covering idempotency collisions, rescheduling behavior, and final-attempt alerting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->