### PR TITLE
fix bug which made downloadall job restart from scratch

### DIFF
--- a/src/Altinn.Correspondence.Application/UpdateOldCorrespondencesWithDownloadAll/UpdateOldCorrespondencesWithDownloadAllHandler.cs
+++ b/src/Altinn.Correspondence.Application/UpdateOldCorrespondencesWithDownloadAll/UpdateOldCorrespondencesWithDownloadAllHandler.cs
@@ -42,6 +42,20 @@ public class UpdateOldCorrespondencesWithDownloadAllHandler(
     {
         _logger.LogInformation("Executing batch starting after cursor {cursorId}", request.CursorId?.ToString().SanitizeForLogging());
 
+        if (request.CursorId.HasValue && !request.CursorCreated.HasValue)
+        {
+            var cursorCorrespondence = await _correspondenceRepository.GetCorrespondenceById(
+                request.CursorId.Value, false, false, false, cancellationToken);
+            if (cursorCorrespondence is null)
+            {
+                _logger.LogError(
+                    "CursorId {cursorId} was provided without CursorCreated and could not be resolved to a correspondence. Aborting to avoid restarting from the beginning.",
+                    request.CursorId.Value.ToString().SanitizeForLogging());
+                return;
+            }
+            request.CursorCreated = cursorCorrespondence.Created;
+        }
+
         var queueLimit = request.windowSize * 2;
         var enqueuedJobs = JobStorage.Current.GetMonitoringApi().EnqueuedCount(HangfireQueues.Migration);
         if (enqueuedJobs >= queueLimit)


### PR DESCRIPTION
## Description
The job which applies the download all functionality to older correspondences had a flaw which made restarts start from scratch if only the cursorId was provided. This lead the batch query to not filter on a lastCreated value and therefore defaulted to the start of the dataset.

## Related Issue(s)
- #2067

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background processing recovery when resuming from a saved position.
  * Prevented processing from restarting from the beginning when the saved position cannot be resolved.
  * Added safer handling and error reporting for incomplete resume information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->