### PR TITLE
make Dialogporten action fields optional to fix GetDialog deserialization failure

### DIFF
--- a/src/Altinn.Correspondence.Integrations/Dialogporten/Models/CreateDialogRequest.cs
+++ b/src/Altinn.Correspondence.Integrations/Dialogporten/Models/CreateDialogRequest.cs
@@ -111,7 +111,7 @@ public class ApiAction
     public required List<Endpoint> Endpoints { get; set; }
 
     [JsonPropertyName("name")]
-    public required string Name { get; set; }
+    public string? Name { get; set; }
 }
 
 public class Attachment
@@ -207,7 +207,7 @@ public class ExtendedStatus
 public class GuiAction
 {
     [JsonPropertyName("action")]
-    public required string Action { get; set; }
+    public string? Action { get; set; }
 
     [JsonPropertyName("url")]
     public required string Url { get; set; }
@@ -219,13 +219,13 @@ public class GuiAction
     public bool IsDeleteDialogAction { get; set; }
 
     [JsonPropertyName("httpMethod")]
-    public required string HttpMethod { get; set; }
+    public string? HttpMethod { get; set; }
 
     [JsonPropertyName("priority")]
-    public required string Priority { get; set; }
+    public string? Priority { get; set; }
 
     [JsonPropertyName("title")]
-    public required List<Title> Title { get; set; }
+    public List<Title>? Title { get; set; }
 
     [JsonPropertyName("prompt")]
     public List<Prompt>? Prompt { get; set; }


### PR DESCRIPTION
## Description
The PR removing build warnings put fields in the CreateDialogRequest action fields to required. As we use this 

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flexibility when creating Dialogporten actions by allowing optional action details, including names, methods, priorities, and titles.
  * Requests can now omit these fields where they are not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->