### PR TITLE
Use URN prefix if available

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Altinn/Authorization/XacmlRequestFactory.cs
+++ b/src/Altinn.Correspondence.Integrations/Altinn/Authorization/XacmlRequestFactory.cs
@@ -18,17 +18,17 @@ public static class XacmlRequestFactory
         XacmlJsonCategory resourceCategory = new() { Attribute = new List<XacmlJsonAttribute>() };
         resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.ResourceId, resourceId, DefaultType, issuer));
         var partyWithoutPrefix = party.WithoutPrefix();
-        if (partyWithoutPrefix.IsOrganizationNumber())
+        if (party.StartsWith(AltinnXacmlUrns.OrganizationNumber) || partyWithoutPrefix.IsOrganizationNumber())
         {
             resourceCategory.Attribute.Add(
                 DecisionHelper.CreateXacmlJsonAttribute(UrnConstants.OrganizationNumberAttribute, partyWithoutPrefix, DefaultType, issuer));
         }
-        else if (partyWithoutPrefix.IsSocialSecurityNumber())
+        else if (party.StartsWith(AltinnXacmlUrns.PersonId) || partyWithoutPrefix.IsSocialSecurityNumber())
         {
             resourceCategory.Attribute.Add(
                 DecisionHelper.CreateXacmlJsonAttribute(UrnConstants.PersonIdAttribute, partyWithoutPrefix, DefaultType, issuer));
         }
-        else if (partyWithoutPrefix.IsPartyId())
+        else if (party.StartsWith(AltinnXacmlUrns.PartyId) || partyWithoutPrefix.IsPartyId())
         {
             resourceCategory.Attribute.Add(
                 DecisionHelper.CreateXacmlJsonAttribute(UrnConstants.Party, partyWithoutPrefix, DefaultType, issuer));


### PR DESCRIPTION
## Description
It used to come in without it, but now it should come with it. 

## Related issue
#2042 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of recipient/party identifiers so values with standard prefix formats are recognized correctly.
  * This helps ensure the right access-related details are included when requests are generated, reducing issues with certain party identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->