### PR TITLE
Added condition endpoint for main notification

### DIFF
--- a/Test/Altinn.Correspondence.Tests/TestingFeature/NotificationTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingFeature/NotificationTests.cs
@@ -90,4 +90,73 @@ public class NotificationTests
         Assert.False(checkNotificationResponse.SendNotification);
     }
 
+    [Fact]
+    public async Task CheckMainNotification_For_Non_Existing_Correspondence()
+    {
+        var correspondenceId = Guid.NewGuid();
+
+        var response = await _client.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/notification/check/main");
+        response.EnsureSuccessStatusCode();
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var checkNotificationResponse = JsonSerializer.Deserialize<CheckNotificationResponse>(responseContent, _responseSerializerOptions);
+        Assert.NotNull(checkNotificationResponse);
+        Assert.False(checkNotificationResponse.SendNotification);
+    }
+
+    [Fact]
+    public async Task CheckMainNotification_For_Correspondence_With_Read_Status_Gives_True()
+    {
+        var client = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.SenderScope));
+        var correspondence = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .WithRequestedPublishTime(DateTime.UtcNow.AddHours(-1))
+            .Build();
+
+        var initializeCorrespondenceResponse = await client.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
+        initializeCorrespondenceResponse.EnsureSuccessStatusCode();
+        var responseContent = await initializeCorrespondenceResponse.Content.ReadAsStringAsync();
+        var correspondenceId = JsonSerializer.Deserialize<InitializeCorrespondencesResponseExt>(responseContent, _responseSerializerOptions)!.Correspondences.First().CorrespondenceId;
+
+        await CorrespondenceHelper.WaitForCorrespondenceStatusUpdate(client, _responseSerializerOptions, correspondenceId, CorrespondenceStatusExt.Published);
+
+        var recipientClient = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.RecipientScope));
+        var fetchResponse = await recipientClient.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}"); // Fetch in order to read
+        fetchResponse.EnsureSuccessStatusCode();
+        var markasread = await recipientClient.PostAsync($"correspondence/api/v1/correspondence/{correspondenceId}/markasread", null);
+        markasread.EnsureSuccessStatusCode();
+
+        var response = await _client.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/notification/check/main");
+        var content = await response.Content.ReadAsStringAsync();
+        var checkNotificationResponse = JsonSerializer.Deserialize<CheckNotificationResponse>(content, _responseSerializerOptions);
+        Assert.NotNull(checkNotificationResponse);
+        Assert.True(checkNotificationResponse.SendNotification);
+    }
+
+    [Fact]
+    public async Task CheckMainNotification_For_Purged_Correspondence_Gives_False()
+    {
+        var client = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.SenderScope));
+        var correspondence = new CorrespondenceBuilder()
+            .CreateCorrespondence()
+            .WithRequestedPublishTime(DateTime.UtcNow.AddHours(-1))
+            .Build();
+
+        var initializeCorrespondenceResponse = await client.PostAsJsonAsync("correspondence/api/v1/correspondence", correspondence);
+        initializeCorrespondenceResponse.EnsureSuccessStatusCode();
+        var responseContent = await initializeCorrespondenceResponse.Content.ReadAsStringAsync();
+        var correspondenceId = JsonSerializer.Deserialize<InitializeCorrespondencesResponseExt>(responseContent, _responseSerializerOptions)!.Correspondences.First().CorrespondenceId;
+
+        await CorrespondenceHelper.WaitForCorrespondenceStatusUpdate(client, _responseSerializerOptions, correspondenceId, CorrespondenceStatusExt.Published);
+
+        var recipientClient = _factory.CreateClientWithAddedClaims(("scope", AuthorizationConstants.RecipientScope));
+        var purgeResponse = await recipientClient.DeleteAsync($"correspondence/api/v1/correspondence/{correspondenceId}/purge");
+        purgeResponse.EnsureSuccessStatusCode();
+
+        var response = await _client.GetAsync($"correspondence/api/v1/correspondence/{correspondenceId}/notification/check/main");
+        var content = await response.Content.ReadAsStringAsync();
+        var checkNotificationResponse = JsonSerializer.Deserialize<CheckNotificationResponse>(content, _responseSerializerOptions);
+        Assert.NotNull(checkNotificationResponse);
+        Assert.False(checkNotificationResponse.SendNotification);
+    }
+
 }

--- a/Test/Altinn.Correspondence.Tests/TestingHandler/CreateNotificationOrderHandlerTests.cs
+++ b/Test/Altinn.Correspondence.Tests/TestingHandler/CreateNotificationOrderHandlerTests.cs
@@ -235,7 +235,30 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             Assert.NotNull(deserialized!.Reminders);
             Assert.True(deserialized.Reminders!.Count >= 1);
             Assert.NotNull(deserialized.Reminders![0].ConditionEndpoint);
