### PR TITLE
add temporary table for IsMigrating correspondences

### DIFF
--- a/src/Altinn.Correspondence.Persistence/Migrations/20260722132513_Add_Temp_Table_For_IsMigrating.Designer.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20260722132513_Add_Temp_Table_For_IsMigrating.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Altinn.Correspondence.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Correspondence.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260722132513_Add_Temp_Table_For_IsMigrating")]
+    partial class Add_Temp_Table_For_IsMigrating
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Altinn.Correspondence.Persistence/Migrations/20260722132513_Add_Temp_Table_For_IsMigrating.cs
+++ b/src/Altinn.Correspondence.Persistence/Migrations/20260722132513_Add_Temp_Table_For_IsMigrating.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Correspondence.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Temp_Table_For_IsMigrating : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                CREATE TABLE ""correspondence"".""TempTableIsMigratingCorrespondences"" (
+                    LIKE ""correspondence"".""Correspondences""
+                );
+            ");
+
+            migrationBuilder.Sql(@"
+                ALTER TABLE ""correspondence"".""TempTableIsMigratingCorrespondences""
+                    ADD PRIMARY KEY (""Id"");
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                DROP TABLE IF EXISTS ""correspondence"".""TempTableIsMigratingCorrespondences"";
+            ");
+        }
+    }
+}


### PR DESCRIPTION
## Description
Added a DB migration to create a separate temporary table for Correspondences with IsMigrating = true. These are mainly testdata which we will consider removing in the future. While these rows reside in the main Correspondences table they slow down some queries to a large extend so a job will be ran which moves these into the newly created table.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)