### PR TITLE
remove IsMigrating filter from db queries

### DIFF
--- a/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
+++ b/Test/Altinn.Correspondence.Tests/Dialogporten/DialogportenServiceTests.cs
@@ -50,7 +50,7 @@ public class DialogportenServiceTests
 
         var mockRepo = new Mock<ICorrespondenceRepository>();
         mockRepo
-            .Setup(r => r.GetCorrespondenceById(correspondence.Id, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(r => r.GetCorrespondenceById(correspondence.Id, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
 
         var mockIdem = new Mock<IIdempotencyKeyRepository>();
@@ -109,7 +109,7 @@ public class DialogportenServiceTests
 
         var mockRepo = new Mock<ICorrespondenceRepository>();
         mockRepo
-            .Setup(r => r.GetCorrespondenceById(correspondence.Id, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(r => r.GetCorrespondenceById(correspondence.Id, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
 
         var mockIdem = new Mock<IIdempotencyKeyRepository>();
@@ -165,7 +165,7 @@ public class DialogportenServiceTests
 
         var mockRepo = new Mock<ICorrespondenceRepository>();
         mockRepo
-            .Setup(r => r.GetCorrespondenceById(correspondence.Id, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(r => r.GetCorrespondenceById(correspondence.Id, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
         mockRepo
             .Setup(r => r.RemoveExternalReference(correspondence, ReferenceType.DialogportenDialogId, It.IsAny<CancellationToken>()))

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceInitializationTests.cs
@@ -2542,7 +2542,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dialogJobId);
             scheduleRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, false, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, false, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CorrespondenceEntity
                 {
                     Id = correspondenceId,
@@ -2623,7 +2623,7 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             };
 
             correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondenceWithNoDialog);
             correspondenceRepositoryMock
                 .Setup(x => x.AreAllAttachmentsPublished(correspondenceId, It.IsAny<CancellationToken>()))

--- a/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingController/Correspondence/CorrespondenceSearchTests.cs
@@ -615,30 +615,5 @@ namespace Altinn.Correspondence.Tests.TestingController.Correspondence
             var result = await search.Content.ReadFromJsonAsync<GetCorrespondencesResponse>(_responseSerializerOptions);
             Assert.Empty(result.Ids);
         }
-
-        [Fact]
-        public async Task GetCorrespondences_WithAltinn2CorrespondenceId_WhenStillMigrating_ReturnsEmptyList()
-        {
-            // Arrange
-            var resourceId = Guid.NewGuid().ToString();
-            var altinn2CorrespondenceId = new Random().Next(100000, int.MaxValue);
-
-            using var scope = _factory.Services.CreateScope();
-            var correspondenceRepository = scope.ServiceProvider.GetRequiredService<ICorrespondenceRepository>();
-            var correspondence = new CorrespondenceEntityBuilder()
-                .WithResourceId(resourceId)
-                .WithAltinn2CorrespondenceId(altinn2CorrespondenceId)
-                .WithIsMigrating(true)
-                .Build();
-            await correspondenceRepository.CreateCorrespondence(correspondence, CancellationToken.None);
-
-            // Act
-            var search = await _senderClient.GetAsync($"/correspondence/api/v1/correspondence?resourceId={resourceId}&altinn2CorrespondenceId={altinn2CorrespondenceId}&role={"recipientandsender"}");
-
-            // Assert
-            Assert.Equal(HttpStatusCode.OK, search.StatusCode);
-            var result = await search.Content.ReadFromJsonAsync<GetCorrespondencesResponse>(_responseSerializerOptions);
-            Assert.Empty(result.Ids);
-        }
     }
 }

--- a/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/DialogportenTests.cs
@@ -328,7 +328,7 @@ public class DialogportenTests
             .AddCorrespondenceStatus(It.IsAny<Core.Models.Entities.CorrespondenceStatusEntity>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Guid());
         correspondenceRepository.Setup(correspondenceRepository => correspondenceRepository
-            .GetCorrespondenceById(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .GetCorrespondenceById(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(testCorrespondence);
         altinnRegisterService.Setup(altinnRegisterService => altinnRegisterService.LookUpPartyById(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(RegisterServiceMockExtensions.BuildOrganization(Guid.NewGuid(), "991825827"));
         using var testFactory = new UnitWebApplicationFactory((IServiceCollection services) =>

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CheckNotificationDeliveryHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CheckNotificationDeliveryHandlerTests.cs
@@ -458,7 +458,7 @@ public class CheckNotificationDeliveryHandlerTests
     {
         _notificationRepositoryMock.Setup(x => x.GetNotificationById(notification.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(notification);
-        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(notification.CorrespondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+        _correspondenceRepositoryMock.Setup(x => x.GetCorrespondenceById(notification.CorrespondenceId, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
         if (notificationStatus != null)
         {

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/ConfirmCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/ConfirmCorrespondenceHandlerTests.cs
@@ -54,7 +54,7 @@ public class ConfirmCorrespondenceHandlerTests
         var user = CreateUserWithCallerUrn($"{UrnConstants.PersonIdAttribute}:10108000398");
 
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondence.Id, true, false, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondence.Id, true, false, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
 
         _altinnAuthorizationServiceMock

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CreateNotificationOrderHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CreateNotificationOrderHandlerTests.cs
@@ -119,7 +119,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             };
 
             _mockCorrespondenceRepository
-                .Setup(x => x.GetCorrespondenceById(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), CancellationToken.None, false))
+                .Setup(x => x.GetCorrespondenceById(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), CancellationToken.None))
                 .ReturnsAsync(correspondence);
 
             _mockNotificationTemplateRepository

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/GetCorrespondenceOverviewHandlerTests.cs
@@ -116,7 +116,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
 
             // Mock correspondence repository
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             // Act
@@ -175,7 +175,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
 
             // Mock correspondence repository
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             // Act
@@ -226,7 +226,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
 
             // Mock correspondence repository
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             // Act
@@ -279,7 +279,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
 
             // Mock correspondence repository
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             // Mock confidential reminder - correspondence has a reminder
@@ -346,7 +346,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
 
             // Mock correspondence repository
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             // Mock confidential reminder - correspondence has a reminder
@@ -413,7 +413,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
 
             // Mock correspondence repository
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             // Act
@@ -441,7 +441,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             var request = new GetCorrespondenceOverviewRequest { CorrespondenceId = correspondenceId };
 
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((CorrespondenceEntity?)null);
 
             // Act
@@ -468,7 +468,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             var request = new GetCorrespondenceOverviewRequest { CorrespondenceId = correspondenceId };
 
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
             _altinnAuthorizationServiceMock
                 .Setup(x => x.CheckAccessAsRecipient(It.IsAny<ClaimsPrincipal>(), It.IsAny<CorrespondenceEntity>(), It.IsAny<CancellationToken>()))
@@ -515,7 +515,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.LookUpPartyById(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(RegisterServiceMockExtensions.BuildOrganization(partyUuid, "991825827"));
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             _confidentialReminderRepositoryMock
@@ -564,7 +564,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.LookUpPartyById(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(RegisterServiceMockExtensions.BuildOrganization(partyUuid, "991825827"));
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             _confidentialReminderRepositoryMock
@@ -620,7 +620,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.LookUpPartyById(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(RegisterServiceMockExtensions.BuildOrganization(partyUuid, "991825827"));
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             // Act
@@ -664,7 +664,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 .Setup(x => x.LookUpPartyById(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(RegisterServiceMockExtensions.BuildOrganization(partyUuid, "991825827"));
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             _cacheMock

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/PublishCorrespondenceHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/PublishCorrespondenceHandlerTests.cs
@@ -66,7 +66,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             _altinnRegisterServiceMock.SetupPartyByIdLookup("310244007", partyUuid);
 
             _correspondenceRepositoryMock
-                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+                .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(correspondence);
 
             _correspondenceRepositoryMock

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/SendNotificationOrderHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/SendNotificationOrderHandlerTests.cs
@@ -97,7 +97,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
                 }
             };
 
-            _mockCorrespondenceRepository.Setup(x => x.GetCorrespondenceById(correspondenceId, false, false, false, CancellationToken.None, false))
+            _mockCorrespondenceRepository.Setup(x => x.GetCorrespondenceById(correspondenceId, false, false, false, CancellationToken.None))
                 .ReturnsAsync(correspondence);
             _mockCorrespondenceNotificationRepository.Setup(x => x.GetPrimaryNotificationsByCorrespondenceId(correspondenceId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<CorrespondenceNotificationEntity> { notification });

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/UnreadConfidentialCorrespondenceReminderHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/UnreadConfidentialCorrespondenceReminderHandlerTests.cs
@@ -58,7 +58,7 @@ public class UnreadConfidentialCorrespondenceReminderHandlerTests
         // Arrange
         var correspondenceId = Guid.NewGuid();
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync((CorrespondenceEntity?)null);
 
         // Act
@@ -84,7 +84,7 @@ public class UnreadConfidentialCorrespondenceReminderHandlerTests
             .WithStatus(CorrespondenceStatus.Read)
             .Build();
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
 
         // Act
@@ -112,7 +112,7 @@ public class UnreadConfidentialCorrespondenceReminderHandlerTests
             .WithStatus(status)
             .Build();
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
 
         // Act
@@ -138,7 +138,7 @@ public class UnreadConfidentialCorrespondenceReminderHandlerTests
         var newDialogId = Guid.NewGuid();
         var correspondence = CreateUnreadCorrespondence(correspondenceId);
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
         _confidentialReminderRepositoryMock
             .Setup(x => x.NumberOfRemindersForRecipient(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -170,7 +170,7 @@ public class UnreadConfidentialCorrespondenceReminderHandlerTests
         var correspondenceId = Guid.NewGuid();
         var correspondence = CreateUnreadCorrespondence(correspondenceId);
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
         _confidentialReminderRepositoryMock
             .Setup(x => x.NumberOfRemindersForRecipient(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -200,7 +200,7 @@ public class UnreadConfidentialCorrespondenceReminderHandlerTests
         var existingDialogId = Guid.NewGuid();
         var correspondence = CreateUnreadCorrespondence(correspondenceId);
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
         _confidentialReminderRepositoryMock
             .Setup(x => x.NumberOfRemindersForRecipient(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -233,7 +233,7 @@ public class UnreadConfidentialCorrespondenceReminderHandlerTests
         var newDialogId = Guid.NewGuid();
         var correspondence = CreateUnreadCorrespondence(correspondenceId);
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
         _confidentialReminderRepositoryMock
             .Setup(x => x.NumberOfRemindersForRecipient(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -267,7 +267,7 @@ public class UnreadConfidentialCorrespondenceReminderHandlerTests
         var newDialogId = Guid.NewGuid();
         var correspondence = CreateUnreadCorrespondence(correspondenceId);
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondenceId, true, true, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
         _confidentialReminderRepositoryMock
             .Setup(x => x.NumberOfRemindersForRecipient(It.IsAny<string>(), It.IsAny<CancellationToken>()))

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/VerifyCorrespondenceConfirmationHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/VerifyCorrespondenceConfirmationHandlerTests.cs
@@ -56,7 +56,7 @@ public class VerifyCorrespondenceConfirmationHandlerTests
             .Build();
 
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondence.Id, true, false, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondence.Id, true, false, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
 
         _dialogportenServiceMock
@@ -92,7 +92,7 @@ public class VerifyCorrespondenceConfirmationHandlerTests
             .Build();
 
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondence.Id, true, false, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondence.Id, true, false, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
 
         _dialogportenServiceMock
@@ -116,7 +116,7 @@ public class VerifyCorrespondenceConfirmationHandlerTests
             .Build();
 
         _correspondenceRepositoryMock
-            .Setup(x => x.GetCorrespondenceById(correspondence.Id, true, false, false, It.IsAny<CancellationToken>(), false))
+            .Setup(x => x.GetCorrespondenceById(correspondence.Id, true, false, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(correspondence);
 
         // Act

--- a/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingRepository/CorrespondenceRepositoryTests.cs
@@ -454,13 +454,6 @@ namespace Altinn.Correspondence.Tests.TestingRepository
                 .WithStatus(CorrespondenceStatus.Confirmed, baseTime.AddMinutes(1))
                 .Build();
 
-            var migrating = new CorrespondenceEntityBuilder()
-                .WithRequestedPublishTime(baseTime.AddMinutes(1))
-                .WithAltinn2CorrespondenceId(5002)
-                .WithIsMigrating(true)
-                .WithStatus(CorrespondenceStatus.Confirmed, baseTime.AddMinutes(2))
-                .Build();
-
             var notConfirmed = new CorrespondenceEntityBuilder()
                 .WithRequestedPublishTime(baseTime.AddMinutes(2))
                 .WithAltinn2CorrespondenceId(5003)
@@ -472,10 +465,10 @@ namespace Altinn.Correspondence.Tests.TestingRepository
                 .WithStatus(CorrespondenceStatus.Confirmed, baseTime.AddMinutes(3))
                 .Build();
 
-            context.Correspondences.AddRange(valid, migrating, notConfirmed, noAltinn2Id);
+            context.Correspondences.AddRange(valid, notConfirmed, noAltinn2Id);
             await context.SaveChangesAsync();
 
-            var windowIds = new List<Guid> { valid.Id, migrating.Id, notConfirmed.Id, noAltinn2Id.Id };
+            var windowIds = new List<Guid> { valid.Id, notConfirmed.Id, noAltinn2Id.Id };
 
             var result = await repo.GetCorrespondencesWithAltinn2IdNotMigratingAndConfirmedStatus(windowIds, CancellationToken.None);
 

--- a/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
+++ b/src/Altinn.Correspondence.Core/Repositories/ICorrespondenceRepostitory.cs
@@ -40,8 +40,7 @@ namespace Altinn.Correspondence.Core.Repositories
             bool includeStatus,
             bool includeContent,
             bool includeForwardingEvents,
-            CancellationToken cancellationToken,
-            bool includeIsMigrating = false);
+            CancellationToken cancellationToken);
 
         Task<CorrespondenceEntity?> GetCorrespondenceByIdForSync(
             Guid guid,

--- a/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
+++ b/src/Altinn.Correspondence.Persistence/Helpers/QueryableExtensions.cs
@@ -136,10 +136,10 @@ namespace Altinn.Correspondence.Persistence.Helpers
         /// Includes only correspondences that have been migrated
         /// </summary>
         /// <param name="query"></param>
-        /// <returns>Filtered query containing only correspondences with Altinn2CorrespondenceId and IsMigrating == false</returns>
+        /// <returns>Filtered query containing only correspondences with Altinn2CorrespondenceId</returns>
         public static IQueryable<CorrespondenceEntity> IncludeOnlyMigrated(this IQueryable<CorrespondenceEntity> query)
         {
-            return query.Where(cs => cs.Altinn2CorrespondenceId.HasValue && cs.IsMigrating == false);
+            return query.Where(cs => cs.Altinn2CorrespondenceId.HasValue);
         }
     }
 }

--- a/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
+++ b/src/Altinn.Correspondence.Persistence/Repositories/CorrespondenceRepository.cs
@@ -75,7 +75,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .FilterBySenderOrRecipient(orgNo, role)             // Filter by role
                 .FilterByStatus(status, orgNo, role)                // Filter by status
                 .Where(c => string.IsNullOrEmpty(sendersReference) || c.SendersReference == sendersReference) // Filter by sendersReference
-                .Where(c => c.IsMigrating == false) // Filter out migrated correspondences that have not become available yet
                 .OrderByDescending(c => c.RequestedPublishTime)              // Sort by RequestedPublishTime
                 .Select(c => c.Id);
 
@@ -88,17 +87,11 @@ namespace Altinn.Correspondence.Persistence.Repositories
             bool includeStatus,
             bool includeContent,
             bool includeForwardingEvents,
-            CancellationToken cancellationToken,
-            bool includeIsMigrating = false)
+            CancellationToken cancellationToken)
         {
             logger.LogDebug("Retrieving correspondence {CorrespondenceId} including: status={IncludeStatus} content={IncludeContent}", guid, includeStatus, includeContent);
             var correspondences = _context.Correspondences.AsSplitQuery().Include(c => c.ReplyOptions).Include(c => c.ExternalReferences).Include(c => c.Notifications).AsQueryable();
 
-            // Exclude migrating correspondences unless explicitly requested, added as an option since this method is frequently used in unit tests where it it useful to override
-            if (!includeIsMigrating)
-            {
-                correspondences = correspondences.Where(c => !c.IsMigrating);
-            }
             if (includeStatus)
             {
                 correspondences = correspondences
@@ -163,7 +156,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
         {
             var correspondence = _context.Correspondences
                 .Where(c => c.Content != null && c.Content.Attachments.Any(ca => ca.AttachmentId == attachmentId))
-                .Where(c => c.IsMigrating == false) // Filter out migrated correspondences that have not become available yet
                 .AsQueryable();
 
             correspondence = includeStatus ? correspondence.Include(c => c.Statuses) : correspondence;
@@ -173,7 +165,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
         public async Task<List<CorrespondenceEntity>> GetNonPublishedCorrespondencesByAttachmentId(Guid attachmentId, CancellationToken cancellationToken = default)
         {
             var correspondences = await _context.Correspondences
-                .Where(c => c.IsMigrating == false) // Filter out migrated correspondences that have not become available yet
                 .Where(correspondence =>
                         correspondence.Content!.Attachments.Any(attachment => attachment.AttachmentId == attachmentId) // Correspondence has the given attachment
                      && !correspondence.Statuses.Any(status => status.Status == CorrespondenceStatus.Published || status.Status == CorrespondenceStatus.ReadyForPublish  // Correspondence is not published
@@ -338,7 +329,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
             var query = _context.Correspondences
                 .AsNoTracking()
                 .FilterMigrated(filterMigrated)
-                .Where(c => c.IsMigrating == false)
                 .AsQueryable();
 
             if (lastCreated.HasValue)
@@ -680,7 +670,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
         {
             var correspondence = await _context.Correspondences
             .Where(c => c.IdempotencyKeys.Any(k => k.Id == idempotentKey))
-            .Where(c => c.IsMigrating == false) // Filter out migrated correspondences that have not become available yet
             .SingleOrDefaultAsync(cancellationToken);
 
             return correspondence;
@@ -691,7 +680,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
             return await _context.Correspondences
                 .Where(c => c.Altinn2CorrespondenceId == altinn2CorrespondenceId)
                 .Where(c => c.ResourceId == resourceId)
-                .Where(c => c.IsMigrating == false)
                 .FilterBySenderOrRecipient(orgNo, role)
                 .SingleOrDefaultAsync(cancellationToken);
         }
@@ -729,7 +717,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
                 .AsSplitQuery()
                 .Where(c => correspondenceIds.Contains(c.Id))
                 .Where(c => c.Altinn2CorrespondenceId != null)
-                .Where(c => !c.IsMigrating)
                 .Where(c => c.Statuses.Any(s => s.Status == CorrespondenceStatus.Confirmed))
                 .Include(c => c.Content)
                 .Include(c => c.ExternalReferences)
@@ -750,7 +737,6 @@ namespace Altinn.Correspondence.Persistence.Repositories
             }
             query = query
                 .Where(c => c.Altinn2CorrespondenceId != null)
-                .Where(c => !c.IsMigrating)
                 .Where(c => c.Statuses.Any(s => s.Status == CorrespondenceStatus.Confirmed))
                 .Include(c => c.Content)
                 .Include(c => c.ExternalReferences)


### PR DESCRIPTION
## Description
All correspondences with IsMigrating = true have been moved to a separate database schema and no longer reside in the correspondence.Correspondences table. Therefore it is safe to remove the IsMigrating filter from the queries.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)