-            Assert.Contains($"/correspondence/api/v1/correspondence/{correspondence.Id}/notification/check", deserialized.Reminders![0].ConditionEndpoint!);
+            Assert.EndsWith($"/correspondence/api/v1/correspondence/{correspondence.Id}/notification/check", deserialized.Reminders![0].ConditionEndpoint!);
+        }
+
+        [Fact]
+        public async Task Process_ShouldSetMainConditionEndpoint_OnTheMainOrder()
+        {
+            // Arrange
+            var requestedPublishTime = DateTimeOffset.UtcNow.AddMinutes(10);
+            var (request, correspondence, _) = SetupOrderData(requestedPublishTime);
+
+            CorrespondenceNotificationEntity? captured = null;
+            _mockCorrespondenceNotificationRepository
+                .Setup(x => x.AddNotification(It.IsAny<CorrespondenceNotificationEntity>(), It.IsAny<CancellationToken>()))
+                .Callback<CorrespondenceNotificationEntity, CancellationToken>((n, _) => captured = n)
+                .ReturnsAsync(Guid.NewGuid());
+
+            // Act
+            await _handler.Process(request, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(captured);
+            var deserialized = JsonSerializer.Deserialize<NotificationOrderRequestV2>(captured!.OrderRequest!);
+            Assert.NotNull(deserialized);
+            Assert.EndsWith($"/correspondence/api/v1/correspondence/{correspondence.Id}/notification/check/main", deserialized!.ConditionEndpoint!);
         }
 
         [Fact]
@@ -801,7 +824,7 @@ namespace Altinn.Correspondence.Tests.TestingHandler
             var mainOrder = orders.Single(o => o.Recipient.RecipientOrganization != null);
             var reminderOnly = orders.Single(o => o.Recipient.RecipientSms?.PhoneNumber == "+4799999999");
             Assert.Null(reminderOnly.Reminders);
-            Assert.NotNull(reminderOnly.ConditionEndpoint);
+            Assert.EndsWith("/notification/check", reminderOnly.ConditionEndpoint);
             Assert.Equal(mainOrder.RequestedSendTime.AddDays(1), reminderOnly.RequestedSendTime);
         }
 

--- a/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Correspondence.API/Controllers/CorrespondenceController.cs
@@ -661,8 +661,33 @@ namespace Altinn.Correspondence.API.Controllers
             [FromServices] CheckNotificationHandler handler,
             CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Checking notification for Correspondence with id: {correspondenceId}", correspondenceId.ToString());
