### PR TITLE
Permit pauses in upload

### DIFF
--- a/src/Altinn.Correspondence.API/Program.cs
+++ b/src/Altinn.Correspondence.API/Program.cs
@@ -164,6 +164,8 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
     services.Configure<KestrelServerOptions>(options =>
     {
         options.Limits.MaxRequestBodySize = null;
+        options.Limits.MinRequestBodyDataRate = null;
+        options.Limits.MinResponseDataRate = null;
     });
     services.Configure<FormOptions>(options =>
     {


### PR DESCRIPTION
## Description
The default is a sliding 5 second window with 240bytes/sec, but in cases where users may have to prepare multiple files on their end, they may have to pause for a bit. Trying to be very liberal with this limit and relying on timeouts instead.

It should resolve some of our "response code 0" issues, although likely not all.

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)