### PR TITLE
Expanded logging to include idempotency key value

### DIFF
--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -155,6 +155,7 @@ namespace Altinn.Correspondence.API.Controllers
         /// Requires uploads of specified attachments if any before it can be Published. <br />
         /// Supports file sizes up to 2 GB each <br />
         /// </remarks>
+        /// <param name="attachments">The attachment files as binary parts, one per entry in Correspondence.Content.Attachments, each part named with the FileName set in its entry</param>
         /// <response code="200">Returns metadata about the initialized correspondence</response>
         /// <response code="400"><ul>
         /// <li>1002: Message title must be plain text</li>

--- a/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
+++ b/src/Altinn.Correspondence.Application/InitializeCorrespondences/InitializeCorrespondencesHandler.cs
@@ -40,7 +40,12 @@ public class InitializeCorrespondencesHandler(
 
     public async Task<OneOf<InitializeCorrespondencesResponse, Error>> Process(InitializeCorrespondencesRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Processing correspondence initialization request for resource {ResourceId}", request.Correspondence.ResourceId);
+        logger.LogInformation(
+            "Processing correspondence initialization request for resource {ResourceId} from consumer {ConsumerOrganizationId} with {RecipientCount} recipients, idempotency key present: {HasIdempotentKey}",
+            request.Correspondence.ResourceId.SanitizeForLogging(),
+            user?.GetCallerOrganizationId()?.SanitizeForLogging(),
+            request.Recipients?.Count ?? 0,
+            request.IdempotentKey.HasValue);
 
         if (request.IdempotentKey.HasValue)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds idempotencyKey to initialize correspondence request logg, so we can track who sends correspondences without the key in application insights.

## Related Issue(s)
- #2080 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved initialization request logging with additional sanitized diagnostic details, including resource and caller identifiers, recipient count, and idempotency-key status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->