-            var commandResult = await handler.Process(correspondenceId, HttpContext.User, cancellationToken);
+            _logger.LogInformation("Checking reminder notification for Correspondence with id: {correspondenceId}", correspondenceId.ToString());
+            var commandResult = await handler.Process(correspondenceId, HttpContext.User, isMainNotification: false, cancellationToken);
+
+            return commandResult.Match(
+                data => Ok(data),
+                Problem
+            );
+        }
+
+        /// <summary>
+        /// Check if the main notification should be sent
+        /// </summary>
+        /// <remarks>
+        /// Unlike the reminder check, a read correspondence still gets its main notification. Only a correspondence that
+        /// is purged, failed or never published suppresses it.
+        /// </remarks>
+        [HttpGet]
+        [Route("{correspondenceId}/notification/check/main")]
+        [Authorize(Policy = AuthorizationConstants.NotificationCheck)]
+        [HideFromPublicApi]
+        public async Task<ActionResult> CheckMainNotification(
+            Guid correspondenceId,
+            [FromServices] CheckNotificationHandler handler,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Checking main notification for Correspondence with id: {correspondenceId}", correspondenceId.ToString());
+            var commandResult = await handler.Process(correspondenceId, HttpContext.User, isMainNotification: true, cancellationToken);
 
             return commandResult.Match(
                 data => Ok(data),

--- a/src/Altinn.Correspondence.Application/CheckNotification/CheckNotificationHandler.cs
+++ b/src/Altinn.Correspondence.Application/CheckNotification/CheckNotificationHandler.cs
@@ -11,11 +11,11 @@ namespace Altinn.Correspondence.Application.CheckNotification;
 public class CheckNotificationHandler(
     ICorrespondenceRepository correspondenceRepository,
     ILogger<CheckNotificationHandler> logger,
-    SendSlackNotificationHandler slackNotificationHandler) : IHandler<Guid, CheckNotificationResponse>
+    SendSlackNotificationHandler slackNotificationHandler)
 {
-    public async Task<OneOf<CheckNotificationResponse, Error>> Process(Guid correspondenceId, ClaimsPrincipal? user, CancellationToken cancellationToken)
+    public async Task<OneOf<CheckNotificationResponse, Error>> Process(Guid correspondenceId, ClaimsPrincipal? user, bool isMainNotification, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Checking notification status for correspondence {CorrespondenceId}", correspondenceId);
+        logger.LogInformation("Checking notification status for correspondence {CorrespondenceId} - IsMainNotification: {IsMainNotification}", correspondenceId, isMainNotification);
         var correspondence = await correspondenceRepository.GetCorrespondenceById(correspondenceId, true, true, false, cancellationToken);
         var response = new CheckNotificationResponse
         {
@@ -27,7 +27,7 @@ public class CheckNotificationHandler(
             response.SendNotification = false;
             return response;
         }
-        if (correspondence.StatusHasBeen(CorrespondenceStatus.Read))
+        if (!isMainNotification && correspondence.StatusHasBeen(CorrespondenceStatus.Read))
         {
             logger.LogInformation("Notification not needed for correspondence {CorrespondenceId} - already read", correspondenceId);
             response.SendNotification = false;

--- a/src/Altinn.Correspondence.Application/CreateNotificationOrder/CreateNotificationOrderHandler.cs
+++ b/src/Altinn.Correspondence.Application/CreateNotificationOrder/CreateNotificationOrderHandler.cs
@@ -211,7 +211,8 @@ public class CreateNotificationOrderHandler(
             ? DateTime.UtcNow
             : context.RequestedPublishTime.UtcDateTime;
         var reminderDelayDays = hostEnvironment.IsProduction() ? 7 : 1;
-        var conditionEndpoint = CreateConditionEndpoint(context.CorrespondenceId.ToString())?.ToString();
+        var mainConditionEndpoint = CreateConditionEndpoint(context.CorrespondenceId.ToString(), isMainNotification: true)?.ToString();
+        var reminderConditionEndpoint = CreateConditionEndpoint(context.CorrespondenceId.ToString(), isMainNotification: false)?.ToString();
 
         var notificationOrders = new List<NotificationOrderRequestV2>();
 
@@ -224,6 +225,7 @@ public class CreateNotificationOrderHandler(
                 {
                     SendersReference = $"corr-{context.SendersReference}",
                     RequestedSendTime = mainSendTime,
+                    ConditionEndpoint = mainConditionEndpoint,
                     IdempotencyId = context.Id.CreateVersion5(BuildRecipientKey(recipient)),
                     Recipient = CreateRecipientOrderV2FromRecipient(recipient, notificationRequest, contents.First(), context, isReminder: false)
                 };
@@ -236,7 +238,7 @@ public class CreateNotificationOrderHandler(
                         {
                             SendersReference = $"corr-{context.SendersReference}",
                             DelayDays = reminderDelayDays,
-                            ConditionEndpoint = conditionEndpoint,
+                            ConditionEndpoint = reminderConditionEndpoint,
                             Recipient = CreateRecipientOrderV2FromRecipient(recipient, notificationRequest, contents.First(), context, isReminder: true)
                         }
                     ];
@@ -252,7 +254,7 @@ public class CreateNotificationOrderHandler(
                 {
                     SendersReference = $"corr-{context.SendersReference}",
                     RequestedSendTime = mainSendTime.AddDays(reminderDelayDays),
-                    ConditionEndpoint = conditionEndpoint,
+                    ConditionEndpoint = reminderConditionEndpoint,
                     IdempotencyId = context.Id.CreateVersion5($"{BuildRecipientKey(recipient)}:reminder"),
                     Recipient = CreateRecipientOrderV2FromRecipient(recipient, notificationRequest, contents.First(), context, isReminder: true)
                 });
@@ -370,10 +372,11 @@ public class CreateNotificationOrderHandler(
         throw new InvalidOperationException("Recipient must have exactly one identifier");
     }
 
-    private Uri? CreateConditionEndpoint(string correspondenceId)
+    private Uri? CreateConditionEndpoint(string correspondenceId, bool isMainNotification)
     {
         var baseUrl = _generalSettings.CorrespondenceBaseUrl.TrimEnd('/');
-        var path = $"/correspondence/api/v1/correspondence/{Uri.EscapeDataString(correspondenceId)}/notification/check";
+        var checkRoute = isMainNotification ? "check/main" : "check";
+        var path = $"/correspondence/api/v1/correspondence/{Uri.EscapeDataString(correspondenceId)}/notification/{checkRoute}";
         var conditionEndpoint = new Uri(new Uri(baseUrl), path);
 
         if (conditionEndpoint.Host == "localhost")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When failing or purging a correspondence before the correspondence notification has been delivered, it would be preferable if the notification delivery also gets cancelled. This PR adds a condition endpoint to the main notification which makes it so the main notification is not sendt if the correspondence is failed or been purged on notification delivery.

## Related Issue(s)
- #2081 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separately checking main notifications and reminders.
  * Main notifications can still be processed when a correspondence has been read.
  * Notification orders now use the appropriate check for main notifications or reminders.

* **Bug Fixes**
  * Corrected notification status handling for nonexistent and purged correspondences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->